### PR TITLE
fix: improve CSS URL escaping for background images

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -1420,6 +1420,15 @@ function removeBackground() {
   document.body.style.removeProperty('--dpp-blur');
 }
 
+function escapeCssUrl(url: string): string {
+  return url
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\)/g, '\\)')
+    .replace(/\n/g, '\\a ')
+    .replace(/\r/g, '\\d ');
+}
+
 function applyBackground(config: BackgroundConfig | null) {
   const normalizedConfig = normalizeBackgroundConfig(config);
   if (!normalizedConfig?.enabled) {
@@ -1456,7 +1465,7 @@ function applyBackground(config: BackgroundConfig | null) {
     right: '0',
     bottom: '0',
     zIndex: '-1',
-    backgroundImage: `url("${imageUrl.replace(/[\\"]/g, '\\$&')}")`,
+    backgroundImage: `url("${escapeCssUrl(imageUrl)}")`,
     backgroundSize: 'cover',
     backgroundPosition: 'center',
     backgroundRepeat: 'no-repeat',


### PR DESCRIPTION
## Summary

- 补全背景图片 URL 在 CSS `url()` 上下文中的转义逻辑
- 原代码仅转义 `\` 和 `"`，新增对 `)`、`\n`、`\r` 的转义

## Changes

- `entrypoints/content.ts`: 新增 `escapeCssUrl()` 函数，替换原有的简单 replace 逻辑

## Test plan

- [ ] 设置包含 `)` 字符的背景图片 URL，确认不被截断
- [ ] 设置 base64 data URI 作为背景图片，确认正常显示
- [ ] 设置普通 URL 作为背景图片，确认无回归

Closes #80