### PR TITLE
fix: encrypt WebDAV credentials at rest

### DIFF
--- a/core/crypto.ts
+++ b/core/crypto.ts
@@ -1,0 +1,78 @@
+const ALGORITHM = 'AES-GCM';
+const KEY_LENGTH = 256;
+const IV_LENGTH = 12;
+const SALT = 'deepseek-pp-sync-v1';
+
+let cachedKey: CryptoKey | null = null;
+
+async function getEncryptionKey(): Promise<CryptoKey> {
+  if (cachedKey) return cachedKey;
+
+  const encoder = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(chrome.runtime.id),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  );
+
+  cachedKey = await crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: encoder.encode(SALT),
+      iterations: 100_000,
+      hash: 'SHA-256',
+    },
+    keyMaterial,
+    { name: ALGORITHM, length: KEY_LENGTH },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+
+  return cachedKey;
+}
+
+export async function encryptString(plaintext: string): Promise<string> {
+  if (!plaintext) return plaintext;
+
+  const key = await getEncryptionKey();
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  const encoded = new TextEncoder().encode(plaintext);
+
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: ALGORITHM, iv },
+    key,
+    encoded,
+  );
+
+  const combined = new Uint8Array(iv.length + ciphertext.byteLength);
+  combined.set(iv, 0);
+  combined.set(new Uint8Array(ciphertext), iv.length);
+
+  return btoa(String.fromCharCode(...combined));
+}
+
+export async function decryptString(ciphertext: string): Promise<string> {
+  if (!ciphertext) return ciphertext;
+
+  try {
+    const key = await getEncryptionKey();
+    const combined = Uint8Array.from(atob(ciphertext), (c) => c.charCodeAt(0));
+
+    if (combined.length < IV_LENGTH + 1) return ciphertext;
+
+    const iv = combined.slice(0, IV_LENGTH);
+    const data = combined.slice(IV_LENGTH);
+
+    const decrypted = await crypto.subtle.decrypt(
+      { name: ALGORITHM, iv },
+      key,
+      data,
+    );
+
+    return new TextDecoder().decode(decrypted);
+  } catch {
+    return ciphertext;
+  }
+}

--- a/core/crypto.ts
+++ b/core/crypto.ts
@@ -2,6 +2,7 @@ const ALGORITHM = 'AES-GCM';
 const KEY_LENGTH = 256;
 const IV_LENGTH = 12;
 const SALT = 'deepseek-pp-sync-v1';
+const VERSION_PREFIX = 'v1:';
 
 let cachedKey: CryptoKey | null = null;
 
@@ -50,29 +51,32 @@ export async function encryptString(plaintext: string): Promise<string> {
   combined.set(iv, 0);
   combined.set(new Uint8Array(ciphertext), iv.length);
 
-  return btoa(String.fromCharCode(...combined));
+  return VERSION_PREFIX + btoa(String.fromCharCode(...combined));
 }
 
-export async function decryptString(ciphertext: string): Promise<string> {
-  if (!ciphertext) return ciphertext;
+export async function decryptString(value: string): Promise<string> {
+  if (!value) return value;
 
-  try {
-    const key = await getEncryptionKey();
-    const combined = Uint8Array.from(atob(ciphertext), (c) => c.charCodeAt(0));
-
-    if (combined.length < IV_LENGTH + 1) return ciphertext;
-
-    const iv = combined.slice(0, IV_LENGTH);
-    const data = combined.slice(IV_LENGTH);
-
-    const decrypted = await crypto.subtle.decrypt(
-      { name: ALGORITHM, iv },
-      key,
-      data,
-    );
-
-    return new TextDecoder().decode(decrypted);
-  } catch {
-    return ciphertext;
+  if (!value.startsWith(VERSION_PREFIX)) {
+    throw new Error('Legacy plaintext detected. Please re-save to encrypt.');
   }
+
+  const raw = value.slice(VERSION_PREFIX.length);
+  const key = await getEncryptionKey();
+  const combined = Uint8Array.from(atob(raw), (c) => c.charCodeAt(0));
+
+  if (combined.length < IV_LENGTH + 1) {
+    throw new Error('Corrupted ciphertext: too short.');
+  }
+
+  const iv = combined.slice(0, IV_LENGTH);
+  const data = combined.slice(IV_LENGTH);
+
+  const decrypted = await crypto.subtle.decrypt(
+    { name: ALGORITHM, iv },
+    key,
+    data,
+  );
+
+  return new TextDecoder().decode(decrypted);
 }

--- a/core/sync/config.ts
+++ b/core/sync/config.ts
@@ -3,6 +3,17 @@ import { encryptString, decryptString } from '../crypto';
 
 const CONFIG_KEY = 'deepseek_pp_sync_config';
 
+async function decryptOrMigrate(value: string): Promise<string> {
+  try {
+    return await decryptString(value);
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('Legacy plaintext')) {
+      return value;
+    }
+    throw err;
+  }
+}
+
 export async function getSyncConfig(): Promise<SyncConfig | null> {
   const data = await chrome.storage.local.get(CONFIG_KEY) as Record<string, SyncConfig | undefined>;
   const config = data[CONFIG_KEY] ?? null;
@@ -10,8 +21,8 @@ export async function getSyncConfig(): Promise<SyncConfig | null> {
 
   return {
     ...config,
-    username: await decryptString(config.username),
-    password: await decryptString(config.password),
+    username: await decryptOrMigrate(config.username),
+    password: await decryptOrMigrate(config.password),
   };
 }
 

--- a/core/sync/config.ts
+++ b/core/sync/config.ts
@@ -1,12 +1,26 @@
 import type { SyncConfig } from '../types';
+import { encryptString, decryptString } from '../crypto';
 
 const CONFIG_KEY = 'deepseek_pp_sync_config';
 
 export async function getSyncConfig(): Promise<SyncConfig | null> {
   const data = await chrome.storage.local.get(CONFIG_KEY) as Record<string, SyncConfig | undefined>;
-  return data[CONFIG_KEY] ?? null;
+  const config = data[CONFIG_KEY] ?? null;
+  if (!config) return null;
+
+  return {
+    ...config,
+    username: await decryptString(config.username),
+    password: await decryptString(config.password),
+  };
 }
 
 export async function saveSyncConfig(config: SyncConfig): Promise<void> {
-  await chrome.storage.local.set({ [CONFIG_KEY]: config });
+  await chrome.storage.local.set({
+    [CONFIG_KEY]: {
+      ...config,
+      username: await encryptString(config.username),
+      password: await encryptString(config.password),
+    },
+  });
 }


### PR DESCRIPTION
## Summary

- 新增 `core/crypto.ts` 加密工具模块（AES-256-GCM + PBKDF2）
- 修改 `core/sync/config.ts`，WebDAV 凭据存储前加密，读取后解密
- 向后兼容：旧版明文凭据在升级后仍可正常读取

## Changes

- `core/crypto.ts`: 新增 `encryptString()` / `decryptString()` 函数
- `core/sync/config.ts`: `getSyncConfig()` 解密 username/password，`saveSyncConfig()` 加密后存储

## 加密方案

- 算法：AES-256-GCM（认证加密）
- 密钥派生：PBKDF2，100K 迭代，SHA-256
- 密钥来源：`chrome.runtime.id`
- IV：每次加密随机生成 12 字节

## Test plan

- [ ] 配置 WebDAV 同步，确认凭据加密存储（DevTools 中不可读）
- [ ] 重启浏览器后确认同步功能正常
- [ ] 升级前已有的明文凭据可正常读取

Closes #78