### PR TITLE
fix: encrypt MCP server secrets at rest

### DIFF
--- a/core/crypto.ts
+++ b/core/crypto.ts
@@ -1,0 +1,78 @@
+const ALGORITHM = 'AES-GCM';
+const KEY_LENGTH = 256;
+const IV_LENGTH = 12;
+const SALT = 'deepseek-pp-sync-v1';
+
+let cachedKey: CryptoKey | null = null;
+
+async function getEncryptionKey(): Promise<CryptoKey> {
+  if (cachedKey) return cachedKey;
+
+  const encoder = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(chrome.runtime.id),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  );
+
+  cachedKey = await crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: encoder.encode(SALT),
+      iterations: 100_000,
+      hash: 'SHA-256',
+    },
+    keyMaterial,
+    { name: ALGORITHM, length: KEY_LENGTH },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+
+  return cachedKey;
+}
+
+export async function encryptString(plaintext: string): Promise<string> {
+  if (!plaintext) return plaintext;
+
+  const key = await getEncryptionKey();
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  const encoded = new TextEncoder().encode(plaintext);
+
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: ALGORITHM, iv },
+    key,
+    encoded,
+  );
+
+  const combined = new Uint8Array(iv.length + ciphertext.byteLength);
+  combined.set(iv, 0);
+  combined.set(new Uint8Array(ciphertext), iv.length);
+
+  return btoa(String.fromCharCode(...combined));
+}
+
+export async function decryptString(ciphertext: string): Promise<string> {
+  if (!ciphertext) return ciphertext;
+
+  try {
+    const key = await getEncryptionKey();
+    const combined = Uint8Array.from(atob(ciphertext), (c) => c.charCodeAt(0));
+
+    if (combined.length < IV_LENGTH + 1) return ciphertext;
+
+    const iv = combined.slice(0, IV_LENGTH);
+    const data = combined.slice(IV_LENGTH);
+
+    const decrypted = await crypto.subtle.decrypt(
+      { name: ALGORITHM, iv },
+      key,
+      data,
+    );
+
+    return new TextDecoder().decode(decrypted);
+  } catch {
+    return ciphertext;
+  }
+}

--- a/core/crypto.ts
+++ b/core/crypto.ts
@@ -2,6 +2,7 @@ const ALGORITHM = 'AES-GCM';
 const KEY_LENGTH = 256;
 const IV_LENGTH = 12;
 const SALT = 'deepseek-pp-sync-v1';
+const VERSION_PREFIX = 'v1:';
 
 let cachedKey: CryptoKey | null = null;
 
@@ -50,29 +51,32 @@ export async function encryptString(plaintext: string): Promise<string> {
   combined.set(iv, 0);
   combined.set(new Uint8Array(ciphertext), iv.length);
 
-  return btoa(String.fromCharCode(...combined));
+  return VERSION_PREFIX + btoa(String.fromCharCode(...combined));
 }
 
-export async function decryptString(ciphertext: string): Promise<string> {
-  if (!ciphertext) return ciphertext;
+export async function decryptString(value: string): Promise<string> {
+  if (!value) return value;
 
-  try {
-    const key = await getEncryptionKey();
-    const combined = Uint8Array.from(atob(ciphertext), (c) => c.charCodeAt(0));
-
-    if (combined.length < IV_LENGTH + 1) return ciphertext;
-
-    const iv = combined.slice(0, IV_LENGTH);
-    const data = combined.slice(IV_LENGTH);
-
-    const decrypted = await crypto.subtle.decrypt(
-      { name: ALGORITHM, iv },
-      key,
-      data,
-    );
-
-    return new TextDecoder().decode(decrypted);
-  } catch {
-    return ciphertext;
+  if (!value.startsWith(VERSION_PREFIX)) {
+    throw new Error('Legacy plaintext detected. Please re-save to encrypt.');
   }
+
+  const raw = value.slice(VERSION_PREFIX.length);
+  const key = await getEncryptionKey();
+  const combined = Uint8Array.from(atob(raw), (c) => c.charCodeAt(0));
+
+  if (combined.length < IV_LENGTH + 1) {
+    throw new Error('Corrupted ciphertext: too short.');
+  }
+
+  const iv = combined.slice(0, IV_LENGTH);
+  const data = combined.slice(IV_LENGTH);
+
+  const decrypted = await crypto.subtle.decrypt(
+    { name: ALGORITHM, iv },
+    key,
+    data,
+  );
+
+  return new TextDecoder().decode(decrypted);
 }

--- a/core/mcp/store.ts
+++ b/core/mcp/store.ts
@@ -10,6 +10,7 @@ import type {
   McpServerUpdateInput,
   McpToolCacheEntry,
 } from './types';
+import { encryptString, decryptString } from '../crypto';
 
 const STORAGE_KEY = 'deepseek_pp_mcp_servers';
 const STORAGE_VERSION = 1;
@@ -185,14 +186,17 @@ export function buildMcpRequestHeaders(server: McpServerConfig): Record<string, 
 
 async function readState(): Promise<McpServerStorageState> {
   const data = await chrome.storage.local.get(STORAGE_KEY) as Record<string, unknown>;
-  return normalizeState(data[STORAGE_KEY]);
+  const state = normalizeState(data[STORAGE_KEY]);
+  state.servers = await Promise.all(state.servers.map(decryptServerSecrets));
+  return state;
 }
 
 async function writeState(state: McpServerStorageState): Promise<void> {
+  const encryptedServers = await Promise.all(state.servers.map(encryptServerSecrets));
   await chrome.storage.local.set({
     [STORAGE_KEY]: {
       version: STORAGE_VERSION,
-      servers: state.servers.map(normalizeServer),
+      servers: encryptedServers.map(normalizeServer),
       toolCaches: state.toolCaches.map(normalizeToolCache),
     },
   });
@@ -390,5 +394,25 @@ function normalizeToolCache(raw: unknown): McpToolCacheEntry {
       toolCount: positiveNumber(value.health?.toolCount, 0),
       error: stringValue(value.health?.error),
     },
+  };
+}
+
+async function encryptServerSecrets(server: McpServerConfig): Promise<McpServerConfig> {
+  return {
+    ...server,
+    secrets: await Promise.all(server.secrets.map(async (secret) => ({
+      ...secret,
+      value: secret.value ? await encryptString(secret.value) : '',
+    }))),
+  };
+}
+
+async function decryptServerSecrets(server: McpServerConfig): Promise<McpServerConfig> {
+  return {
+    ...server,
+    secrets: await Promise.all(server.secrets.map(async (secret) => ({
+      ...secret,
+      value: secret.value ? await decryptString(secret.value) : '',
+    }))),
   };
 }

--- a/core/mcp/store.ts
+++ b/core/mcp/store.ts
@@ -407,12 +407,23 @@ async function encryptServerSecrets(server: McpServerConfig): Promise<McpServerC
   };
 }
 
+async function decryptOrMigrate(value: string): Promise<string> {
+  try {
+    return await decryptString(value);
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('Legacy plaintext')) {
+      return value;
+    }
+    throw err;
+  }
+}
+
 async function decryptServerSecrets(server: McpServerConfig): Promise<McpServerConfig> {
   return {
     ...server,
     secrets: await Promise.all(server.secrets.map(async (secret) => ({
       ...secret,
-      value: secret.value ? await decryptString(secret.value) : '',
+      value: secret.value ? await decryptOrMigrate(secret.value) : '',
     }))),
   };
 }


### PR DESCRIPTION
## Summary

- 复用 `core/crypto.ts` 加密 MCP 服务端密钥（bearer token、basic auth、自定义 header）
- 修改 `core/mcp/store.ts`，写入前加密，读取后解密
- 向后兼容：旧版明文密钥在升级后仍可正常读取

## Changes

- `core/crypto.ts`: 新增加密工具模块（与 #83 共用）
- `core/mcp/store.ts`: `readState()` 解密 secrets，`writeState()` 加密后存储

## Test plan

- [ ] 配置 MCP 服务器（含 bearer token），确认密钥加密存储
- [ ] 重启浏览器后确认 MCP 功能正常
- [ ] 升级前已有的明文密钥可正常读取
- [ ] WebDAV 同步不包含 MCP 密钥（已有逻辑不变）

Closes #79