### PR TITLE
fix: add nonce verification for postMessage channel

### DIFF
--- a/core/automation/messages.ts
+++ b/core/automation/messages.ts
@@ -28,6 +28,7 @@ export interface AutomationWindowRunRequestMessage {
 
 export interface AutomationWindowRunResultMessage {
   source: typeof MAIN_WORLD_WINDOW_SOURCE;
+  nonce?: string;
   type: typeof AUTOMATION_WINDOW_RUN_RESULT;
   id: string;
   result: AutomationRunnerResult;

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -69,11 +69,15 @@ export default defineContentScript({
   async main() {
     installExtensionInvalidationGuards();
 
+    // NOTE: Nonce verification is a weak anti-spoofing measure. It blocks
+    // low-cost forgery (scripts that only guess the source string) but does
+    // NOT provide cryptographic authentication. The main security boundary
+    // remains the background service worker's tool call validation.
     const handleMainWorldMessage = async (event: MessageEvent) => {
       if (event.data?.source !== 'deepseek-pp-main') return;
 
       const expectedNonce = document.documentElement?.getAttribute('data-dpp-nonce');
-      if (expectedNonce && event.data.nonce !== expectedNonce) return;
+      if (!expectedNonce || event.data.nonce !== expectedNonce) return;
 
       try {
         switch (event.data.type) {
@@ -509,7 +513,7 @@ function forwardAutomationRunToMainWorld(request: AutomationRunnerRequest): Prom
     const handleResult = (event: MessageEvent) => {
       if (!isAutomationWindowRunResultMessage(event.data)) return;
       const expectedNonce = document.documentElement?.getAttribute('data-dpp-nonce');
-      if (expectedNonce && event.data.nonce !== expectedNonce) return;
+      if (!expectedNonce || event.data.nonce !== expectedNonce) return;
       if (event.data.id !== id) return;
       window.clearTimeout(timeout);
       window.removeEventListener('message', handleResult);
@@ -621,7 +625,7 @@ function requestManualToolContinuation(request: AutomationRunnerRequest): Promis
     const handleResult = (event: MessageEvent) => {
       if (event.data?.source !== 'deepseek-pp-main') return;
       const expectedNonce = document.documentElement?.getAttribute('data-dpp-nonce');
-      if (expectedNonce && event.data.nonce !== expectedNonce) return;
+      if (!expectedNonce || event.data.nonce !== expectedNonce) return;
       if (event.data.type !== 'MANUAL_TOOL_CONTINUATION_RESULT' || event.data.id !== id) return;
       window.clearTimeout(timeout);
       window.removeEventListener('message', handleResult);

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -72,6 +72,9 @@ export default defineContentScript({
     const handleMainWorldMessage = async (event: MessageEvent) => {
       if (event.data?.source !== 'deepseek-pp-main') return;
 
+      const expectedNonce = document.documentElement?.getAttribute('data-dpp-nonce');
+      if (expectedNonce && event.data.nonce !== expectedNonce) return;
+
       try {
         switch (event.data.type) {
           case 'TOOL_CALL': {
@@ -505,6 +508,8 @@ function forwardAutomationRunToMainWorld(request: AutomationRunnerRequest): Prom
 
     const handleResult = (event: MessageEvent) => {
       if (!isAutomationWindowRunResultMessage(event.data)) return;
+      const expectedNonce = document.documentElement?.getAttribute('data-dpp-nonce');
+      if (expectedNonce && event.data.nonce !== expectedNonce) return;
       if (event.data.id !== id) return;
       window.clearTimeout(timeout);
       window.removeEventListener('message', handleResult);
@@ -615,6 +620,8 @@ function requestManualToolContinuation(request: AutomationRunnerRequest): Promis
 
     const handleResult = (event: MessageEvent) => {
       if (event.data?.source !== 'deepseek-pp-main') return;
+      const expectedNonce = document.documentElement?.getAttribute('data-dpp-nonce');
+      if (expectedNonce && event.data.nonce !== expectedNonce) return;
       if (event.data.type !== 'MANUAL_TOOL_CONTINUATION_RESULT' || event.data.id !== id) return;
       window.clearTimeout(timeout);
       window.removeEventListener('message', handleResult);

--- a/entrypoints/main-world.content.ts
+++ b/entrypoints/main-world.content.ts
@@ -19,17 +19,31 @@ import {
 import { runDeepSeekAutomation } from '../core/automation/runner';
 import type { AutomationRunnerRequest, AutomationRunnerResult } from '../core/automation/types';
 
+const DPP_NONCE_ATTR = 'data-dpp-nonce';
+
+function generateNonce(): string {
+  const array = new Uint8Array(16);
+  crypto.getRandomValues(array);
+  return Array.from(array, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
 export default defineContentScript({
   matches: ['*://chat.deepseek.com/*'],
   world: 'MAIN',
   runAt: 'document_start',
   main() {
+    const nonce = generateNonce();
+    if (document.documentElement) {
+      document.documentElement.setAttribute(DPP_NONCE_ATTR, nonce);
+    }
+
     installFetchHook();
 
     updateHookState({
       onToolCall(call: ToolCall) {
         window.postMessage({
           source: 'deepseek-pp-main',
+          nonce,
           type: 'TOOL_CALL',
           data: call,
         });
@@ -46,6 +60,7 @@ export default defineContentScript({
           window.addEventListener('message', handler);
           window.postMessage({
             source: 'deepseek-pp-main',
+            nonce,
             type: 'EXECUTE_TOOL_CALL',
             data: call,
             id,
@@ -55,6 +70,7 @@ export default defineContentScript({
       onToolCallsRestored(records: ToolCallRestoreRecord[]) {
         window.postMessage({
           source: 'deepseek-pp-main',
+          nonce,
           type: 'RESTORE_TOOL_CALLS',
           records,
         });
@@ -62,6 +78,7 @@ export default defineContentScript({
       onResponseComplete(complete: ResponseCompletePayload) {
         window.postMessage({
           source: 'deepseek-pp-main',
+          nonce,
           type: 'RESPONSE_COMPLETE',
           payload: complete,
         });
@@ -69,6 +86,7 @@ export default defineContentScript({
       onMemoriesUsed(ids: number[]) {
         window.postMessage({
           source: 'deepseek-pp-main',
+          nonce,
           type: 'MEMORIES_USED',
           ids,
         });
@@ -118,6 +136,7 @@ async function handleAutomationRunRequest(id: string, request: AutomationRunnerR
 
   window.postMessage({
     source: MAIN_WORLD_WINDOW_SOURCE,
+    nonce,
     type: AUTOMATION_WINDOW_RUN_RESULT,
     id,
     result,
@@ -137,6 +156,7 @@ async function handleManualToolContinuation(id: string, request: AutomationRunne
 
   window.postMessage({
     source: MAIN_WORLD_WINDOW_SOURCE,
+    nonce,
     type: 'MANUAL_TOOL_CONTINUATION_RESULT',
     id,
     result,
@@ -161,6 +181,7 @@ function executeToolCallViaContent(call: ToolCall): Promise<ToolResult> {
     window.addEventListener('message', handler);
     window.postMessage({
       source: 'deepseek-pp-main',
+      nonce,
       type: 'EXECUTE_TOOL_CALL',
       data: call,
       id,

--- a/entrypoints/main-world.content.ts
+++ b/entrypoints/main-world.content.ts
@@ -19,6 +19,9 @@ import {
 import { runDeepSeekAutomation } from '../core/automation/runner';
 import type { AutomationRunnerRequest, AutomationRunnerResult } from '../core/automation/types';
 
+// Weak anti-spoofing nonce: blocks low-cost postMessage forgery but does NOT
+// provide cryptographic authentication. The nonce is stored in a DOM attribute
+// readable by page scripts. Main security boundary is background service worker.
 const DPP_NONCE_ATTR = 'data-dpp-nonce';
 
 function generateNonce(): string {


### PR DESCRIPTION
## Summary

- 为 postMessage 通道添加 nonce 验证机制
- Main world 脚本页面加载时生成随机 nonce，存储在 `data-dpp-nonce` 属性
- 所有 main-world -> content-script 消息包含 nonce
- Content script 验证 nonce 后才处理消息

## Changes

- `entrypoints/main-world.content.ts`: 生成 nonce 并在所有 `postMessage` 调用中包含
- `entrypoints/content.ts`: 在消息处理前验证 nonce

## 安全说明

- 阻止"不知道 nonce"的脚本伪造消息（相比仅检查 source 字符串有实质提升）
- 同源脚本仍可读取 nonce（`window.postMessage` 架构限制）
- 主要防御依赖 background service worker 的工具调用验证

## Test plan

- [ ] 打开 DeepSeek 页面，确认扩展功能正常（工具调用、记忆、技能弹窗）
- [ ] 确认自动化任务正常执行
- [ ] 确认 `data-dpp-nonce` 属性在 `<html>` 元素上设置

Closes #81