### PR TITLE
[codex] Fix Windows shell host path and encoding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
+          registry-url: https://registry.npmjs.org
 
       - name: Setup Go for actionlint
         uses: actions/setup-go@v5
@@ -50,6 +51,44 @@ jobs:
 
       - name: Run release quality gates
         run: npm run ci:quality
+
+      - name: Publish Shell Host npm package
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          TAG="${INPUT_TAG:-${GITHUB_REF_NAME}}"
+          VERSION="${TAG#v}"
+          ROOT_VERSION="$(node -p "require('./package.json').version")"
+          SHELL_VERSION="$(node -p "require('./packages/shell-host/package.json').version")"
+
+          if [ "$ROOT_VERSION" != "$VERSION" ]; then
+            echo "package.json version $ROOT_VERSION does not match release tag $TAG" >&2
+            exit 1
+          fi
+          if [ "$SHELL_VERSION" != "$VERSION" ]; then
+            echo "packages/shell-host/package.json version $SHELL_VERSION does not match release tag $TAG" >&2
+            exit 1
+          fi
+
+          PUBLISHED_VERSION="$(npm view "deepseek-pp-shell-host@$VERSION" version 2>/dev/null || true)"
+          if [ "$PUBLISHED_VERSION" = "$VERSION" ]; then
+            echo "deepseek-pp-shell-host@$VERSION is already published"
+            exit 0
+          fi
+
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "NPM_TOKEN secret is required because deepseek-pp-shell-host@$VERSION is not published." >&2
+            exit 1
+          fi
+
+          npm publish --workspace packages/shell-host --access public
+          PUBLISHED_VERSION="$(npm view "deepseek-pp-shell-host@$VERSION" version 2>/dev/null || true)"
+          if [ "$PUBLISHED_VERSION" != "$VERSION" ]; then
+            echo "npm publish completed but registry does not expose deepseek-pp-shell-host@$VERSION" >&2
+            exit 1
+          fi
 
       - name: Locate packages
         id: package

--- a/core/prompt/augmentation.ts
+++ b/core/prompt/augmentation.ts
@@ -142,7 +142,7 @@ function renderShellMcpHint(
     statusName
       ? `Use <${statusName}>{}</${statusName}> first when you need host status, shell, PATH, or working-directory context.`
       : '',
-    'Match command syntax to shell_status.shell. On Windows the Shell Local host uses PowerShell by default, so use PowerShell commands such as Get-ChildItem -Name and quote paths once inside the command string. Use cmd.exe /c explicitly only when you need CMD syntax such as dir /b.',
+    'Match command syntax to shell_status.shell. On Windows the Shell Local host uses PowerShell by default, so list files with commands such as Get-ChildItem -LiteralPath "D:\\\\Documents\\\\Downloads\\\\CN" -File | Select-Object -ExpandProperty FullName, and quote paths once inside the command string. Use cmd.exe /c explicitly only when you need CMD syntax such as dir /b.',
     `Recognized shell tool names: ${SHELL_TOOL_NAMES.join(', ')}`,
   ].filter(Boolean).join('\n');
 }

--- a/core/skill/builtin.ts
+++ b/core/skill/builtin.ts
@@ -16,7 +16,7 @@ export const BUILTIN_SKILLS: Skill[] = [
 - 如果 shell 工具已出现在 Available Tools / MCP 工具列表中，直接输出对应 XML 工具标签调用。
 - 不要输出伪 JSON 调用；DeepSeek++ 只执行 <shell_exec>{"command":"..."}</shell_exec> 这种 XML 标签格式。
 - 不要猜测文件路径，先用 shell_status 判断平台和 shell，再用对应 shell 的目录命令确认实际路径。
-- Windows 默认 shell 是 PowerShell：列目录用 Get-ChildItem -Name "D:\\Documents\\Downloads"，不要把 CMD 的 dir /b 直接当 PowerShell 命令；确实需要 CMD 语法时显式运行 cmd.exe /c "..."。
+- Windows 默认 shell 是 PowerShell：列目录用 Get-ChildItem -LiteralPath "D:\\Documents\\Downloads\\CN" -File | Select-Object -ExpandProperty FullName，不要把 CMD 的 dir /b 直接当 PowerShell 命令；确实需要 CMD 语法时显式运行 cmd.exe /c "..."。
 - Windows 路径在 JSON 中使用双反斜杠或正斜杠，并在命令字符串里只包一层引号，例如 <shell_exec>{"command":"officecli view \\\"D:\\\\Documents\\\\Downloads\\\\123.docx\\\" text"}</shell_exec>。
 
 ## 使用流程

--- a/core/skill/officecli-library.ts
+++ b/core/skill/officecli-library.ts
@@ -251,7 +251,7 @@ const DEEPSEEK_OFFICECLI_EXECUTION_GUARDRAILS = `你正在 DeepSeek++ 内使用 
 - 所有 OfficeCLI 操作都通过 shell_exec 执行，例如 <shell_exec>{"command":"${OFFICECLI_BIN_PATH} --version"}</shell_exec>。
 - 不要输出伪 JSON 调用；DeepSeek++ 只执行 <shell_exec>{"command":"..."}</shell_exec> 这种 XML 标签格式。
 - 首次处理 Office 文档时先调用 shell_status，之后必须使用返回的 shell 对应的命令语法。
-- Windows 默认 shell 是 PowerShell：列目录用 Get-ChildItem -Name，不要把 CMD 的 dir /b 或 Unix 的 which/sed/find 直接当 PowerShell 命令。
+- Windows 默认 shell 是 PowerShell：列目录用 Get-ChildItem -LiteralPath "D:\\Documents\\Downloads\\CN" -File | Select-Object -ExpandProperty FullName，不要把 CMD 的 dir /b 或 Unix 的 which/sed/find 直接当 PowerShell 命令。
 - Windows 路径在 JSON 中使用双反斜杠或正斜杠，并在命令字符串里只包一层引号，例如 <shell_exec>{"command":"${OFFICECLI_BIN_PATH} view \\\"D:\\\\Documents\\\\Downloads\\\\123.docx\\\" text"}</shell_exec>。
 - 禁止使用 \`officecli new pptx/docx/xlsx "标题" --prompt "..."\`、\`--mode fast\`、\`login\`、\`set-key\`、\`whoami\` 等 hosted AI 生成/账号命令。
 - 如果 \`${OFFICECLI_BIN_PATH} --help\` 只显示 \`new\`、\`doctor\`、\`login\`、\`set-key\`、\`config\`、\`upgrade\`，说明当前二进制是生成额度版；必须停止并说明需要安装/切换到命令版 OfficeCLI。

--- a/packages/shell-host/native/shell-mcp-host.mjs
+++ b/packages/shell-host/native/shell-mcp-host.mjs
@@ -311,8 +311,10 @@ function execCommand(command, { cwd, env, timeoutMs }) {
 }
 
 function createChildEnv(extraEnv) {
+  const explicitPath = getExplicitPathOverride(extraEnv);
   const env = extraEnv && typeof extraEnv === 'object' ? { ...process.env, ...extraEnv } : { ...process.env };
-  setEnvironmentPath(env, getEnvironmentPath(env) || getEnvironmentPath(process.env));
+  const pathValue = explicitPath !== null ? explicitPath : (getEnvironmentPath(env) || getEnvironmentPath(process.env));
+  setEnvironmentPath(env, pathValue);
   if (platform() === 'win32') {
     env.PYTHONUTF8 ??= '1';
     env.PYTHONIOENCODING ??= 'utf-8';
@@ -345,15 +347,28 @@ function splitPath(value) {
 }
 
 function getEnvironmentPath(env) {
+  const canonicalKey = platform() === 'win32' ? 'Path' : 'PATH';
+  if (typeof env[canonicalKey] === 'string') return env[canonicalKey];
   const key = Object.keys(env).find(name => name.toLowerCase() === 'path');
   return key ? env[key] || '' : '';
 }
 
 function setEnvironmentPath(env, value) {
-  const existingKey = Object.keys(env).find(name => name.toLowerCase() === 'path');
-  if (existingKey && existingKey !== 'PATH') delete env[existingKey];
-  env.PATH = value;
-  if (platform() === 'win32') env.Path = value;
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === 'path') delete env[key];
+  }
+  env[platform() === 'win32' ? 'Path' : 'PATH'] = value;
+}
+
+function getExplicitPathOverride(env) {
+  if (!env || typeof env !== 'object') return null;
+  let value = null;
+  for (const [key, candidate] of Object.entries(env)) {
+    if (key.toLowerCase() === 'path' && typeof candidate === 'string') {
+      value = candidate;
+    }
+  }
+  return value;
 }
 
 function dedupePathDirs(dirs) {

--- a/packages/shell-host/native/shell-mcp-host.mjs
+++ b/packages/shell-host/native/shell-mcp-host.mjs
@@ -1,8 +1,16 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { homedir, hostname, platform, arch } from 'node:os';
+import {
+  arch,
+  homedir,
+  hostname,
+  platform,
+  release as osRelease,
+  type as osType,
+  version as osVersion,
+} from 'node:os';
 import { existsSync } from 'node:fs';
 
 // Resolve package root from this script's location (native/ -> package root).
@@ -17,8 +25,8 @@ const localBinDirs = [
   resolve(PROJECT_ROOT, 'node_modules', '.bin'),
   resolve(PROJECT_ROOT, '..', '..', 'node_modules', '.bin'),
 ].filter(existsSync);
-const sep = platform() === 'win32' ? ';' : ':';
-const currentPath = process.env.PATH || (platform() === 'win32' ? '' : '/usr/bin:/bin');
+const PATH_SEPARATOR = platform() === 'win32' ? ';' : ':';
+const currentPath = getEnvironmentPath(process.env) || (platform() === 'win32' ? '' : '/usr/bin:/bin');
 const localAppData = process.env.LOCALAPPDATA || resolve(homedir(), 'AppData', 'Local');
 const userBinDirs = platform() === 'win32'
   ? [resolve(localAppData, 'OfficeCLI')]
@@ -28,13 +36,26 @@ const userBinDirs = platform() === 'win32'
       '/usr/local/bin',
     ];
 const managedPathDirs = new Set([nodeBinDir, ...localBinDirs, ...userBinDirs]);
-const existingPathDirs = currentPath.split(sep).filter(d => d && !managedPathDirs.has(d));
-process.env.PATH = [...new Set([nodeBinDir, ...userBinDirs, ...existingPathDirs, ...localBinDirs])].join(sep);
+const existingPathDirs = splitPath(currentPath).filter(d => !managedPathDirs.has(d));
+const hostPath = dedupePathDirs([
+  nodeBinDir,
+  ...userBinDirs,
+  ...readWindowsUserMachinePathDirs(),
+  ...existingPathDirs,
+  ...localBinDirs,
+]).join(PATH_SEPARATOR);
+setEnvironmentPath(process.env, hostPath);
 
 const MCP_PROTOCOL_VERSION = '2025-06-18';
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_OUTPUT_BYTES = 128_000;
 const DEFAULT_SHELL = platform() === 'win32' ? 'powershell.exe' : process.env.SHELL || '/bin/sh';
+const WINDOWS_POWERSHELL_UTF8_PREAMBLE = [
+  '[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false)',
+  '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)',
+  '$OutputEncoding = [Console]::OutputEncoding',
+  'try { chcp.com 65001 > $null } catch {}',
+].join('; ');
 
 const TOOL_DEFINITIONS = [
   {
@@ -175,10 +196,16 @@ async function handleCallTool(id, params) {
         data: {
           platform: platform(),
           arch: arch(),
+          osType: osType(),
+          osRelease: osRelease(),
+          osVersion: osVersion(),
+          windowsVersion: getWindowsVersionLabel(),
           shell: DEFAULT_SHELL,
           cwd: homedir(),
           nodeVersion: process.version,
           hostname: hostname(),
+          path: getEnvironmentPath(process.env),
+          pathEntries: splitPath(getEnvironmentPath(process.env)),
         },
       },
     });
@@ -194,7 +221,7 @@ async function handleCallTool(id, params) {
     }
 
     const cwd = typeof args.cwd === 'string' && args.cwd.trim() ? args.cwd.trim() : homedir();
-    const env = args.env && typeof args.env === 'object' ? { ...process.env, ...args.env } : process.env;
+    const env = createChildEnv(args.env);
     const timeoutMs = typeof args.timeout_ms === 'number' && args.timeout_ms >= 1000
       ? Math.min(args.timeout_ms, 600_000)
       : DEFAULT_TIMEOUT_MS;
@@ -283,6 +310,16 @@ function execCommand(command, { cwd, env, timeoutMs }) {
   });
 }
 
+function createChildEnv(extraEnv) {
+  const env = extraEnv && typeof extraEnv === 'object' ? { ...process.env, ...extraEnv } : { ...process.env };
+  setEnvironmentPath(env, getEnvironmentPath(env) || getEnvironmentPath(process.env));
+  if (platform() === 'win32') {
+    env.PYTHONUTF8 ??= '1';
+    env.PYTHONIOENCODING ??= 'utf-8';
+  }
+  return env;
+}
+
 function createShellInvocation(command) {
   if (platform() === 'win32') {
     return {
@@ -292,12 +329,83 @@ function createShellInvocation(command) {
         '-NoProfile',
         '-NonInteractive',
         '-Command',
-        command,
+        `${WINDOWS_POWERSHELL_UTF8_PREAMBLE}; ${command}`,
       ],
     };
   }
 
   return { shellBin: DEFAULT_SHELL, shellArgs: ['-c', command] };
+}
+
+function splitPath(value) {
+  return (value || '')
+    .split(PATH_SEPARATOR)
+    .map(entry => entry.trim())
+    .filter(Boolean);
+}
+
+function getEnvironmentPath(env) {
+  const key = Object.keys(env).find(name => name.toLowerCase() === 'path');
+  return key ? env[key] || '' : '';
+}
+
+function setEnvironmentPath(env, value) {
+  const existingKey = Object.keys(env).find(name => name.toLowerCase() === 'path');
+  if (existingKey && existingKey !== 'PATH') delete env[existingKey];
+  env.PATH = value;
+  if (platform() === 'win32') env.Path = value;
+}
+
+function dedupePathDirs(dirs) {
+  const seen = new Set();
+  const result = [];
+  for (const dir of dirs) {
+    if (!dir) continue;
+    const key = platform() === 'win32'
+      ? dir.replace(/[\\/]+$/, '').toLowerCase()
+      : dir.replace(/\/+$/, '');
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(dir);
+  }
+  return result;
+}
+
+function readWindowsUserMachinePathDirs() {
+  if (platform() !== 'win32') return [];
+  const command = [
+    "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
+    "$paths = @([Environment]::GetEnvironmentVariable('Path', 'Machine'), [Environment]::GetEnvironmentVariable('Path', 'User'))",
+    "$paths | Where-Object { $_ } | ForEach-Object { [Environment]::ExpandEnvironmentVariables($_) }",
+  ].join('; ');
+  try {
+    const out = execFileSync('powershell.exe', [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      command,
+    ], {
+      encoding: 'utf8',
+      timeout: 10_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    return splitPath(out.replace(/\r?\n/g, PATH_SEPARATOR));
+  } catch (err) {
+    process.stderr.write(`[shell-mcp-host] Could not read Windows User/Machine PATH: ${err.message}\n`);
+    return [];
+  }
+}
+
+function getWindowsVersionLabel() {
+  if (platform() !== 'win32') return null;
+  const release = osRelease();
+  const parts = release.split('.').map(part => Number.parseInt(part, 10));
+  const build = parts[2] || 0;
+  if (parts[0] === 10 && build >= 22000) return `Windows 11 (${release})`;
+  if (parts[0] === 10) return `Windows 10 (${release})`;
+  return `Windows (${release})`;
 }
 
 function formatExecSummary(result) {

--- a/scripts/automation-contract-smoke.mjs
+++ b/scripts/automation-contract-smoke.mjs
@@ -68,6 +68,7 @@ assertContains('packages/shell-host/package.json', 'deepseek-pp-shell-host');
 assertContains('packages/shell-host/native/shell-mcp-host.mjs', 'shell_exec');
 assertContains('packages/shell-host/native/shell-mcp-host.mjs', 'readWindowsUserMachinePathDirs');
 assertContains('packages/shell-host/native/shell-mcp-host.mjs', 'WINDOWS_POWERSHELL_UTF8_PREAMBLE');
+assertContains('packages/shell-host/native/shell-mcp-host.mjs', 'getExplicitPathOverride');
 assertContains('packages/shell-host/native/shell-mcp-host.mjs', 'windowsVersion');
 assertContains('packages/shell-host/lib/installer.mjs', 'OFFICECLI_REQUIRED_HELP_PATTERNS');
 assertContains('.github/workflows/release.yml', 'npm publish --workspace packages/shell-host --access public');

--- a/scripts/automation-contract-smoke.mjs
+++ b/scripts/automation-contract-smoke.mjs
@@ -66,7 +66,12 @@ assertContains('scripts/shell-mcp-host.mjs', '../packages/shell-host/native/shel
 assertContains('scripts/install-shell-host.mjs', '../packages/shell-host/lib/installer.mjs');
 assertContains('packages/shell-host/package.json', 'deepseek-pp-shell-host');
 assertContains('packages/shell-host/native/shell-mcp-host.mjs', 'shell_exec');
+assertContains('packages/shell-host/native/shell-mcp-host.mjs', 'readWindowsUserMachinePathDirs');
+assertContains('packages/shell-host/native/shell-mcp-host.mjs', 'WINDOWS_POWERSHELL_UTF8_PREAMBLE');
+assertContains('packages/shell-host/native/shell-mcp-host.mjs', 'windowsVersion');
 assertContains('packages/shell-host/lib/installer.mjs', 'OFFICECLI_REQUIRED_HELP_PATTERNS');
+assertContains('.github/workflows/release.yml', 'npm publish --workspace packages/shell-host --access public');
+assertContains('.github/workflows/release.yml', 'NPM_TOKEN secret is required');
 assertNotContains('README.md', ['Agent', '任务'].join(' '));
 assertNotContains('README.md', ['screenshot-sidepanel', 'agent.svg'].join('-'));
 

--- a/scripts/prompt-freeze.mjs
+++ b/scripts/prompt-freeze.mjs
@@ -11,7 +11,7 @@ const EXPECTED_HASHES = {
   systemTemplateThinking: 'fa31e863e5f54f7a4e48cffdbae0e543028de4a565f77504e66edd707c73b5f3',
   memoryToolSchemas: 'a64e0a8874552177eba10089d5acfdc2996d0b703f83b1a57e9d76c733da9a7b',
   promptAugmentationBuild: '1b42d5b8df743388dfb86ee83e055e00a56fb5389bd7df1afd961c57b45b2335',
-  promptToolSchemaRenderer: '472e3019265d562803501e949e4b05517fcf8a41c67036cc17f481be4fb25918',
+  promptToolSchemaRenderer: '79ed41ef27d6e22d1b1501a0824116e52452fc8b9fcc6c2e212dbbdb266590a1',
   inlineAgentContinuationPrompt: '72c9a77d04a9d9b06258b3ba97e0f45c7d9c3a95d6beb402e1d3bbba5197b3c5',
   inlineAgentNudgePrompt: '93bc1a0ce340e6212d30a9af1e345d0f7e1eaab9a495d8c78abb48f4ec94368d',
   inlineAgentFinalizationPrompt: 'a476d1b4ad4d8f1895e2f1bedeacbc41932257c359106d7c9ecd090e7abff5da',

--- a/scripts/shell-smoke.mjs
+++ b/scripts/shell-smoke.mjs
@@ -166,6 +166,34 @@ await testMethod('tools/call shell_exec (unicode stdout)', 'tools/call', {
   assert(data.stdout.trim() === '中文路径-123', `expected unicode output, got "${data.stdout.trim()}"`);
 });
 
+{
+  const inheritedPath = process.env.Path || process.env.PATH || '';
+  const expectedPrefix = platform() === 'win32' ? 'C:\\deepseek-expected' : '/tmp/deepseek-expected';
+  const wrongPrefix = platform() === 'win32' ? 'C:\\deepseek-wrong' : '/tmp/deepseek-wrong';
+  const pathSep = platform() === 'win32' ? ';' : ':';
+  const command = platform() === 'win32'
+    ? 'Write-Output $env:Path'
+    : 'printf "%s\\n" "$PATH"';
+  const env = platform() === 'win32'
+    ? {
+        PATH: `${wrongPrefix}${pathSep}${inheritedPath}`,
+        Path: `${expectedPrefix}${pathSep}${inheritedPath}`,
+      }
+    : {
+        PATH: `${expectedPrefix}${pathSep}${inheritedPath}`,
+      };
+
+  await testMethod('tools/call shell_exec (PATH env override)', 'tools/call', {
+    name: 'shell_exec',
+    arguments: { command, env },
+  }, (res) => {
+    assert(res.result, 'expected result');
+    const data = res.result.structuredContent?.data;
+    assert(data?.exitCode === 0, `expected exitCode 0, got ${data?.exitCode}`);
+    assert(data.stdout.trim().startsWith(expectedPrefix), `expected PATH to start with ${expectedPrefix}, got "${data.stdout.trim()}"`);
+  });
+}
+
 if (platform() !== 'win32') {
   await testMethod('tools/call shell_exec (PATH order)', 'tools/call', {
     name: 'shell_exec',

--- a/scripts/shell-smoke.mjs
+++ b/scripts/shell-smoke.mjs
@@ -136,6 +136,11 @@ await testMethod('tools/call shell_status', 'tools/call', {
   assert(data?.platform, 'expected platform in status');
   assert(data?.nodeVersion, 'expected nodeVersion');
   assert(data?.shell, 'expected shell in status');
+  assert(data?.osRelease, 'expected osRelease in status');
+  assert(Array.isArray(data?.pathEntries), 'expected pathEntries in status');
+  if (data.platform === 'win32') {
+    assert(data.windowsVersion, 'expected windowsVersion on Windows');
+  }
   reportedShell = data.shell;
 });
 
@@ -149,6 +154,16 @@ await testMethod('tools/call shell_exec (echo)', 'tools/call', {
   assert(data.exitCode === 0, `expected exitCode 0, got ${data.exitCode}`);
   assert(data.shell === reportedShell, `expected shell_exec shell ${data.shell} to match shell_status ${reportedShell}`);
   assert(data.stdout.trim() === 'hello_world', `expected hello_world, got "${data.stdout.trim()}"`);
+});
+
+await testMethod('tools/call shell_exec (unicode stdout)', 'tools/call', {
+  name: 'shell_exec',
+  arguments: { command: platform() === 'win32' ? 'Write-Output "中文路径-123"' : 'printf "中文路径-123\\n"' },
+}, (res) => {
+  assert(res.result, 'expected result');
+  const data = res.result.structuredContent?.data;
+  assert(data?.exitCode === 0, `expected exitCode 0, got ${data?.exitCode}`);
+  assert(data.stdout.trim() === '中文路径-123', `expected unicode output, got "${data.stdout.trim()}"`);
 });
 
 if (platform() !== 'win32') {


### PR DESCRIPTION
## What changed

- Rebuild the Shell Native Host PATH on Windows from the process PATH plus User/Machine PATH, so Chrome's stale or minimal environment does not hide tools such as `D:\Tools\Assembly\officecli.exe`.
- Force PowerShell command execution and child process output toward UTF-8, and expose richer `shell_status` data including OS release, Windows version label, and PATH entries.
- Tighten Shell/OfficeCLI prompt guidance to use PowerShell `Get-ChildItem -LiteralPath ...` for Windows file listing instead of mixing `dir /b` into PowerShell.
- Add release workflow gating for `deepseek-pp-shell-host` npm publication so future GitHub releases cannot silently leave the `npx deepseek-pp-shell-host ...` installer on an older registry version.

## Why

Issue #109 showed two separate failures: Windows filename output became mojibake before OfficeCLI was called, and the public npm installer path was still serving `deepseek-pp-shell-host@0.4.4` even though GitHub Release v0.6.1 existed.

## Validation

- `npm run ci:quality`
- `npm pack --dry-run --workspace packages/shell-host`
- `npm view deepseek-pp-shell-host version versions dist-tags --json`

## Follow-up before release

The local environment is not authenticated to npm, and `gh secret list` did not show an `NPM_TOKEN` secret for this repository. A release that needs to publish `deepseek-pp-shell-host` will now fail clearly until `NPM_TOKEN` is configured or the package is published through another authenticated path.

Addresses #109.