### PR TITLE
feat: add Tavily as configurable search provider alongside Bing scraper

### DIFF
--- a/core/chat/tavily-api-key.ts
+++ b/core/chat/tavily-api-key.ts
@@ -14,6 +14,9 @@ export async function saveTavilyApiKey(apiKey: string): Promise<void> {
   if (!normalized) {
     throw new Error('Tavily API Key cannot be empty');
   }
+  if (!normalized.startsWith('tvly-')) {
+    throw new Error('Invalid Tavily API Key format (expected tvly-…)');
+  }
   await chrome.storage.local.set({ [TAVILY_API_KEY_STORAGE_KEY]: normalized });
 }
 

--- a/core/chat/tavily-api-key.ts
+++ b/core/chat/tavily-api-key.ts
@@ -1,0 +1,28 @@
+export const TAVILY_API_KEY_STORAGE_KEY = 'deepseek_pp_tavily_api_key';
+
+export async function getTavilyApiKey(): Promise<string | null> {
+  const data = await chrome.storage.local.get(TAVILY_API_KEY_STORAGE_KEY) as Record<string, unknown>;
+  return normalizeApiKey(data[TAVILY_API_KEY_STORAGE_KEY]);
+}
+
+export async function hasTavilyApiKey(): Promise<boolean> {
+  return (await getTavilyApiKey()) !== null;
+}
+
+export async function saveTavilyApiKey(apiKey: string): Promise<void> {
+  const normalized = normalizeApiKey(apiKey);
+  if (!normalized) {
+    throw new Error('Tavily API Key cannot be empty');
+  }
+  await chrome.storage.local.set({ [TAVILY_API_KEY_STORAGE_KEY]: normalized });
+}
+
+export async function clearTavilyApiKey(): Promise<void> {
+  await chrome.storage.local.remove(TAVILY_API_KEY_STORAGE_KEY);
+}
+
+function normalizeApiKey(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/core/tool/web-search.ts
+++ b/core/tool/web-search.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_LOCALE, translate, type SupportedLocale } from '../i18n';
+import { getTavilyApiKey } from '../chat/tavily-api-key';
 import type {
   JsonValue,
   ToolCall,
@@ -117,6 +118,56 @@ interface SearchResult {
   snippet: string;
 }
 
+async function tavilySearch(
+  apiKey: string,
+  query: string,
+  topK: number,
+): Promise<SearchResult[]> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
+
+  let response: Response;
+  try {
+    response = await fetch('https://api.tavily.com/search', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        api_key: apiKey,
+        query,
+        max_results: topK,
+        search_depth: 'basic',
+      }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Tavily API returned status ${response.status}`);
+  }
+
+  const data = await response.json() as {
+    results?: Array<{ title?: string; url?: string; content?: string }>;
+  };
+
+  if (!Array.isArray(data.results)) {
+    throw new Error('Tavily API returned unexpected response format');
+  }
+
+  return data.results
+    .filter((r): r is { title: string; url: string; content?: string } =>
+      typeof r.title === 'string' && typeof r.url === 'string')
+    .slice(0, topK)
+    .map((r) => ({
+      title: r.title,
+      url: r.url,
+      snippet: r.content ?? '',
+    }));
+}
+
 async function performWebSearch(call: ToolCall, locale: SupportedLocale): Promise<ToolResult> {
   const query = typeof call.payload.query === 'string' ? call.payload.query.trim() : '';
   if (!query) {
@@ -132,6 +183,28 @@ async function performWebSearch(call: ToolCall, locale: SupportedLocale): Promis
   const topK = typeof call.payload.topK === 'number'
     ? Math.min(Math.max(1, Math.floor(call.payload.topK)), 10)
     : 5;
+
+  // Try Tavily first if an API key is configured.
+  try {
+    const tavilyKey = await getTavilyApiKey();
+    if (tavilyKey) {
+      const results = await tavilySearch(tavilyKey, query, topK);
+      if (results.length > 0) {
+        return {
+          ok: true,
+          name: call.name,
+          provider: call.provider ?? createWebSearchToolProviderIdentity(locale),
+          summary: translate(locale, 'tool.web.searchComplete', { count: results.length }),
+          output: results as unknown as JsonValue,
+          detail: results
+            .map((r, i) => `${i + 1}. [${r.title}](${r.url})\n   ${r.snippet}`)
+            .join('\n'),
+        };
+      }
+    }
+  } catch {
+    // Tavily failed — fall through to Bing scraper.
+  }
 
   // Try multiple Bing domains as fallback.
   // Each domain times out in 8s; total stays under 20s.

--- a/core/tool/web-search.ts
+++ b/core/tool/web-search.ts
@@ -132,9 +132,9 @@ async function tavilySearch(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        api_key: apiKey,
         query,
         max_results: topK,
         search_depth: 'basic',

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -118,6 +118,11 @@ import {
   saveDeepSeekApiKey,
 } from '../core/chat/api-key';
 import {
+  clearTavilyApiKey,
+  hasTavilyApiKey,
+  saveTavilyApiKey,
+} from '../core/chat/tavily-api-key';
+import {
   createAutomation,
   deleteAutomation,
   getAllAutomations,
@@ -829,6 +834,19 @@ async function handleMessage(
       officialApiChatMessages = [];
       await createContextMenus();
       await broadcastChatAuthStatus(sender.tab?.id);
+      return { ok: true, configured: false };
+
+    case 'GET_TAVILY_API_KEY_STATUS':
+      return { ok: true, configured: await hasTavilyApiKey() };
+
+    case 'SAVE_TAVILY_API_KEY': {
+      const { apiKey: tavilyKey } = message.payload as { apiKey?: string };
+      await saveTavilyApiKey(tavilyKey ?? '');
+      return { ok: true, configured: true };
+    }
+
+    case 'CLEAR_TAVILY_API_KEY':
+      await clearTavilyApiKey();
       return { ok: true, configured: false };
 
     case 'GET_DEEPSEEK_THEME':

--- a/entrypoints/sidepanel/pages/SettingsPage.tsx
+++ b/entrypoints/sidepanel/pages/SettingsPage.tsx
@@ -62,12 +62,20 @@ export default function SettingsPage() {
   const [apiKeyInput, setApiKeyInput] = useState('');
   const [apiKeyStatus, setApiKeyStatus] = useState<'idle' | 'saving' | 'clearing' | 'success' | 'error'>('idle');
   const [apiKeyMessage, setApiKeyMessage] = useState('');
+  const [tavilyKeyConfigured, setTavilyKeyConfigured] = useState(false);
+  const [tavilyKeyInput, setTavilyKeyInput] = useState('');
+  const [tavilyKeyStatus, setTavilyKeyStatus] = useState<'idle' | 'saving' | 'clearing' | 'success' | 'error'>('idle');
+  const [tavilyKeyMessage, setTavilyKeyMessage] = useState('');
 
   useEffect(() => {
     getChatEnabled().then(setChatEnabledState);
     chrome.runtime.sendMessage({ type: 'GET_DEEPSEEK_API_KEY_STATUS' })
       .then((result: { configured?: boolean } | undefined) => {
         setApiKeyConfigured(result?.configured === true);
+      });
+    chrome.runtime.sendMessage({ type: 'GET_TAVILY_API_KEY_STATUS' })
+      .then((result: { configured?: boolean } | undefined) => {
+        setTavilyKeyConfigured(result?.configured === true);
       })
       .catch(() => setApiKeyConfigured(false));
   }, []);
@@ -326,6 +334,47 @@ export default function SettingsPage() {
     } catch (error) {
       setApiKeyStatus('error');
       setApiKeyMessage(error instanceof Error ? error.message : t('sidepanel.settings.clearFailed'));
+    }
+  };
+
+  const handleSaveTavilyKey = async () => {
+    const key = tavilyKeyInput.trim();
+    if (!key) {
+      setTavilyKeyStatus('error');
+      setTavilyKeyMessage(t('sidepanel.settings.apiKeyRequired'));
+      return;
+    }
+    setTavilyKeyStatus('saving');
+    setTavilyKeyMessage('');
+    try {
+      const result = await chrome.runtime.sendMessage({
+        type: 'SAVE_TAVILY_API_KEY',
+        payload: { apiKey: key },
+      });
+      if (!result?.ok) throw new Error(result?.error || t('sidepanel.settings.saveFailed'));
+      setTavilyKeyConfigured(true);
+      setTavilyKeyInput('');
+      setTavilyKeyStatus('success');
+      setTavilyKeyMessage(t('sidepanel.settings.apiKeySaved'));
+    } catch (error) {
+      setTavilyKeyStatus('error');
+      setTavilyKeyMessage(error instanceof Error ? error.message : t('sidepanel.settings.saveFailed'));
+    }
+  };
+
+  const handleClearTavilyKey = async () => {
+    setTavilyKeyStatus('clearing');
+    setTavilyKeyMessage('');
+    try {
+      const result = await chrome.runtime.sendMessage({ type: 'CLEAR_TAVILY_API_KEY' });
+      if (!result?.ok) throw new Error(result?.error || t('sidepanel.settings.clearFailed'));
+      setTavilyKeyConfigured(false);
+      setTavilyKeyInput('');
+      setTavilyKeyStatus('success');
+      setTavilyKeyMessage(t('sidepanel.settings.apiKeyCleared'));
+    } catch (error) {
+      setTavilyKeyStatus('error');
+      setTavilyKeyMessage(error instanceof Error ? error.message : t('sidepanel.settings.clearFailed'));
     }
   };
 
@@ -623,6 +672,72 @@ export default function SettingsPage() {
                 }}
               >
                 {apiKeyMessage}
+              </div>
+            )}
+          </div>
+
+          <div
+            className="pt-3 border-t space-y-2"
+            style={{ borderColor: 'var(--ds-border)' }}
+          >
+            <div className="flex justify-between items-center gap-3">
+              <div>
+                <div className="text-xs font-medium" style={{ color: 'var(--ds-text)' }}>
+                  Tavily API Key
+                </div>
+                <div className="text-[11px] mt-0.5" style={{ color: 'var(--ds-text-tertiary)' }}>
+                  Optional. Enables Tavily as web search provider (replaces Bing scraping when set).
+                </div>
+              </div>
+              <span
+                className="shrink-0 text-[10px] px-2 py-0.5 rounded-full"
+                style={{
+                  color: tavilyKeyConfigured ? 'var(--ds-success)' : 'var(--ds-text-tertiary)',
+                  background: tavilyKeyConfigured ? 'var(--ds-success-bg)' : 'var(--ds-surface)',
+                }}
+              >
+                {tavilyKeyConfigured ? t('sidepanel.settings.configured') : t('sidepanel.settings.notConfigured')}
+              </span>
+            </div>
+
+            <div className="flex gap-2">
+              <input
+                type="password"
+                value={tavilyKeyInput}
+                onChange={(e) => setTavilyKeyInput(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleSaveTavilyKey()}
+                placeholder={tavilyKeyConfigured ? t('sidepanel.settings.apiKeyReplacePlaceholder') : 'tvly-...'}
+                className={inputClass}
+                style={inputStyle}
+              />
+              <button
+                onClick={handleSaveTavilyKey}
+                disabled={!tavilyKeyInput.trim() || tavilyKeyStatus === 'saving'}
+                className="ds-btn-secondary shrink-0 px-3 py-2 text-[11px] font-medium rounded-lg transition-all duration-150 disabled:opacity-40"
+              >
+                {tavilyKeyStatus === 'saving' ? t('sidepanel.settings.saving') : t('common.save')}
+              </button>
+            </div>
+
+            {tavilyKeyConfigured && (
+              <button
+                onClick={handleClearTavilyKey}
+                disabled={tavilyKeyStatus === 'clearing'}
+                className="ds-btn-secondary w-full py-2 text-[11px] font-medium rounded-lg transition-all duration-150 disabled:opacity-40"
+              >
+                {tavilyKeyStatus === 'clearing' ? t('sidepanel.settings.clearing') : t('sidepanel.settings.clearApiKey')}
+              </button>
+            )}
+
+            {tavilyKeyMessage && (
+              <div
+                className="text-[11px] px-3 py-2 rounded-lg"
+                style={{
+                  color: tavilyKeyStatus === 'error' ? 'var(--ds-danger)' : 'var(--ds-success)',
+                  background: tavilyKeyStatus === 'error' ? 'var(--ds-danger-bg)' : 'var(--ds-success-bg)',
+                }}
+              >
+                {tavilyKeyMessage}
               </div>
             )}
           </div>

--- a/entrypoints/sidepanel/pages/SettingsPage.tsx
+++ b/entrypoints/sidepanel/pages/SettingsPage.tsx
@@ -72,12 +72,13 @@ export default function SettingsPage() {
     chrome.runtime.sendMessage({ type: 'GET_DEEPSEEK_API_KEY_STATUS' })
       .then((result: { configured?: boolean } | undefined) => {
         setApiKeyConfigured(result?.configured === true);
-      });
+      })
+      .catch(() => setApiKeyConfigured(false));
     chrome.runtime.sendMessage({ type: 'GET_TAVILY_API_KEY_STATUS' })
       .then((result: { configured?: boolean } | undefined) => {
         setTavilyKeyConfigured(result?.configured === true);
       })
-      .catch(() => setApiKeyConfigured(false));
+      .catch(() => setTavilyKeyConfigured(false));
   }, []);
 
   const fileInputRef = useRef<HTMLInputElement>(null);

--- a/scripts/web-search-smoke.mjs
+++ b/scripts/web-search-smoke.mjs
@@ -324,6 +324,41 @@ async function main() {
   check(continuationPrompt.includes('结果一'), '包含搜索结果');
   check(continuationPrompt.includes('</tool_results>'), '正确闭合');
 
+  // ── 测试 7（条件联网）：Tavily 搜索 ──
+  console.log('\n=== 测试 7: Tavily 搜索 (需要 TAVILY_API_KEY) ===');
+  const tavilyApiKey = process.env.TAVILY_API_KEY;
+  if (tavilyApiKey) {
+    try {
+      const tavilyResponse = await fetch('https://api.tavily.com/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          api_key: tavilyApiKey,
+          query: 'DeepSeek AI',
+          max_results: 3,
+          search_depth: 'basic',
+        }),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!tavilyResponse.ok) throw new Error(`Tavily API returned status ${tavilyResponse.status}`);
+      const tavilyData = await tavilyResponse.json();
+      const tavilyResults = tavilyData.results || [];
+      check(Array.isArray(tavilyResults), `Tavily 返回结果是数组`);
+      check(tavilyResults.length > 0, `Tavily 返回 ${tavilyResults.length} 条结果`);
+      if (tavilyResults.length > 0) {
+        check(typeof tavilyResults[0].title === 'string', `结果包含 title`);
+        check(typeof tavilyResults[0].url === 'string', `结果包含 url`);
+        tavilyResults.forEach((r, i) => {
+          console.log(`     ${i+1}. ${(r.title || '').slice(0, 50)}`);
+        });
+      }
+    } catch (e) {
+      check(false, `Tavily 搜索异常: ${e.message}`);
+    }
+  } else {
+    console.log('  ⏭️  TAVILY_API_KEY 未设置，跳过 Tavily 测试');
+  }
+
   // ── 汇总 ──
   const total = passed + failed;
   console.log(`\n========================================`);

--- a/scripts/web-search-smoke.mjs
+++ b/scripts/web-search-smoke.mjs
@@ -331,9 +331,11 @@ async function main() {
     try {
       const tavilyResponse = await fetch('https://api.tavily.com/search', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${tavilyApiKey}`,
+        },
         body: JSON.stringify({
-          api_key: tavilyApiKey,
           query: 'DeepSeek AI',
           max_results: 3,
           search_depth: 'basic',

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -36,7 +36,7 @@ function createManifest(env: ConfigEnv): UserManifest {
     version: extensionVersion,
     permissions: isChromiumTarget ? [...permissions, 'sidePanel'] : permissions,
     optional_host_permissions: ['http://*/*', 'https://*/*'],
-    host_permissions: ['*://chat.deepseek.com/*', 'https://api.deepseek.com/*', '*://cn.bing.com/*', '*://www.bing.com/*'],
+    host_permissions: ['*://chat.deepseek.com/*', 'https://api.deepseek.com/*', '*://cn.bing.com/*', '*://www.bing.com/*', 'https://api.tavily.com/*'],
     content_security_policy: {
       extension_pages: "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
     },


### PR DESCRIPTION
## Summary

Adds Tavily Search API as an opt-in parallel web search provider. When a `TAVILY_API_KEY` is stored in `chrome.storage.local`, web search calls are routed through Tavily; otherwise the existing Bing HTML scraper remains the default fallback. This is an **additive** change — no existing code or dependencies are removed.

## Changes

### New file
- **`core/chat/tavily-api-key.ts`** — Storage helpers (`getTavilyApiKey`, `saveTavilyApiKey`, `clearTavilyApiKey`, `hasTavilyApiKey`) following the existing `api-key.ts` pattern, using key `deepseek_pp_tavily_api_key`.

### Modified files
- **`core/tool/web-search.ts`** — Added `tavilySearch()` function that POSTs to `https://api.tavily.com/search` and maps results to the existing `SearchResult` shape. Updated `performWebSearch()` to check for a stored Tavily key first, call `tavilySearch()` on success, and fall through to the Bing scraper on failure.
- **`entrypoints/background.ts`** — Added `GET_TAVILY_API_KEY_STATUS`, `SAVE_TAVILY_API_KEY`, and `CLEAR_TAVILY_API_KEY` message handlers, consistent with the existing DeepSeek key pattern.
- **`entrypoints/sidepanel/pages/SettingsPage.tsx`** — Added Tavily API Key input field and save/clear controls, mirroring the DeepSeek API key UI block.
- **`wxt.config.ts`** — Added `https://api.tavily.com/*` to `host_permissions`.
- **`scripts/web-search-smoke.mjs`** — Added a conditional test block (test 7) that exercises the Tavily code path when `TAVILY_API_KEY` env var is set.

## Dependency changes
- None — Tavily is accessed via native `fetch()`.

## Environment variable changes
- **`TAVILY_API_KEY`** — Stored at runtime in `chrome.storage.local`; also read from `process.env` in the smoke test for CI validation.

## Notes for reviewers
- The Tavily search uses `search_depth: 'basic'` (1 credit per call) and a 10s timeout.
- On any Tavily failure (network, auth, empty results), the code silently falls through to the existing Bing scraper — no user-visible error.
- TypeScript compilation passes cleanly (`npx tsc --noEmit`).


### Automated Review

- Passed after 2 attempt(s)
- Final review: The implementation correctly migrates Tavily as an additive/optional web search provider while preserving Bing scraping as the default. All three issues cited in the attempt-2 description are properly resolved: the `.catch()` handler bug in SettingsPage.tsx is fixed (both DeepSeek and Tavily status checks now use the correct setters), the Tavily API call uses `Authorization: Bearer` in both `web-search.ts` and the smoke test, and `saveTavilyApiKey` validates the `tvly-` prefix. The `wxt.config.ts` correctly adds `https://api.tavily.com/*` to host_permissions. The `let response: Response` / try-finally pattern matches the existing Bing search code. No critical or major issues found.
