### PR TITLE
fix(automation): 修复后台自动化 token missing（#222）

### DIFF
--- a/core/automation/auth.ts
+++ b/core/automation/auth.ts
@@ -1,0 +1,33 @@
+import { createAutomationRunnerFailure } from './messages';
+import type { AutomationRunnerRequest, AutomationRunnerResult } from './types';
+
+export type ResolvedAutomationClientHeaders =
+  | { kind: 'ok'; headers: Record<string, string> }
+  | { kind: 'failure'; result: AutomationRunnerResult };
+
+export function createAutomationAuthFailure(
+  request: Pick<AutomationRunnerRequest, 'chatSessionId' | 'parentMessageId'>,
+  message: string,
+): AutomationRunnerResult {
+  return createAutomationRunnerFailure(
+    request,
+    'deepseek_auth_token_missing',
+    message,
+    'auth',
+    false,
+  );
+}
+
+export function resolveAutomationClientHeaders(
+  clientHeaders: Record<string, string> | null | undefined,
+  request: Pick<AutomationRunnerRequest, 'chatSessionId' | 'parentMessageId'>,
+  message: string,
+): ResolvedAutomationClientHeaders {
+  if (!clientHeaders?.Authorization) {
+    return {
+      kind: 'failure',
+      result: createAutomationAuthFailure(request, message),
+    };
+  }
+  return { kind: 'ok', headers: clientHeaders };
+}

--- a/core/automation/runner.ts
+++ b/core/automation/runner.ts
@@ -31,6 +31,7 @@ const AUTOMATION_MISSING_TOKEN_MESSAGE =
 
 export interface AutomationRunnerOptions {
   executeToolCall?: (call: ToolCall) => Promise<ToolResult>;
+  clientHeaders?: Record<string, string>;
 }
 
 export async function runDeepSeekAutomation(
@@ -43,7 +44,8 @@ export async function runDeepSeekAutomation(
 
   try {
     parentMessageId = normalizeMessageId(request.parentMessageId, 'parent_message_id');
-    const clientHeaders = createClientHeaders({ missingTokenMessage: AUTOMATION_MISSING_TOKEN_MESSAGE });
+    const clientHeaders = options?.clientHeaders
+      ?? createClientHeaders({ missingTokenMessage: AUTOMATION_MISSING_TOKEN_MESSAGE });
     chatSessionId ??= await createChatSession(clientHeaders);
     const { augmented: prompt } = buildPromptAugmentation(request.prompt, {
       memories: request.promptContext?.memories ?? [],
@@ -84,7 +86,7 @@ export async function runDeepSeekAutomation(
 
     const completedAt = Date.now();
     const finalAssistantMessageId = stream.responseMessageId ?? assistantMessageId;
-    const history = await readHistorySnapshot(chatSessionId, finalAssistantMessageId).catch(() => null);
+    const history = await readHistorySnapshot(chatSessionId, finalAssistantMessageId, { clientHeaders }).catch(() => null);
     const nextParentMessageId = history?.parentMessageId ?? finalAssistantMessageId;
     const result: AutomationRunnerSuccess = {
       ok: true,

--- a/core/deepseek/adapter.ts
+++ b/core/deepseek/adapter.ts
@@ -11,6 +11,7 @@ import {
   type PowChallenge,
 } from './pow';
 
+const DEEPSEEK_WEB_ORIGIN = new URL(DEEPSEEK_API_URL).origin;
 const COMPLETION_PATH = new URL(DEEPSEEK_API_URL).pathname;
 const POW_CHALLENGE_PATH = '/api/v0/chat/create_pow_challenge';
 const CHAT_SESSION_CREATE_PATH = '/api/v0/chat_session/create';
@@ -274,12 +275,27 @@ export async function submitPromptStreaming(
   return readCompletionStreamWithCallbacks(response, callbacks);
 }
 
+export function getDeepSeekWebOrigin(): string {
+  const hostname = globalThis.location?.hostname;
+  if (hostname === 'chat.deepseek.com') {
+    return globalThis.location.origin;
+  }
+  return DEEPSEEK_WEB_ORIGIN;
+}
+
+export interface ReadHistorySnapshotOptions {
+  clientHeaders?: Record<string, string>;
+  baseUrl?: string;
+}
+
 export async function readHistorySnapshot(
   chatSessionId: string,
   expectedAssistantMessageId: number,
+  options?: ReadHistorySnapshotOptions,
 ): Promise<DeepSeekHistorySnapshot | null> {
-  const clientHeaders = createClientHeaders();
-  const url = new URL(HISTORY_PATH, location.origin);
+  const clientHeaders = options?.clientHeaders ?? createClientHeaders();
+  const baseUrl = options?.baseUrl ?? getDeepSeekWebOrigin();
+  const url = new URL(HISTORY_PATH, baseUrl);
   url.searchParams.set('chat_session_id', chatSessionId);
   const response = await fetch(url.href, {
     method: 'GET',
@@ -323,7 +339,7 @@ export function normalizeMessageId(value: unknown, fieldName = 'message_id'): nu
 }
 
 export function buildDeepSeekSessionUrl(chatSessionId: string): string {
-  return `${location.origin}/a/chat/s/${chatSessionId}`;
+  return `${getDeepSeekWebOrigin()}/a/chat/s/${chatSessionId}`;
 }
 
 async function readCompletionStream(response: Response): Promise<ModelTurn> {

--- a/core/interceptor/fetch-hook.ts
+++ b/core/interceptor/fetch-hook.ts
@@ -113,7 +113,11 @@ export interface RequestBodyModification {
 function hookFetch() {
   originalFetch = window.fetch;
 
-  window.fetch = async function (input: RequestInfo | URL, init?: RequestInit) {
+  const hookedFetch = async function hookedFetch(
+    this: typeof globalThis,
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 
     if (url.includes(HISTORY_PATH)) {
@@ -141,6 +145,8 @@ function hookFetch() {
     const requestInit = modified ? { ...init, body: modified.body } : init;
     return interceptFetchResponse(originalFetch.call(this, input, requestInit), requestContext);
   };
+
+  window.fetch = Object.assign(hookedFetch, originalFetch);
 }
 
 function hookXHR() {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -157,6 +157,7 @@ import {
   setAutomationStatus,
   updateAutomation,
 } from '../core/automation/store';
+import { resolveAutomationClientHeaders } from '../core/automation/auth';
 import { runDeepSeekAutomation } from '../core/automation/runner';
 import {
   AUTOMATION_WAKE_ALARM_NAME,
@@ -1191,6 +1192,14 @@ async function broadcastToTabs(payload: Record<string, unknown>, excludeTabId?: 
 }
 
 async function loadOrRefreshClientHeaders(preferredTabId?: number): Promise<Record<string, string> | null> {
+  // When the caller knows the active DeepSeek tab, refresh from it first so manual
+  // flows do not reuse a stale cached token without hitting the live page context.
+  if (preferredTabId !== undefined) {
+    await refreshClientHeadersFromDeepSeekTabs(preferredTabId);
+    const refreshed = await loadClientHeadersFromStorage();
+    if (refreshed) return refreshed;
+  }
+
   const cached = await loadClientHeadersFromStorage();
   if (cached) return cached;
 
@@ -1597,7 +1606,7 @@ async function runAutomationNow(id: string, excludeTabId?: number) {
     automationId: id,
     trigger: 'manual',
     scheduledFor: null,
-    executor: executeAutomationWithContext,
+    executor: (request) => executeAutomationWithContext(request, excludeTabId),
   });
 
   await broadcastAutomationUpdate(excludeTabId);
@@ -1609,12 +1618,22 @@ async function runAutomationNow(id: string, excludeTabId?: number) {
 
 async function executeAutomationWithContext(
   request: AutomationRunnerRequest,
+  preferredTabId?: number,
 ): Promise<AutomationRunnerResult> {
-  const [memories, activePreset, toolDescriptors] = await Promise.all([
+  const [memories, activePreset, toolDescriptors, clientHeaders] = await Promise.all([
     getAllMemories(),
     getActivePreset(),
     getRuntimeToolDescriptors(currentBackgroundLocale),
+    loadOrRefreshClientHeaders(preferredTabId),
   ]);
+  const resolvedHeaders = resolveAutomationClientHeaders(
+    clientHeaders,
+    request,
+    backgroundT('background.auth.missingDeepSeek'),
+  );
+  if (resolvedHeaders.kind === 'failure') {
+    return resolvedHeaders.result;
+  }
   const enabledDescriptors = toolDescriptors.filter((descriptor) => descriptor.execution.enabled);
   const [project, projectPromptContext] = request.chatSessionId
     ? await Promise.all([
@@ -1633,6 +1652,7 @@ async function executeAutomationWithContext(
       toolDescriptors: enabledDescriptors,
     },
   }, {
+    clientHeaders: resolvedHeaders.headers,
     executeToolCall: (call) => executeBackgroundRuntimeToolCall(call, 'automation'),
   });
 }

--- a/scripts/automation-contract-smoke.mjs
+++ b/scripts/automation-contract-smoke.mjs
@@ -50,6 +50,10 @@ assertContains('entrypoints/sidepanel/pages/CapabilitiesPage.tsx', "import Autom
 assertContains('entrypoints/sidepanel/pages/CapabilitiesPage.tsx', "sub === 'automation' && <AutomationPage />");
 assertContains('entrypoints/sidepanel/pages/AutomationPage.tsx', 'export default function AutomationPage');
 assertContains('core/automation/runner.ts', 'runDeepSeekAutomation');
+assertContains('core/automation/auth.ts', 'resolveAutomationClientHeaders');
+assertContains('entrypoints/background.ts', 'resolveAutomationClientHeaders');
+assertContains('entrypoints/background.ts', 'loadOrRefreshClientHeaders(preferredTabId)');
+assertContains('entrypoints/background.ts', 'if (preferredTabId !== undefined)');
 assertContains('core/automation/scheduler.ts', 'runAutomation');
 assertContains('wxt.config.ts', "'alarms'");
 assertContains('entrypoints/background.ts', 'chrome.alarms.create');
@@ -67,6 +71,7 @@ assertContains('core/inline-agent/loop.ts', 'INLINE_AGENT_MAX_STEPS');
 assertContains('core/inline-agent/prompt.ts', 'buildContinuationPrompt');
 assertContains('core/inline-agent/renderer.ts', 'createAgentStepElement');
 assertContains('core/deepseek/adapter.ts', 'BYPASS_HOOK_HEADER');
+assertContains('core/deepseek/adapter.ts', 'getDeepSeekWebOrigin');
 assertContains('core/shell/index.ts', 'createShellMcpPresetInput');
 assertContains('scripts/shell-mcp-host.mjs', '../packages/shell-host/native/shell-mcp-host.mjs');
 assertContains('scripts/install-shell-host.mjs', '../packages/shell-host/lib/installer.mjs');

--- a/tests/automation-auth.test.ts
+++ b/tests/automation-auth.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAutomationClientHeaders } from '../core/automation/auth';
+
+describe('automation auth helpers', () => {
+  it('returns a non-retryable auth failure when headers are missing', () => {
+    const result = resolveAutomationClientHeaders(
+      null,
+      { chatSessionId: 'session-1', parentMessageId: 12 },
+      'Sign in at chat.deepseek.com first.',
+    );
+
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') return;
+    expect(result.result).toMatchObject({
+      ok: false,
+      chatSessionId: 'session-1',
+      parentMessageId: 12,
+      error: {
+        code: 'deepseek_auth_token_missing',
+        message: 'Sign in at chat.deepseek.com first.',
+        phase: 'auth',
+        retryable: false,
+      },
+    });
+  });
+
+  it('returns headers when authorization is present', () => {
+    const headers = { Authorization: 'Bearer cached-token' };
+    const result = resolveAutomationClientHeaders(
+      headers,
+      { chatSessionId: null, parentMessageId: null },
+      'missing',
+    );
+
+    expect(result).toEqual({ kind: 'ok', headers });
+  });
+});

--- a/tests/automation-runner-auth.test.ts
+++ b/tests/automation-runner-auth.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AutomationRunnerRequest } from '../core/automation/types';
+
+const authErrors = vi.hoisted(() => {
+  class DeepSeekAuthError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'DeepSeekAuthError';
+    }
+  }
+  return { DeepSeekAuthError };
+});
+
+const adapterMocks = vi.hoisted(() => ({
+  createChatSession: vi.fn(),
+  createPowHeaders: vi.fn(),
+  readHistorySnapshot: vi.fn(),
+  submitPrompt: vi.fn(),
+  createClientHeaders: vi.fn(),
+}));
+
+vi.mock('../core/deepseek/adapter', () => {
+  class DeepSeekPowError extends Error {}
+  class DeepSeekSessionError extends Error {}
+  class DeepSeekPayloadError extends Error {
+    readonly retryable: boolean;
+
+    constructor(message: string, options?: { retryable?: boolean }) {
+      super(message);
+      this.retryable = options?.retryable ?? false;
+    }
+  }
+
+  return {
+    DeepSeekAuthError: authErrors.DeepSeekAuthError,
+    DeepSeekPowError,
+    DeepSeekSessionError,
+    DeepSeekPayloadError,
+    buildDeepSeekSessionUrl: (chatSessionId: string) => `https://chat.deepseek.com/a/chat/s/${chatSessionId}`,
+    createChatSession: adapterMocks.createChatSession,
+    createClientHeaders: adapterMocks.createClientHeaders,
+    createPowHeaders: adapterMocks.createPowHeaders,
+    normalizeMessageId: () => null,
+    readHistorySnapshot: adapterMocks.readHistorySnapshot,
+    submitPrompt: adapterMocks.submitPrompt,
+  };
+});
+
+const { runDeepSeekAutomation } = await import('../core/automation/runner');
+
+describe('runDeepSeekAutomation auth handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapterMocks.createClientHeaders.mockImplementation(() => {
+      throw new authErrors.DeepSeekAuthError('DeepSeek login token is missing.');
+    });
+  });
+
+  it('fails with auth metadata when client headers are not injected', async () => {
+    const result = await runDeepSeekAutomation(createRequest());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: 'deepseek_auth_token_missing',
+      phase: 'auth',
+      retryable: false,
+    });
+    expect(adapterMocks.createChatSession).not.toHaveBeenCalled();
+  });
+
+  it('passes injected headers through to history verification', async () => {
+    adapterMocks.createPowHeaders.mockResolvedValue({ 'X-DS-PoW-Response': 'pow-1' });
+    adapterMocks.createChatSession.mockResolvedValue('session-1');
+    adapterMocks.submitPrompt.mockResolvedValue({
+      assistantText: 'Done.',
+      responseMessageId: 101,
+      requestMessageId: 100,
+      finished: true,
+    });
+    adapterMocks.readHistorySnapshot.mockResolvedValue({
+      chatSessionId: 'session-1',
+      parentMessageId: 100,
+      assistantMessageId: 101,
+      messageCount: 2,
+      verifiedAt: Date.now(),
+    });
+
+    const clientHeaders = { Authorization: 'Bearer injected-token' };
+    const result = await runDeepSeekAutomation(createRequest(), { clientHeaders });
+
+    expect(result.ok).toBe(true);
+    expect(adapterMocks.createClientHeaders).not.toHaveBeenCalled();
+    expect(adapterMocks.readHistorySnapshot).toHaveBeenCalledWith(
+      'session-1',
+      101,
+      { clientHeaders },
+    );
+  });
+});
+
+function createRequest(): AutomationRunnerRequest {
+  return {
+    runId: 'run-1',
+    automationId: 'automation-1',
+    prompt: 'Say hello.',
+    trigger: 'manual',
+    chatSessionId: null,
+    parentMessageId: null,
+    promptOptions: {
+      modelType: null,
+      searchEnabled: false,
+      thinkingEnabled: false,
+      refFileIds: [],
+    },
+    requestedAt: 1,
+  };
+}

--- a/tests/automation-runner-pow.test.ts
+++ b/tests/automation-runner-pow.test.ts
@@ -84,6 +84,29 @@ describe('runDeepSeekAutomation PoW handling', () => {
     adapterMocks.readHistorySnapshot.mockResolvedValue(null);
   });
 
+  it('uses injected client headers without calling createClientHeaders', async () => {
+    adapterMocks.submitPrompt.mockResolvedValueOnce({
+      assistantText: 'Done.',
+      responseMessageId: 101,
+      requestMessageId: 100,
+      finished: true,
+    });
+
+    const result = await runDeepSeekAutomation(createRequest(), {
+      clientHeaders: { Authorization: 'Bearer injected-token' },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(adapterMocks.submitPrompt.mock.calls[0][0]).toMatchObject({
+      clientHeaders: { Authorization: 'Bearer injected-token' },
+    });
+    expect(adapterMocks.readHistorySnapshot).toHaveBeenCalledWith(
+      'session-1',
+      101,
+      { clientHeaders: { Authorization: 'Bearer injected-token' } },
+    );
+  });
+
   it('creates fresh PoW headers for the initial completion and each tool continuation', async () => {
     adapterMocks.submitPrompt
       .mockResolvedValueOnce({

--- a/tests/deepseek-adapter-stream.test.ts
+++ b/tests/deepseek-adapter-stream.test.ts
@@ -8,7 +8,7 @@ describe('DeepSeek web adapter streaming', () => {
   });
 
   it('can stream chunks without retaining the full assistant text', async () => {
-    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => createSseResponse([
+    vi.stubGlobal('fetch', vi.fn(async () => createSseResponse([
       'data: {"v":"Hello "}',
       'data: {"v":"world"}',
       'data: {"p":"response/status","v":"FINISHED"}',
@@ -33,7 +33,7 @@ describe('DeepSeek web adapter streaming', () => {
   });
 
   it('retains full assistant text by default', async () => {
-    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => createSseResponse([
+    vi.stubGlobal('fetch', vi.fn(async () => createSseResponse([
       'data: {"v":"Hello "}',
       'data: {"v":"world"}',
     ].join('\n\n'))));

--- a/tests/deepseek-official-api.test.ts
+++ b/tests/deepseek-official-api.test.ts
@@ -4,6 +4,7 @@ import {
   DEEPSEEK_OFFICIAL_API_URL,
   submitOfficialDeepSeekStreaming,
 } from '../core/deepseek/official-api';
+import { createFetchStub } from './helpers/fetch-stub';
 
 describe('DeepSeek official API adapter', () => {
   it('builds current official model and thinking request bodies', () => {
@@ -36,13 +37,14 @@ describe('DeepSeek official API adapter', () => {
   });
 
   it('streams OpenAI-compatible reasoning and answer deltas with the configured API key', async () => {
-    const fetchImpl = vi.fn<typeof fetch>(async () => createSseResponse([
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(async () => createSseResponse([
       'data: {"choices":[{"delta":{"reasoning_content":"Think"},"finish_reason":null}]}',
       'data: {"choices":[{"delta":{"content":"Hel"},"finish_reason":null}]}',
       'data: {"choices":[{"delta":{"content":"lo"},"finish_reason":null}]}',
       'data: {"choices":[{"delta":{"content":""},"finish_reason":"stop"}]}',
       'data: [DONE]',
     ].join('\n\n')));
+    const fetchImpl = createFetchStub(fetchMock);
     const chunks: string[] = [];
     const reasoningChunks: string[] = [];
 
@@ -67,15 +69,15 @@ describe('DeepSeek official API adapter', () => {
     expect(turn).toEqual({ assistantText: 'Hello', reasoningText: 'Think', finished: true });
     expect(chunks).toEqual(['Hel', 'lo']);
     expect(reasoningChunks).toEqual(['Think']);
-    expect(fetchImpl).toHaveBeenCalledWith(DEEPSEEK_OFFICIAL_API_URL, expect.objectContaining({
+    expect(fetchMock).toHaveBeenCalledWith(DEEPSEEK_OFFICIAL_API_URL, expect.objectContaining({
       method: 'POST',
       headers: expect.objectContaining({
         authorization: 'Bearer sk-test',
       }),
     }));
 
-    const init = fetchImpl.mock.calls[0][1] as RequestInit;
-    expect(JSON.parse(init.body as string)).toMatchObject({
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(JSON.parse((init?.body as string) ?? '{}')).toMatchObject({
       model: 'deepseek-v4-flash',
       messages: [{ role: 'user', content: 'hello' }],
       stream: true,
@@ -83,10 +85,10 @@ describe('DeepSeek official API adapter', () => {
   });
 
   it('surfaces official API error messages', async () => {
-    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(
+    const fetchImpl = createFetchStub(vi.fn(async () => new Response(
       JSON.stringify({ error: { message: 'invalid api key' } }),
       { status: 401 },
-    ));
+    )));
 
     await expect(submitOfficialDeepSeekStreaming({
       apiKey: 'bad-key',

--- a/tests/deepseek-web-origin.test.ts
+++ b/tests/deepseek-web-origin.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildDeepSeekSessionUrl, getDeepSeekWebOrigin } from '../core/deepseek/adapter';
+
+describe('DeepSeek web origin resolution', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses chat.deepseek.com when running on the DeepSeek site', () => {
+    vi.stubGlobal('location', {
+      hostname: 'chat.deepseek.com',
+      origin: 'https://chat.deepseek.com',
+    } as Location);
+
+    expect(getDeepSeekWebOrigin()).toBe('https://chat.deepseek.com');
+    expect(buildDeepSeekSessionUrl('session-1')).toBe('https://chat.deepseek.com/a/chat/s/session-1');
+  });
+
+  it('falls back to the DeepSeek origin in extension or service worker contexts', () => {
+    vi.stubGlobal('location', {
+      hostname: 'chhlagfdfeanaefgbdbgmdlpgaoahhbi',
+      origin: 'chrome-extension://chhlagfdfeanaefgbdbgmdlpgaoahhbi',
+    } as Location);
+
+    expect(getDeepSeekWebOrigin()).toBe('https://chat.deepseek.com');
+    expect(buildDeepSeekSessionUrl('session-1')).toBe('https://chat.deepseek.com/a/chat/s/session-1');
+  });
+});

--- a/tests/helpers/fetch-stub.ts
+++ b/tests/helpers/fetch-stub.ts
@@ -1,0 +1,7 @@
+import { vi, type Mock } from 'vitest';
+
+export function createFetchStub(
+  impl: Mock<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>,
+): typeof fetch {
+  return Object.assign(impl, fetch);
+}

--- a/tests/read-history-snapshot.test.ts
+++ b/tests/read-history-snapshot.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readHistorySnapshot } from '../core/deepseek/adapter';
+
+describe('readHistorySnapshot', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses injected client headers and base URL in background-safe mode', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      expect(url).toBe('https://chat.deepseek.com/api/v0/chat/history_messages?chat_session_id=session-1');
+      return new Response(JSON.stringify({
+        data: {
+          biz_data: {
+            chat_messages: [
+              { message_id: 100, parent_id: null, message_role: 'user' },
+              { message_id: 101, parent_id: 100, message_role: 'assistant' },
+            ],
+          },
+        },
+      }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const snapshot = await readHistorySnapshot('session-1', 101, {
+      clientHeaders: { Authorization: 'Bearer injected-token' },
+      baseUrl: 'https://chat.deepseek.com',
+    });
+
+    expect(snapshot).toMatchObject({
+      chatSessionId: 'session-1',
+      parentMessageId: 101,
+      assistantMessageId: 101,
+      messageCount: 2,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://chat.deepseek.com/api/v0/chat/history_messages?chat_session_id=session-1',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer injected-token',
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

修复 #222：后台自动化报「token missing」。根因是 Service Worker 无法读取页面 `localStorage` 中的 DeepSeek 登录 token。本 PR 让自动化与侧边栏聊天、对话导出使用同一套 headers 加载/刷新逻辑，手动执行时优先从触发标签页刷新，缺失时快速失败，并修复 SW 环境下的 session/history URL。

Fixes #222

## PR Type

- [ ] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

`git fetch origin && git checkout main && git pull` (base: 2421774 Release 0.7.5)

## Local Validation

Commands run:

```bash
npm run compile
npm test
npm run build:chrome
npm run build:all
npm run verify:automation
npm run verify:mcp:mock
npm run verify:i18n
npm run smoke:shell
npm run smoke:pow
```

Result summary:

- `npm run compile` — PASS
- `npm test` — PASS (51 files, 228 tests)
- `npm run build:chrome` — PASS
- `npm run build:all` — PASS (chrome, edge, firefox)
- `npm run verify:automation` — PASS
- `npm run verify:mcp:mock` — PASS (automation continuation/history)
- `npm run verify:i18n` — PASS
- `npm run smoke:shell` — PASS (12 passed)
- `npm run smoke:pow` — PASS
- No failing commands observed for the changed automation auth path.

## Local Feature Evidence

Evidence:

未附手动录屏/截图（贡献者环境无法完成浏览器内登录验证）。

替代证据：
- `verify:mcp:mock` 覆盖 automation continuation/history
- 新增单元测试：automation-auth、automation-runner-auth、read-history-snapshot、deepseek-web-origin
- 维护者可用 `npm run build:chrome` + Load unpacked 按 #222 复现

---

## English note

Fixes #222 without manual screen recording; automated tests and MCP mock smoke cover the automation auth/history path.