### PR TITLE
fix(scripts): resolve project root cross-platform via fileURLToPath

### DIFF
--- a/scripts/automation-contract-smoke.mjs
+++ b/scripts/automation-contract-smoke.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = path.resolve(new URL('..', import.meta.url).pathname);
+const root = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 const failures = [];
 
 const requiredFiles = [

--- a/scripts/copy-to-android-assets.mjs
+++ b/scripts/copy-to-android-assets.mjs
@@ -2,8 +2,9 @@
 import { cp, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = resolve(new URL('..', import.meta.url).pathname);
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const chromeBuildDir = resolve(root, 'dist/chrome-mv3');
 const androidAssetDir = resolve(root, 'android/app/src/main/assets/dpp');
 const shimSource = resolve(root, 'android/web/android-bridge-shim.js');

--- a/scripts/i18n-coverage-audit.mjs
+++ b/scripts/i18n-coverage-audit.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { extname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = resolve(new URL('..', import.meta.url).pathname);
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const failures = [];
 const hanText = /\p{Script=Han}/u;
 const scannableExtensions = new Set(['.js', '.jsx', '.json', '.mjs', '.ts', '.tsx']);
@@ -213,5 +214,6 @@ function readText(relativePath) {
 }
 
 function toProjectPath(absolutePath) {
-  return relative(root, absolutePath).split('/').join('/');
+  // Normalize Windows backslashes so paths match the forward-slash allowlist keys.
+  return relative(root, absolutePath).split(/[\\/]/).join('/');
 }

--- a/scripts/i18n-locale-check.mjs
+++ b/scripts/i18n-locale-check.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = resolve(new URL('..', import.meta.url).pathname);
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const failures = [];
 const localePaths = {
   en: 'public/_locales/en/messages.json',

--- a/scripts/manifest-policy-check.mjs
+++ b/scripts/manifest-policy-check.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = resolve(new URL('..', import.meta.url).pathname);
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const failures = [];
 const packageJson = readJson('package.json');
 

--- a/scripts/package-sources.mjs
+++ b/scripts/package-sources.mjs
@@ -3,8 +3,9 @@ import { execFileSync } from 'node:child_process';
 import { mkdirSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
-const root = resolve(new URL('..', import.meta.url).pathname);
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
 const version = packageJson.version;
 

--- a/scripts/release-assets-check.mjs
+++ b/scripts/release-assets-check.mjs
@@ -2,8 +2,9 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, statSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = resolve(new URL('..', import.meta.url).pathname);
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
 const version = packageJson.version;
 const distDir = resolve(root, 'dist');

--- a/scripts/run-android-gradle.mjs
+++ b/scripts/run-android-gradle.mjs
@@ -2,8 +2,9 @@
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
-const root = resolve(new URL('..', import.meta.url).pathname);
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const androidDir = resolve(root, 'android');
 const args = process.argv.slice(2);
 


### PR DESCRIPTION
## Summary

Fix the build/CI scripts so they resolve the project root correctly on Windows and on any repo path containing a space.

## PR Type

- [ ] User-facing feature or behavior change
- [x] Bug fix
- [x] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

Branched from latest `origin/main`.

## Local Validation

Commands run:

```bash
npm run compile
npm test
npm run verify:automation
npm run verify:i18n
npm run verify:manifest-policy
```

Result summary:

All pass on Windows with a repo path containing a space. Before the fix, `verify:automation` failed (existing `shell_exec` fragment reported as missing) and `i18n-coverage-audit` scanned 0 files; after the fix all of the above pass and the i18n audit scans 223 files.

## Local Feature Evidence

Evidence:

N/A — build/CI tooling fix only, no user-facing behavior change.