### PR TITLE
Fix #250: GitHub skill source from repo root fails cloud sync download

### DIFF
--- a/core/sync/schema.ts
+++ b/core/sync/schema.ts
@@ -114,7 +114,7 @@ export function validateGitHubSkillSource(value: unknown, path = 'skillSource'):
     repo: requiredString(object.repo, `${path}.repo`),
     repository: requiredString(object.repository, `${path}.repository`),
     ref: requiredString(object.ref, `${path}.ref`),
-    rootPath: requiredString(object.rootPath, `${path}.rootPath`),
+    rootPath: requiredStringAllowEmpty(object.rootPath, `${path}.rootPath`),
     commitSha: requiredString(object.commitSha, `${path}.commitSha`),
     defaultBranch: requiredString(object.defaultBranch, `${path}.defaultBranch`),
     repoUrl: requiredString(object.repoUrl, `${path}.repoUrl`),
@@ -272,6 +272,17 @@ function arrayValue(value: unknown, path: string): unknown[] {
 function requiredString(value: unknown, path: string): string {
   if (typeof value !== 'string' || value.trim().length === 0) {
     throw new Error(`${path} must be a non-empty string`);
+  }
+  return value;
+}
+
+// GitHub skill sources use an empty rootPath to denote the repository root
+// (consistent with createSourceId's `rootPath || '.'` fallback and the UI's
+// `rootPath || repoRoot` display). Allow empty here so a snapshot uploaded from
+// a repo-root import can be re-downloaded on a new device.
+function requiredStringAllowEmpty(value: unknown, path: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${path} must be a string`);
   }
   return value;
 }

--- a/tests/persisted-data-i18n.test.ts
+++ b/tests/persisted-data-i18n.test.ts
@@ -211,4 +211,32 @@ describe('persisted user data i18n boundaries', () => {
     expect(parseValidatedArray('skill-sources.json', JSON.stringify([localSource]), validateSkillImportSource)[0])
       .toEqual(localSource);
   });
+
+  it('accepts a GitHub source imported from the repository root (empty rootPath)', () => {
+    // Regression for https://github.com/zhu1090093659/deepseek-pp/issues/250
+    // Importing from a bare repo URL (no sub-path) stores rootPath as "".
+    // The download validation must accept it, not reject it as a non-empty string.
+    const repoRootSource: GitHubSkillSource = {
+      id: 'github:example/skills:main:.',
+      provider: 'github',
+      url: 'https://github.com/example/skills',
+      owner: 'example',
+      repo: 'skills',
+      repository: 'example/skills',
+      ref: 'main',
+      rootPath: '',
+      commitSha: 'abc123',
+      defaultBranch: 'main',
+      repoUrl: 'https://github.com/example/skills',
+      skillPaths: ['SKILL.md'],
+      importedSkillNames: ['demo'],
+      importedAt: 1,
+      updatedAt: 2,
+    };
+
+    expect(validateGitHubSkillSource(repoRootSource)).toEqual(repoRootSource);
+    expect(validateSkillImportSource(repoRootSource)).toEqual(repoRootSource);
+    expect(parseValidatedArray('skill-sources.json', JSON.stringify([repoRootSource]), validateSkillImportSource)[0])
+      .toEqual(repoRootSource);
+  });
 });


### PR DESCRIPTION
## Summary

Fix the `skill-sources.json[0].rootPath must be a non-empty string` error that blocks first-time cloud sync downloads on a new device when a GitHub skill was imported from a bare repo URL (no sub-path).

## PR Type

- [x] Bug fix
- [ ] User-facing feature or behavior change
- [ ] Documentation only
- [ ] Maintenance / refactor

## Root Cause

Importing a skill from `https://github.com/owner/repo` (repo root, no sub-path) stores `rootPath = ""`. This empty value correctly denotes the repository root — it's consistent with `createSourceId`'s `rootPath || '.'` fallback and the UI's `rootPath || repoRoot` display, and `findSkillPaths` already tolerates it.

However, the download-time schema validation (`validateGitHubSkillSource`) used `requiredString`, which rejects empty strings. So a snapshot uploaded from a repo-root import could never be re-downloaded on another device.

## Fix

- Add `requiredStringAllowEmpty` helper in `core/sync/schema.ts` (requires the value to be a `string`, but allows empty).
- Use it for the GitHub source `rootPath` field.
- Local skill `rootPath` keeps `requiredString` (filesystem absolute paths are never empty).

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base commit: `fb4e7fe` (Release DeepSeek++ 1.0.2)

## Local Validation

Commands run:

```bash
npx vitest run tests/persisted-data-i18n.test.ts
npx vitest run
npx tsc --noEmit
```

Result summary:
- New regression test `accepts a GitHub source imported from the repository root (empty rootPath)` passes.
- Full suite: 259 tests pass.
- `tsc --noEmit` clean.

## Test

Added a regression test in `tests/persisted-data-i18n.test.ts` covering a GitHub source with `rootPath: ""`, asserting it passes `validateGitHubSkillSource`, `validateSkillImportSource`, and `parseValidatedArray`.

Fixes #250