### PR TITLE
fix(automation): resolve missing DeepSeek login token in background runner

### DIFF
--- a/core/automation/runner.ts
+++ b/core/automation/runner.ts
@@ -85,7 +85,7 @@ export async function runDeepSeekAutomation(
 
     const completedAt = Date.now();
     const finalAssistantMessageId = stream.responseMessageId ?? assistantMessageId;
-    const history = await readHistorySnapshot(chatSessionId, finalAssistantMessageId).catch(() => null);
+    const history = await readHistorySnapshot(chatSessionId, finalAssistantMessageId, clientHeaders).catch(() => null);
     const nextParentMessageId = history?.parentMessageId ?? finalAssistantMessageId;
     const result: AutomationRunnerSuccess = {
       ok: true,

--- a/core/automation/runner.ts
+++ b/core/automation/runner.ts
@@ -31,6 +31,7 @@ const AUTOMATION_MISSING_TOKEN_MESSAGE =
 
 export interface AutomationRunnerOptions {
   executeToolCall?: (call: ToolCall) => Promise<ToolResult>;
+  clientHeaders?: Record<string, string>;
 }
 
 export async function runDeepSeekAutomation(
@@ -43,7 +44,7 @@ export async function runDeepSeekAutomation(
 
   try {
     parentMessageId = normalizeMessageId(request.parentMessageId, 'parent_message_id');
-    const clientHeaders = createClientHeaders({ missingTokenMessage: AUTOMATION_MISSING_TOKEN_MESSAGE });
+    const clientHeaders = options?.clientHeaders ?? createClientHeaders({ missingTokenMessage: AUTOMATION_MISSING_TOKEN_MESSAGE });
     chatSessionId ??= await createChatSession(clientHeaders);
     const { augmented: prompt } = buildPromptAugmentation(request.prompt, {
       memories: request.promptContext?.memories ?? [],

--- a/core/deepseek/adapter.ts
+++ b/core/deepseek/adapter.ts
@@ -441,9 +441,10 @@ export async function submitPromptStreaming(
 export async function readHistorySnapshot(
   chatSessionId: string,
   expectedAssistantMessageId: number,
+  clientHeadersOverride?: Record<string, string>,
 ): Promise<DeepSeekHistorySnapshot | null> {
-  const clientHeaders = createClientHeaders();
-  const url = new URL(HISTORY_PATH, location.origin);
+  const clientHeaders = clientHeadersOverride ?? createClientHeaders();
+  const url = new URL(HISTORY_PATH, DEEPSEEK_API_URL);
   url.searchParams.set('chat_session_id', chatSessionId);
   const response = await fetch(url.href, {
     method: 'GET',
@@ -487,7 +488,7 @@ export function normalizeMessageId(value: unknown, fieldName = 'message_id'): nu
 }
 
 export function buildDeepSeekSessionUrl(chatSessionId: string): string {
-  return `${location.origin}/a/chat/s/${chatSessionId}`;
+  return `${new URL(DEEPSEEK_API_URL).origin}/a/chat/s/${chatSessionId}`;
 }
 
 async function readCompletionStream(response: Response): Promise<ModelTurn> {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -190,6 +190,7 @@ import {
   updateAutomation,
 } from '../core/automation/store';
 import { runDeepSeekAutomation } from '../core/automation/runner';
+import { createAutomationRunnerFailure } from '../core/automation/messages';
 import {
   AUTOMATION_WAKE_ALARM_NAME,
   AUTOMATION_WAKE_INTERVAL_MINUTES,
@@ -241,6 +242,8 @@ import type { ConversationExportProgress, ConversationExportResult } from '../co
 const DEEPSEEK_HOME_URL = 'https://chat.deepseek.com/';
 const DEEPSEEK_TAB_URL_PATTERN = '*://chat.deepseek.com/*';
 const REFRESH_AUTH_MESSAGE = { type: 'REFRESH_DEEPSEEK_AUTH' } as const;
+const AUTOMATION_AUTH_TOKEN_MISSING_MESSAGE =
+  'DeepSeek login token is missing. Refresh chat.deepseek.com or sign in again, then retry the automation.';
 let chatSessionId: string | null = null;
 let chatParentMessageId: number | null = null;
 let officialApiChatMessages: OfficialDeepSeekMessage[] = [];
@@ -2004,6 +2007,17 @@ async function executeAutomationWithContext(
     ])
     : [null, null];
 
+  const clientHeaders = await loadOrRefreshClientHeaders();
+  if (!clientHeaders) {
+    return createAutomationRunnerFailure(
+      { ...request },
+      'deepseek_auth_token_missing',
+      AUTOMATION_AUTH_TOKEN_MISSING_MESSAGE,
+      'auth',
+      true,
+    );
+  }
+
   return runDeepSeekAutomation({
     ...request,
     locale: currentBackgroundLocale,
@@ -2015,6 +2029,7 @@ async function executeAutomationWithContext(
     },
   }, {
     executeToolCall: (call) => executeBackgroundRuntimeToolCall(call, 'automation'),
+    clientHeaders,
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes #305.

Automation runs (manual trigger & scheduled) execute in the **background service worker**, which has no access to chat.deepseek.com's localStorage. That is where DeepSeek stores the userToken. The automation runner therefore threw:

> DeepSeek login token is missing. Refresh chat.deepseek.com or sign in again, then retry the automation.

…even though the user was signed in and could chat normally in the sidebar — exactly the symptom in the issue.

### Root cause

`runDeepSeekAutomation` called `createClientHeaders` directly, which reads the userToken from localStorage. That works in the content/sidepanel worlds but returns null in the service worker, so it always threw `DeepSeekAuthError`.

Every other background-side DeepSeek caller (conversation export, etc.) already routes auth through `loadOrRefreshClientHeaders`, which reads cached headers from chrome.storage.local and falls back to probing live DeepSeek tabs via the content script. The automation executor was the only background caller that bypassed this.

### Fix

- Load client headers via `loadOrRefreshClientHeaders` in `executeAutomationWithContext` before invoking the runner.
- Pass them into `runDeepSeekAutomation` through a new `clientHeaders` option on `AutomationRunnerOptions`.
- If no headers can be obtained, surface a retryable auth failure (`deepseek_auth_token_missing`) with the same message the runner previously produced — so the UI and retry behavior stay consistent.

## PR Type

- [x] Bug fix

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch.

Base sync commit: `ff9e5a8` (origin/main)

## AI Coding Disclosure

- [x] Partially AI-assisted: AI helped write or modify some programming changes.

AI model(s) used: GLM-5.2 (ZCode)

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 344/344 passing
- `npm run build` — succeeds
