### PR TITLE
fix: clarify local Skill on-demand resources

### DIFF
--- a/core/i18n/resources/en.ts
+++ b/core/i18n/resources/en.ts
@@ -176,9 +176,10 @@ export const en = {
       referencedMode: 'Referenced folder',
       warningOverflow: '{count} more warnings',
       renamedBadge: 'Renamed',
-      resourceCount: '{count} resources',
+      resourceCount: '{count} bundled',
       scriptCount: '{count} scripts',
-      omittedCount: '{count} omitted',
+      omittedCount: '{count} on demand',
+      omittedExplanation: '{count} supporting files were not bundled into context because a count or size limit was reached. They were not deleted and remain available in the local Skill folder for on-demand reads through Shell MCP.',
       renamedNotice: '{count} Skills were renamed automatically because of naming conflicts.',
       meta: {
         skill: 'Skill',

--- a/core/i18n/resources/en.ts
+++ b/core/i18n/resources/en.ts
@@ -179,7 +179,16 @@ export const en = {
       resourceCount: '{count} bundled',
       scriptCount: '{count} scripts',
       omittedCount: '{count} on demand',
+      notBundledCount: '{count} not bundled',
       omittedExplanation: '{count} supporting files were not bundled into context because a count or size limit was reached. They were not deleted and remain available in the local Skill folder for on-demand reads through Shell MCP.',
+      omittedUnavailableExplanation: '{count} supporting files were not bundled into context. They were not deleted and remain in the local Skill folder, but on-demand reads are currently unavailable. Fix the affected Shell MCP reader before importing those Skills.',
+      readerUnavailable: 'On-demand reader unavailable',
+      readerTechnicalDetail: 'Details: {detail}',
+      readerActions: {
+        updateHost: 'Reinstall Shell Native Host from MCP > Shell Local, restart the browser, then preview again.',
+        enableReader: 'Set Shell Local execution mode to Auto and allow local_file_read, then preview again.',
+        checkConnection: 'Check the Shell Local connection and preview again.',
+      },
       renamedNotice: '{count} Skills were renamed automatically because of naming conflicts.',
       meta: {
         skill: 'Skill',

--- a/core/i18n/resources/zh-CN.ts
+++ b/core/i18n/resources/zh-CN.ts
@@ -176,9 +176,10 @@ export const zhCN = {
       referencedMode: '引用文件夹',
       warningOverflow: '还有 {count} 条警告',
       renamedBadge: '已改名',
-      resourceCount: '资源 {count}',
+      resourceCount: '已内嵌 {count}',
       scriptCount: '脚本 {count}',
-      omittedCount: '省略 {count}',
+      omittedCount: '按需读取 {count}',
+      omittedExplanation: '另有 {count} 个支持文件因数量或大小上限未嵌入上下文。文件没有被删除，仍保留在本地 Skill 目录，可通过 Shell MCP 按需读取。',
       renamedNotice: '有 {count} 个 Skill 因命名冲突自动加后缀。',
       meta: {
         skill: 'Skill',

--- a/core/i18n/resources/zh-CN.ts
+++ b/core/i18n/resources/zh-CN.ts
@@ -179,7 +179,16 @@ export const zhCN = {
       resourceCount: '已内嵌 {count}',
       scriptCount: '脚本 {count}',
       omittedCount: '按需读取 {count}',
+      notBundledCount: '未内嵌 {count}',
       omittedExplanation: '另有 {count} 个支持文件因数量或大小上限未嵌入上下文。文件没有被删除，仍保留在本地 Skill 目录，可通过 Shell MCP 按需读取。',
+      omittedUnavailableExplanation: '另有 {count} 个支持文件未嵌入上下文。文件没有被删除，仍保留在本地 Skill 目录，但当前无法按需读取；请先修复受影响 Skill 的 Shell MCP 读取器再导入。',
+      readerUnavailable: '按需读取器不可用',
+      readerTechnicalDetail: '技术详情：{detail}',
+      readerActions: {
+        updateHost: '请在 MCP > Shell Local 重新安装 Shell Native Host，重启浏览器后再预览。',
+        enableReader: '请将 Shell Local 执行模式设为“自动”，并允许 local_file_read，然后重新预览。',
+        checkConnection: '请检查 Shell Local 连接后重新预览。',
+      },
       renamedNotice: '有 {count} 个 Skill 因命名冲突自动加后缀。',
       meta: {
         skill: 'Skill',

--- a/core/skill/local-importer.ts
+++ b/core/skill/local-importer.ts
@@ -445,7 +445,7 @@ function buildLocalImportedInstructions(input: {
     parsed.lastUpdated ? `- Upstream updated: ${parsed.lastUpdated}` : '',
     `- Bundled supporting files: ${resources.length}`,
     scriptFiles.length > 0 ? `- Local executable/script files: ${scriptFiles.length}` : '',
-    omittedFiles.length > 0 ? `- Omitted supporting files: ${omittedFiles.length}` : '',
+    omittedFiles.length > 0 ? `- Supporting files available on demand: ${omittedFiles.length}` : '',
   ].filter(Boolean).join('\n');
 
   const executionBoundary = [
@@ -485,9 +485,9 @@ function buildLocalImportedInstructions(input: {
   ].join('\n\n');
 
   const omitted = omittedFiles.length === 0 ? '' : [
-    '## Omitted Supporting Files',
+    '## Supporting Files Available on Demand',
     '',
-    'These files were not bundled into the prompt because of count, size, or type limits. Inspect the local directory when needed.',
+    'These files remain in the referenced local Skill directory and were not bundled into the prompt because of count or size limits. Read them with Shell MCP when the upstream instructions need them.',
     '',
     ...omittedFiles.map((file) => `- ${relativeToSkillDirectory(file.path, directory)} (${file.bytes} bytes)`),
   ].join('\n');

--- a/core/skill/local-importer.ts
+++ b/core/skill/local-importer.ts
@@ -3,7 +3,9 @@ import { getAllMcpServers, updateMcpServer } from '../mcp/store';
 import { buildShellAllowlistUpgrade, isShellMcpServer } from '../shell';
 import type {
   LocalSkillImportRequest,
-  LocalSkillImportResult,
+  LocalSkillImportBlock,
+  LocalSkillImportBlockCode,
+  LocalSkillImportResponse,
   LocalSkillPreview,
   LocalSkillPreviewItem,
   LocalSkillSource,
@@ -32,6 +34,27 @@ interface LocalSkillHostBundle {
   skills: LocalSkillHostItem[];
   warnings: string[];
   truncated: boolean;
+}
+
+interface LocalSkillBundleReadResult {
+  bundle: LocalSkillHostBundle;
+  onDemandResourceBlock?: LocalSkillImportBlock;
+}
+
+interface OnDemandResourceIssue {
+  code: LocalSkillImportBlockCode;
+  detail?: string;
+  message: string;
+}
+
+class LocalSkillImportBlockedError extends Error {
+  constructor(
+    message: string,
+    readonly importBlock: LocalSkillImportBlock,
+  ) {
+    super(message);
+    this.name = 'LocalSkillImportBlockedError';
+  }
 }
 
 interface LocalSkillHostItem {
@@ -89,12 +112,29 @@ export async function pickLocalSkillFolder(defaultPath?: string): Promise<string
 
 export async function importLocalSkillSource(
   request: LocalSkillImportRequest,
-): Promise<LocalSkillImportResult> {
+): Promise<LocalSkillImportResponse> {
   if (request.selectedPaths.length === 0) {
     throw new Error('Select at least one local Skill before importing.');
   }
 
-  const loaded = await loadLocalSkillSource(request.rootPath, new Set(request.selectedPaths));
+  const selectedImportNames = new Map(Object.entries(request.selectedImportNames ?? {}));
+  let loaded: LoadedLocalSource;
+  try {
+    loaded = await loadLocalSkillSource(
+      request.rootPath,
+      new Set(request.selectedPaths),
+      selectedImportNames,
+    );
+  } catch (error) {
+    if (error instanceof LocalSkillImportBlockedError) {
+      return {
+        ok: false,
+        error: error.message,
+        importBlock: error.importBlock,
+      };
+    }
+    throw error;
+  }
   const selected = loaded.skills.filter((skill) => request.selectedPaths.includes(skill.item.path));
   const importedPaths = new Set(selected.map((skill) => skill.item.path));
   const missingPaths = request.selectedPaths.filter((path) => !importedPaths.has(path));
@@ -137,8 +177,12 @@ export async function importLocalSkillSource(
   };
 }
 
-async function loadLocalSkillSource(rootPath: string, selectedPaths?: Set<string>): Promise<LoadedLocalSource> {
-  const bundle = await readLocalSkillBundle(rootPath, selectedPaths);
+async function loadLocalSkillSource(
+  rootPath: string,
+  selectedPaths?: Set<string>,
+  selectedImportNames?: ReadonlyMap<string, string>,
+): Promise<LoadedLocalSource> {
+  const { bundle, onDemandResourceBlock } = await readLocalSkillBundle(rootPath, selectedPaths);
   if (bundle.skills.length === 0) {
     throw new Error('No SKILL.md was found under this local directory.');
   }
@@ -159,7 +203,13 @@ async function loadLocalSkillSource(rootPath: string, selectedPaths?: Set<string
   };
 
   const existingContext = await createExistingSkillContext(source.id);
-  const loadedSkills = bundle.skills.map((skill) => loadLocalSkill(source, skill, existingContext));
+  const loadedSkills = bundle.skills.map((skill) => loadLocalSkill(
+    source,
+    skill,
+    existingContext,
+    skill.omittedFiles.length > 0 ? onDemandResourceBlock : undefined,
+    selectedImportNames?.get(skill.path),
+  ));
   const previewSkills = loadedSkills.map((skill) => skill.item);
 
   return {
@@ -181,6 +231,8 @@ function loadLocalSkill(
   source: LocalSkillSource,
   hostSkill: LocalSkillHostItem,
   existingContext: ExistingSkillContext,
+  importBlock?: LocalSkillImportBlock,
+  selectedImportName?: string,
 ): LoadedLocalSkill {
   const warnings = [...hostSkill.warnings];
   if (hostSkill.content.length > MAX_SKILL_BYTES) {
@@ -189,7 +241,7 @@ function loadLocalSkill(
 
   const parsed = parseSkillDoc(hostSkill.content, hostSkill.path);
   const existingRemoteSkill = existingContext.bySourcePath.get(`${source.id}:${hostSkill.path}`);
-  const baseImportName = existingRemoteSkill?.name ?? parsed.name;
+  const baseImportName = existingRemoteSkill?.name ?? selectedImportName ?? parsed.name;
   const importName = existingRemoteSkill?.name ?? createUniqueSkillName(baseImportName, existingContext.occupiedNames);
   existingContext.occupiedNames.add(importName);
 
@@ -256,6 +308,7 @@ function loadLocalSkill(
     omittedFiles: remote.omittedFiles,
     scriptFiles: remote.scriptFiles ?? [],
     warnings,
+    importBlock,
     nameChanged: importName !== parsed.name,
     existingSkillName: existingRemoteSkill?.name ?? conflictingSkill?.name,
     existingSourceId: existingRemoteSkill?.remote?.sourceId ?? conflictingSkill?.remote?.sourceId,
@@ -286,7 +339,7 @@ async function createExistingSkillContext(sourceId: string): Promise<ExistingSki
   };
 }
 
-async function readLocalSkillBundle(rootPath: string, selectedPaths?: Set<string>): Promise<LocalSkillHostBundle> {
+async function readLocalSkillBundle(rootPath: string, selectedPaths?: Set<string>): Promise<LocalSkillBundleReadResult> {
   const server = await getShellMcpServer();
   const result = await executeShellMcpTool(server, 'local_skill_preview', {
     rootPath,
@@ -297,20 +350,43 @@ async function readLocalSkillBundle(rootPath: string, selectedPaths?: Set<string
     throw new Error(formatToolFailure(result));
   }
   const bundle = parseLocalSkillHostBundle(result.output);
-  await ensureOnDemandResourcesReadable(server, bundle);
-  return bundle;
+  const onDemandResourceIssue = await getOnDemandResourceIssue(server, bundle);
+  if (selectedPaths && onDemandResourceIssue) {
+    throw new LocalSkillImportBlockedError(
+      onDemandResourceIssue.message,
+      toLocalSkillImportBlock(onDemandResourceIssue),
+    );
+  }
+  return {
+    bundle,
+    onDemandResourceBlock: onDemandResourceIssue
+      ? toLocalSkillImportBlock(onDemandResourceIssue)
+      : undefined,
+  };
 }
 
-async function ensureOnDemandResourcesReadable(
+function toLocalSkillImportBlock(issue: OnDemandResourceIssue): LocalSkillImportBlock {
+  return {
+    code: issue.code,
+    ...(issue.detail ? { detail: issue.detail } : {}),
+  };
+}
+
+async function getOnDemandResourceIssue(
   server: McpServerConfig,
   bundle: LocalSkillHostBundle,
-): Promise<void> {
+): Promise<OnDemandResourceIssue | null> {
   const hasOnDemandResources = bundle.skills.some((skill) => skill.omittedFiles.length > 0);
-  if (!hasOnDemandResources) return;
+  if (!hasOnDemandResources) return null;
 
   const discovery = await refreshMcpServerDiscovery(server.id);
   if (discovery.health.status === 'error') {
-    throw new Error(`Unable to verify Shell MCP local_file_read availability: ${discovery.health.error || 'MCP discovery failed.'}`);
+    const detail = discovery.health.error || 'MCP discovery failed.';
+    return {
+      code: 'shell_discovery_failed',
+      detail,
+      message: `Unable to verify Shell MCP local_file_read availability: ${detail}`,
+    };
   }
   const runtimeDescriptors = await getMcpToolDescriptors();
   const reader = runtimeDescriptors.find((descriptor) =>
@@ -318,11 +394,19 @@ async function ensureOnDemandResourcesReadable(
     descriptor.provider.id === server.id &&
     ON_DEMAND_RESOURCE_READER_NAMES.has(descriptor.name)
   );
-  if (reader) return;
+  if (reader) return null;
 
   const hasLocalFileReader = discovery.descriptors.some((descriptor) => descriptor.name === 'local_file_read');
-  if (!hasLocalFileReader) throw new Error(STALE_LOCAL_FILE_READ_MESSAGE);
-  throw new Error('Shell MCP on-demand file reading is not available to chat. Set Shell Local execution mode to Auto and allow local_file_read before importing this Skill.');
+  if (!hasLocalFileReader) {
+    return {
+      code: 'shell_host_update_required',
+      message: STALE_LOCAL_FILE_READ_MESSAGE,
+    };
+  }
+  return {
+    code: 'shell_reader_unavailable',
+    message: 'Shell MCP on-demand file reading is not available to chat. Set Shell Local execution mode to Auto and allow local_file_read before importing this Skill.',
+  };
 }
 
 async function executeShellMcpTool(

--- a/core/skill/local-importer.ts
+++ b/core/skill/local-importer.ts
@@ -1,4 +1,4 @@
-import { executeMcpToolCall, refreshMcpServerDiscovery } from '../mcp/discovery';
+import { executeMcpToolCall, getMcpToolDescriptors, refreshMcpServerDiscovery } from '../mcp/discovery';
 import { getAllMcpServers, updateMcpServer } from '../mcp/store';
 import { buildShellAllowlistUpgrade, isShellMcpServer } from '../shell';
 import type {
@@ -19,6 +19,11 @@ import {
 } from './registry';
 
 const MAX_SKILL_BYTES = 120_000;
+const ON_DEMAND_RESOURCE_READER_NAMES = new Set(['local_file_read', 'shell_exec']);
+const STALE_LOCAL_FILE_READ_MESSAGE = [
+  'Current Shell Native Host can preview local Skills but does not expose local_file_read, and shell_exec is not available to chat.',
+  'Reinstall Shell Native Host from MCP > Shell Local to add the least-privilege reader, restart the browser, then try again.',
+].join(' ');
 
 interface LocalSkillHostBundle {
   rootPath: string;
@@ -291,7 +296,33 @@ async function readLocalSkillBundle(rootPath: string, selectedPaths?: Set<string
   if (!result.ok) {
     throw new Error(formatToolFailure(result));
   }
-  return parseLocalSkillHostBundle(result.output);
+  const bundle = parseLocalSkillHostBundle(result.output);
+  await ensureOnDemandResourcesReadable(server, bundle);
+  return bundle;
+}
+
+async function ensureOnDemandResourcesReadable(
+  server: McpServerConfig,
+  bundle: LocalSkillHostBundle,
+): Promise<void> {
+  const hasOnDemandResources = bundle.skills.some((skill) => skill.omittedFiles.length > 0);
+  if (!hasOnDemandResources) return;
+
+  const discovery = await refreshMcpServerDiscovery(server.id);
+  if (discovery.health.status === 'error') {
+    throw new Error(`Unable to verify Shell MCP local_file_read availability: ${discovery.health.error || 'MCP discovery failed.'}`);
+  }
+  const runtimeDescriptors = await getMcpToolDescriptors();
+  const reader = runtimeDescriptors.find((descriptor) =>
+    descriptor.provider.kind === 'mcp' &&
+    descriptor.provider.id === server.id &&
+    ON_DEMAND_RESOURCE_READER_NAMES.has(descriptor.name)
+  );
+  if (reader) return;
+
+  const hasLocalFileReader = discovery.descriptors.some((descriptor) => descriptor.name === 'local_file_read');
+  if (!hasLocalFileReader) throw new Error(STALE_LOCAL_FILE_READ_MESSAGE);
+  throw new Error('Shell MCP on-demand file reading is not available to chat. Set Shell Local execution mode to Auto and allow local_file_read before importing this Skill.');
 }
 
 async function executeShellMcpTool(

--- a/core/types.ts
+++ b/core/types.ts
@@ -399,6 +399,16 @@ export interface GitHubSkillImportResult {
   warnings: string[];
 }
 
+export type LocalSkillImportBlockCode =
+  | 'shell_host_update_required'
+  | 'shell_reader_unavailable'
+  | 'shell_discovery_failed';
+
+export interface LocalSkillImportBlock {
+  code: LocalSkillImportBlockCode;
+  detail?: string;
+}
+
 export interface LocalSkillPreviewItem {
   path: string;
   name: string;
@@ -412,6 +422,7 @@ export interface LocalSkillPreviewItem {
   omittedFiles: RemoteSkillFile[];
   scriptFiles: RemoteSkillFile[];
   warnings: string[];
+  importBlock?: LocalSkillImportBlock;
   nameChanged: boolean;
   existingSkillName?: string;
   existingSourceId?: string;
@@ -427,6 +438,7 @@ export interface LocalSkillPreview {
 export interface LocalSkillImportRequest {
   rootPath: string;
   selectedPaths: string[];
+  selectedImportNames?: Record<string, string>;
 }
 
 export interface LocalSkillImportResult {
@@ -437,6 +449,14 @@ export interface LocalSkillImportResult {
   renamed: number;
   warnings: string[];
 }
+
+export interface LocalSkillImportFailure {
+  ok: false;
+  error: string;
+  importBlock: LocalSkillImportBlock;
+}
+
+export type LocalSkillImportResponse = LocalSkillImportResult | LocalSkillImportFailure;
 
 export interface GitHubSkillUpdatePreview {
   source: GitHubSkillSource;

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -649,6 +649,7 @@ async function handleMessage(
 
     case 'IMPORT_LOCAL_SKILL_SOURCE': {
       const result = await importLocalSkillSource(message.payload as LocalSkillImportRequest);
+      if (!result.ok) return result;
       await broadcastStateUpdate(sender.tab?.id);
       return result;
     }

--- a/entrypoints/sidepanel/components/LocalSkillImportPanel.tsx
+++ b/entrypoints/sidepanel/components/LocalSkillImportPanel.tsx
@@ -266,10 +266,14 @@ export default function LocalSkillImportPanel({ onImported, onCancel }: Props) {
 function SourceSummary({ preview }: { preview: LocalSkillPreview }) {
   const { t } = useI18n();
   const { source } = preview;
+  const omittedCount = preview.skills.reduce((sum, skill) => sum + skill.omittedFiles.length, 0);
+  const sourceWarningSet = new Set(preview.warnings);
   const warnings = [
     ...preview.warnings,
-    ...preview.skills.flatMap((skill) => skill.warnings.map((warning) => `${skill.importName}: ${warning}`)),
-  ];
+    ...preview.skills.flatMap((skill) => skill.warnings
+      .filter((warning) => !sourceWarningSet.has(warning) && !isGenericOmissionWarning(warning))
+      .map((warning) => `${skill.importName}: ${warning}`)),
+  ].filter((warning) => !isGenericOmissionWarning(warning));
 
   return (
     <div className="ds-surface-panel rounded-xl p-3 space-y-2">
@@ -285,6 +289,11 @@ function SourceSummary({ preview }: { preview: LocalSkillPreview }) {
         <Meta label={t('sidepanel.localSkillImport.meta.skill')} value={String(preview.skills.length)} />
         <Meta label={t('sidepanel.localSkillImport.meta.mode')} value={t('sidepanel.localSkillImport.referencedMode')} />
       </div>
+      {omittedCount > 0 && (
+        <div className="rounded-lg px-3 py-2 text-[11px] leading-relaxed" style={{ color: 'var(--ds-info)', background: 'var(--ds-info-bg)' }}>
+          {t('sidepanel.localSkillImport.omittedExplanation', { count: omittedCount })}
+        </div>
+      )}
       {warnings.length > 0 && (
         <div className="rounded-lg px-3 py-2 text-[11px] leading-relaxed" style={{ color: 'var(--ds-warning)', background: 'var(--ds-warning-bg)' }}>
           {warnings.slice(0, 4).map((warning) => (
@@ -340,13 +349,22 @@ function PreviewSkillRow({ skill, checked, onToggle }: {
               <span className="ds-tag px-1.5 py-0.5 rounded-full">{t('sidepanel.localSkillImport.scriptCount', { count: skill.scriptFiles.length })}</span>
             )}
             {skill.omittedFiles.length > 0 && (
-              <span className="ds-tag px-1.5 py-0.5 rounded-full">{t('sidepanel.localSkillImport.omittedCount', { count: skill.omittedFiles.length })}</span>
+              <span
+                className="ds-tag px-1.5 py-0.5 rounded-full"
+                title={t('sidepanel.localSkillImport.omittedExplanation', { count: skill.omittedFiles.length })}
+              >
+                {t('sidepanel.localSkillImport.omittedCount', { count: skill.omittedFiles.length })}
+              </span>
             )}
           </div>
         </div>
       </div>
     </label>
   );
+}
+
+function isGenericOmissionWarning(warning: string): boolean {
+  return /^\d+ local supporting file\(s\) were omitted\.$/.test(warning.trim());
 }
 
 function StatusMessage({ state, message, result }: {

--- a/entrypoints/sidepanel/components/LocalSkillImportPanel.tsx
+++ b/entrypoints/sidepanel/components/LocalSkillImportPanel.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from 'react';
 import type {
   LocalSkillImportResult,
+  LocalSkillImportBlock,
   LocalSkillPreview,
   LocalSkillPreviewItem,
 } from '../../../core/types';
@@ -26,10 +27,21 @@ export default function LocalSkillImportPanel({ onImported, onCancel }: Props) {
   const previewRequestIdRef = useRef(0);
 
   const selectedCount = selectedPaths.size;
-  const allSelected = preview ? preview.skills.length > 0 && selectedCount === preview.skills.length : false;
+  const selectablePaths = useMemo(() => new Set(
+    preview?.skills
+      .filter((skill) => !skill.importBlock)
+      .map((skill) => skill.path) ?? [],
+  ), [preview]);
+  const allSelected = selectablePaths.size > 0 &&
+    [...selectablePaths].every((path) => selectedPaths.has(path));
   const canPreview = rootPath.trim().length > 0 && state !== 'previewing' && state !== 'importing' && !picking;
   const canPick = state !== 'previewing' && state !== 'importing' && !picking;
-  const canImport = Boolean(preview) && selectedCount > 0 && state !== 'importing' && state !== 'previewing' && !picking;
+  const canImport = Boolean(preview) &&
+    selectedCount > 0 &&
+    [...selectedPaths].every((path) => selectablePaths.has(path)) &&
+    state !== 'importing' &&
+    state !== 'previewing' &&
+    !picking;
 
   const selectedBytes = useMemo(() => {
     if (!preview) return 0;
@@ -56,7 +68,11 @@ export default function LocalSkillImportPanel({ onImported, onCancel }: Props) {
       if (requestId !== previewRequestIdRef.current || latestPathRef.current.trim() !== requestedPath) return;
       const nextPreview = response as LocalSkillPreview;
       setPreview(nextPreview);
-      setSelectedPaths(new Set(nextPreview.skills.map((skill) => skill.path)));
+      setSelectedPaths(new Set(
+        nextPreview.skills
+          .filter((skill) => !skill.importBlock)
+          .map((skill) => skill.path),
+      ));
       setState('ready');
     } catch (error) {
       if (requestId !== previewRequestIdRef.current || latestPathRef.current.trim() !== requestedPath) return;
@@ -107,9 +123,18 @@ export default function LocalSkillImportPanel({ onImported, onCancel }: Props) {
         payload: {
           rootPath: rootPath.trim(),
           selectedPaths: [...selectedPaths],
+          selectedImportNames: Object.fromEntries(
+            preview.skills
+              .filter((skill) => selectedPaths.has(skill.path))
+              .map((skill) => [skill.path, skill.importName]),
+          ),
         },
       });
-      if (response?.ok === false) throw new Error(response.error ?? t('sidepanel.localSkillImport.importFailed'));
+      if (response?.ok === false) {
+        const importBlock = readLocalSkillImportBlock(response.importBlock);
+        if (importBlock) throw new Error(formatImportBlockMessage(importBlock, t));
+        throw new Error(response.error ?? t('sidepanel.localSkillImport.importFailed'));
+      }
       const importResult = response as LocalSkillImportResult;
       setResult(importResult);
       setState('success');
@@ -122,6 +147,7 @@ export default function LocalSkillImportPanel({ onImported, onCancel }: Props) {
   };
 
   const togglePath = (path: string) => {
+    if (!selectablePaths.has(path)) return;
     setSelectedPaths((current) => {
       const next = new Set(current);
       if (next.has(path)) next.delete(path);
@@ -132,7 +158,7 @@ export default function LocalSkillImportPanel({ onImported, onCancel }: Props) {
 
   const toggleAll = () => {
     if (!preview) return;
-    setSelectedPaths(allSelected ? new Set() : new Set(preview.skills.map((skill) => skill.path)));
+    setSelectedPaths(allSelected ? new Set() : new Set(selectablePaths));
   };
 
   return (
@@ -267,6 +293,9 @@ function SourceSummary({ preview }: { preview: LocalSkillPreview }) {
   const { t } = useI18n();
   const { source } = preview;
   const omittedCount = preview.skills.reduce((sum, skill) => sum + skill.omittedFiles.length, 0);
+  const unavailableOmittedCount = preview.skills
+    .filter((skill) => skill.importBlock)
+    .reduce((sum, skill) => sum + skill.omittedFiles.length, 0);
   const sourceWarningSet = new Set(preview.warnings);
   const warnings = [
     ...preview.warnings,
@@ -291,7 +320,12 @@ function SourceSummary({ preview }: { preview: LocalSkillPreview }) {
       </div>
       {omittedCount > 0 && (
         <div className="rounded-lg px-3 py-2 text-[11px] leading-relaxed" style={{ color: 'var(--ds-info)', background: 'var(--ds-info-bg)' }}>
-          {t('sidepanel.localSkillImport.omittedExplanation', { count: omittedCount })}
+          {t(
+            unavailableOmittedCount > 0
+              ? 'sidepanel.localSkillImport.omittedUnavailableExplanation'
+              : 'sidepanel.localSkillImport.omittedExplanation',
+            { count: omittedCount },
+          )}
         </div>
       )}
       {warnings.length > 0 && (
@@ -312,13 +346,18 @@ function PreviewSkillRow({ skill, checked, onToggle }: {
   onToggle: () => void;
 }) {
   const { t } = useI18n();
+  const blocked = Boolean(skill.importBlock);
+  const blockInstructions = skill.importBlock
+    ? getImportBlockInstructions(skill.importBlock, t)
+    : '';
 
   return (
-    <label className="ds-card rounded-xl p-3 block cursor-pointer">
+    <label className={`ds-card rounded-xl p-3 block ${blocked ? 'cursor-not-allowed opacity-70' : 'cursor-pointer'}`}>
       <div className="flex items-start gap-3">
         <input
           type="checkbox"
           checked={checked}
+          disabled={blocked}
           onChange={onToggle}
           className="mt-1 w-4 h-4"
         />
@@ -351,16 +390,80 @@ function PreviewSkillRow({ skill, checked, onToggle }: {
             {skill.omittedFiles.length > 0 && (
               <span
                 className="ds-tag px-1.5 py-0.5 rounded-full"
-                title={t('sidepanel.localSkillImport.omittedExplanation', { count: skill.omittedFiles.length })}
+                title={t(
+                  blocked
+                    ? 'sidepanel.localSkillImport.omittedUnavailableExplanation'
+                    : 'sidepanel.localSkillImport.omittedExplanation',
+                  { count: skill.omittedFiles.length },
+                )}
               >
-                {t('sidepanel.localSkillImport.omittedCount', { count: skill.omittedFiles.length })}
+                {t(
+                  blocked
+                    ? 'sidepanel.localSkillImport.notBundledCount'
+                    : 'sidepanel.localSkillImport.omittedCount',
+                  { count: skill.omittedFiles.length },
+                )}
               </span>
             )}
           </div>
+          {skill.importBlock && (
+            <div className="mt-2 rounded-lg px-2.5 py-2 text-[10px] leading-relaxed" style={{ color: 'var(--ds-warning)', background: 'var(--ds-warning-bg)' }}>
+              <div className="font-medium">{t('sidepanel.localSkillImport.readerUnavailable')}</div>
+              <div className="mt-0.5">{blockInstructions}</div>
+              {skill.importBlock.detail && (
+                <div className="mt-0.5 opacity-80">
+                  {t('sidepanel.localSkillImport.readerTechnicalDetail', { detail: skill.importBlock.detail })}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </label>
   );
+}
+
+function getImportBlockInstructions(
+  block: LocalSkillImportBlock,
+  t: ReturnType<typeof useI18n>['t'],
+): string {
+  switch (block.code) {
+    case 'shell_host_update_required':
+      return t('sidepanel.localSkillImport.readerActions.updateHost');
+    case 'shell_reader_unavailable':
+      return t('sidepanel.localSkillImport.readerActions.enableReader');
+    case 'shell_discovery_failed':
+      return t('sidepanel.localSkillImport.readerActions.checkConnection');
+  }
+}
+
+function formatImportBlockMessage(
+  block: LocalSkillImportBlock,
+  t: ReturnType<typeof useI18n>['t'],
+): string {
+  return [
+    t('sidepanel.localSkillImport.readerUnavailable'),
+    getImportBlockInstructions(block, t),
+    block.detail
+      ? t('sidepanel.localSkillImport.readerTechnicalDetail', { detail: block.detail })
+      : '',
+  ].filter(Boolean).join(' ');
+}
+
+function readLocalSkillImportBlock(value: unknown): LocalSkillImportBlock | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as { code?: unknown; detail?: unknown };
+  if (
+    candidate.code !== 'shell_host_update_required' &&
+    candidate.code !== 'shell_reader_unavailable' &&
+    candidate.code !== 'shell_discovery_failed'
+  ) return null;
+  return {
+    code: candidate.code,
+    ...(typeof candidate.detail === 'string' && candidate.detail
+      ? { detail: candidate.detail }
+      : {}),
+  };
 }
 
 function isGenericOmissionWarning(warning: string): boolean {

--- a/packages/shell-host/native/shell-mcp-host.mjs
+++ b/packages/shell-host/native/shell-mcp-host.mjs
@@ -1005,10 +1005,6 @@ function collectLocalSkillResources(rootPath, directory, skillBody, startingCont
     includedFiles.push({ path: candidate.path, bytes, content });
   }
 
-  if (omittedFiles.length > 0) {
-    warnings.push(`${omittedFiles.length} local supporting file(s) were omitted.`);
-  }
-
   return { includedFiles, omittedFiles, scriptFiles, warnings: dedupeStrings(warnings) };
 }
 

--- a/tests/local-skill-importer.test.ts
+++ b/tests/local-skill-importer.test.ts
@@ -180,6 +180,22 @@ describe('local Skill importer', () => {
     expect(imported.instructions).not.toContain('### nested/references/child.md');
   });
 
+  it('describes non-bundled local resources as available on demand', async () => {
+    vi.mocked(executeMcpToolCall).mockResolvedValueOnce(createLocalSkillWithOnDemandResourceToolResult());
+
+    const result = await importLocalSkillSource({
+      rootPath: '/Users/me/.codex/skills/demo',
+      selectedPaths: ['SKILL.md'],
+    });
+
+    const imported = result.imported[0];
+    expect(imported.instructions).toContain('Supporting files available on demand: 1');
+    expect(imported.instructions).toContain('## Supporting Files Available on Demand');
+    expect(imported.instructions).toContain('Read them with Shell MCP when the upstream instructions need them.');
+    expect(imported.instructions).toContain('- references/extended-guide.md (2048 bytes)');
+    expect(imported.instructions).not.toContain('## Omitted Supporting Files');
+  });
+
   it('imports a BOM-prefixed SKILL.md without losing the frontmatter name (issue #296)', async () => {
     // Editors on Windows commonly save SKILL.md with a UTF-8 BOM. Previously
     // the BOM defeated the `^---` frontmatter fence, `name:` was dropped, and
@@ -398,6 +414,26 @@ function createNestedLocalSkillToolResult() {
             warnings: [],
           },
         ],
+      },
+    },
+  };
+}
+
+function createLocalSkillWithOnDemandResourceToolResult() {
+  const result = createLocalSkillToolResult();
+  return {
+    ...result,
+    output: {
+      ...result.output,
+      data: {
+        ...result.output.data,
+        skills: [{
+          ...result.output.data.skills[0],
+          omittedFiles: [{
+            path: 'references/extended-guide.md',
+            bytes: 2048,
+          }],
+        }],
       },
     },
   };

--- a/tests/local-skill-importer.test.ts
+++ b/tests/local-skill-importer.test.ts
@@ -8,12 +8,13 @@ vi.mock('../core/mcp/store', () => ({
 
 vi.mock('../core/mcp/discovery', () => ({
   executeMcpToolCall: vi.fn(),
+  getMcpToolDescriptors: vi.fn(),
   refreshMcpServerDiscovery: vi.fn(),
 }));
 
-import { executeMcpToolCall, refreshMcpServerDiscovery } from '../core/mcp/discovery';
+import { executeMcpToolCall, getMcpToolDescriptors, refreshMcpServerDiscovery } from '../core/mcp/discovery';
 import { getAllMcpServers, updateMcpServer } from '../core/mcp/store';
-import type { McpServerConfig } from '../core/mcp/types';
+import type { McpServerConfig, McpToolCacheEntry } from '../core/mcp/types';
 import { importLocalSkillSource, pickLocalSkillFolder, previewLocalSkillSource } from '../core/skill/local-importer';
 
 const SKILL_STORAGE_KEY = 'deepseek_pp_skills';
@@ -44,6 +45,7 @@ beforeEach(() => {
     allowlist: patch.allowlist ?? shellServer.allowlist,
   }));
   vi.mocked(refreshMcpServerDiscovery).mockResolvedValue({} as never);
+  vi.mocked(getMcpToolDescriptors).mockResolvedValue([]);
   vi.mocked(executeMcpToolCall).mockResolvedValue(createLocalSkillToolResult());
 });
 
@@ -182,6 +184,9 @@ describe('local Skill importer', () => {
 
   it('describes non-bundled local resources as available on demand', async () => {
     vi.mocked(executeMcpToolCall).mockResolvedValueOnce(createLocalSkillWithOnDemandResourceToolResult());
+    const discovery = createShellDiscovery(['local_file_read'], true, null, 'auto');
+    vi.mocked(refreshMcpServerDiscovery).mockResolvedValueOnce(discovery);
+    vi.mocked(getMcpToolDescriptors).mockResolvedValueOnce(discovery.descriptors);
 
     const result = await importLocalSkillSource({
       rootPath: '/Users/me/.codex/skills/demo',
@@ -194,6 +199,55 @@ describe('local Skill importer', () => {
     expect(imported.instructions).toContain('Read them with Shell MCP when the upstream instructions need them.');
     expect(imported.instructions).toContain('- references/extended-guide.md (2048 bytes)');
     expect(imported.instructions).not.toContain('## Omitted Supporting Files');
+  });
+
+  it('requires a current Shell Host before promising on-demand resource reads', async () => {
+    vi.mocked(executeMcpToolCall).mockResolvedValueOnce(createLocalSkillWithOnDemandResourceToolResult());
+    vi.mocked(refreshMcpServerDiscovery).mockResolvedValueOnce(createShellDiscovery(['local_skill_preview', 'shell_exec']));
+
+    await expect(previewLocalSkillSource('/Users/me/.codex/skills/demo')).rejects.toThrow(
+      'does not expose local_file_read',
+    );
+  });
+
+  it('rejects on-demand imports when local_file_read is disabled by policy', async () => {
+    vi.mocked(executeMcpToolCall).mockResolvedValueOnce(createLocalSkillWithOnDemandResourceToolResult());
+    vi.mocked(refreshMcpServerDiscovery).mockResolvedValueOnce(createShellDiscovery(['local_file_read'], false, null, 'auto'));
+
+    await expect(previewLocalSkillSource('/Users/me/.codex/skills/demo')).rejects.toThrow(
+      'not available to chat',
+    );
+  });
+
+  it('rejects manual readers that are not injected into the chat prompt', async () => {
+    vi.mocked(executeMcpToolCall).mockResolvedValueOnce(createLocalSkillWithOnDemandResourceToolResult());
+    vi.mocked(refreshMcpServerDiscovery).mockResolvedValueOnce(createShellDiscovery(['local_file_read']));
+
+    await expect(previewLocalSkillSource('/Users/me/.codex/skills/demo')).rejects.toThrow(
+      'execution mode to Auto',
+    );
+  });
+
+  it('accepts an enabled auto shell_exec fallback on older Shell Hosts', async () => {
+    vi.mocked(executeMcpToolCall).mockResolvedValueOnce(createLocalSkillWithOnDemandResourceToolResult());
+    const discovery = createShellDiscovery(['local_skill_preview', 'shell_exec'], true, null, 'auto');
+    vi.mocked(refreshMcpServerDiscovery).mockResolvedValueOnce(discovery);
+    vi.mocked(getMcpToolDescriptors).mockResolvedValueOnce(
+      discovery.descriptors.filter((descriptor) => descriptor.name === 'shell_exec'),
+    );
+
+    await expect(previewLocalSkillSource('/Users/me/.codex/skills/demo')).resolves.toMatchObject({
+      skills: [expect.objectContaining({ omittedFiles: [expect.any(Object)] })],
+    });
+  });
+
+  it('surfaces Shell discovery failures while checking on-demand resource support', async () => {
+    vi.mocked(executeMcpToolCall).mockResolvedValueOnce(createLocalSkillWithOnDemandResourceToolResult());
+    vi.mocked(refreshMcpServerDiscovery).mockResolvedValueOnce(createShellDiscovery([], true, 'native host disconnected'));
+
+    await expect(previewLocalSkillSource('/Users/me/.codex/skills/demo')).rejects.toThrow(
+      'native host disconnected',
+    );
   });
 
   it('imports a BOM-prefixed SKILL.md without losing the frontmatter name (issue #296)', async () => {
@@ -435,6 +489,47 @@ function createLocalSkillWithOnDemandResourceToolResult() {
           }],
         }],
       },
+    },
+  };
+}
+
+function createShellDiscovery(
+  toolNames: string[],
+  enabled = true,
+  error: string | null = null,
+  mode: 'auto' | 'manual' = 'manual',
+): McpToolCacheEntry {
+  const now = Date.now();
+  return {
+    serverId: 'shell-local',
+    descriptors: toolNames.map((name) => ({
+      id: `mcp:shell-local:${name}`,
+      provider: {
+        kind: 'mcp' as const,
+        id: 'shell-local',
+        displayName: SHELL_MCP_SERVER_NAME,
+        transport: 'native_messaging' as const,
+      },
+      name,
+      invocationName: name,
+      title: name,
+      description: name,
+      inputSchema: { type: 'object', properties: {} },
+      execution: {
+        enabled,
+        mode,
+        risk: 'low' as const,
+      },
+    })),
+    refreshedAt: now,
+    expiresAt: now + 60_000,
+    health: {
+      serverId: 'shell-local',
+      status: error ? 'error' : 'ready',
+      checkedAt: now,
+      latencyMs: 1,
+      toolCount: toolNames.length,
+      error,
     },
   };
 }

--- a/tests/local-skill-importer.test.ts
+++ b/tests/local-skill-importer.test.ts
@@ -16,6 +16,7 @@ import { executeMcpToolCall, getMcpToolDescriptors, refreshMcpServerDiscovery } 
 import { getAllMcpServers, updateMcpServer } from '../core/mcp/store';
 import type { McpServerConfig, McpToolCacheEntry } from '../core/mcp/types';
 import { importLocalSkillSource, pickLocalSkillFolder, previewLocalSkillSource } from '../core/skill/local-importer';
+import type { LocalSkillImportResponse, LocalSkillImportResult } from '../core/types';
 
 const SKILL_STORAGE_KEY = 'deepseek_pp_skills';
 
@@ -143,6 +144,7 @@ describe('local Skill importer', () => {
       rootPath: '/Users/me/.codex/skills/demo',
       selectedPaths: ['SKILL.md'],
     });
+    expectImportSuccess(result);
 
     expect(result.imported).toHaveLength(1);
     expect(result.imported[0].remote).toMatchObject({
@@ -167,6 +169,7 @@ describe('local Skill importer', () => {
       rootPath: '/Users/me/.codex/skills',
       selectedPaths: ['nested/SKILL.md'],
     });
+    expectImportSuccess(result);
 
     const imported = result.imported[0];
     expect(imported.remote).toMatchObject({
@@ -192,6 +195,7 @@ describe('local Skill importer', () => {
       rootPath: '/Users/me/.codex/skills/demo',
       selectedPaths: ['SKILL.md'],
     });
+    expectImportSuccess(result);
 
     const imported = result.imported[0];
     expect(imported.instructions).toContain('Supporting files available on demand: 1');
@@ -201,31 +205,47 @@ describe('local Skill importer', () => {
     expect(imported.instructions).not.toContain('## Omitted Supporting Files');
   });
 
-  it('requires a current Shell Host before promising on-demand resource reads', async () => {
+  it('keeps preview available but blocks affected Skills on stale Shell Hosts', async () => {
     vi.mocked(executeMcpToolCall).mockResolvedValueOnce(createLocalSkillWithOnDemandResourceToolResult());
     vi.mocked(refreshMcpServerDiscovery).mockResolvedValueOnce(createShellDiscovery(['local_skill_preview', 'shell_exec']));
 
-    await expect(previewLocalSkillSource('/Users/me/.codex/skills/demo')).rejects.toThrow(
-      'does not expose local_file_read',
-    );
+    const preview = await previewLocalSkillSource('/Users/me/.codex/skills/demo');
+
+    expect(preview.skills[0].importBlock).toEqual({
+      code: 'shell_host_update_required',
+    });
   });
 
   it('rejects on-demand imports when local_file_read is disabled by policy', async () => {
     vi.mocked(executeMcpToolCall).mockResolvedValueOnce(createLocalSkillWithOnDemandResourceToolResult());
     vi.mocked(refreshMcpServerDiscovery).mockResolvedValueOnce(createShellDiscovery(['local_file_read'], false, null, 'auto'));
 
-    await expect(previewLocalSkillSource('/Users/me/.codex/skills/demo')).rejects.toThrow(
-      'not available to chat',
-    );
+    await expect(importLocalSkillSource({
+      rootPath: '/Users/me/.codex/skills/demo',
+      selectedPaths: ['SKILL.md'],
+    })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('not available to chat'),
+      importBlock: {
+        code: 'shell_reader_unavailable',
+      },
+    });
   });
 
   it('rejects manual readers that are not injected into the chat prompt', async () => {
     vi.mocked(executeMcpToolCall).mockResolvedValueOnce(createLocalSkillWithOnDemandResourceToolResult());
     vi.mocked(refreshMcpServerDiscovery).mockResolvedValueOnce(createShellDiscovery(['local_file_read']));
 
-    await expect(previewLocalSkillSource('/Users/me/.codex/skills/demo')).rejects.toThrow(
-      'execution mode to Auto',
-    );
+    await expect(importLocalSkillSource({
+      rootPath: '/Users/me/.codex/skills/demo',
+      selectedPaths: ['SKILL.md'],
+    })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('execution mode to Auto'),
+      importBlock: {
+        code: 'shell_reader_unavailable',
+      },
+    });
   });
 
   it('accepts an enabled auto shell_exec fallback on older Shell Hosts', async () => {
@@ -237,7 +257,10 @@ describe('local Skill importer', () => {
     );
 
     await expect(previewLocalSkillSource('/Users/me/.codex/skills/demo')).resolves.toMatchObject({
-      skills: [expect.objectContaining({ omittedFiles: [expect.any(Object)] })],
+      skills: [expect.objectContaining({
+        omittedFiles: [expect.any(Object)],
+        importBlock: undefined,
+      })],
     });
   });
 
@@ -245,9 +268,63 @@ describe('local Skill importer', () => {
     vi.mocked(executeMcpToolCall).mockResolvedValueOnce(createLocalSkillWithOnDemandResourceToolResult());
     vi.mocked(refreshMcpServerDiscovery).mockResolvedValueOnce(createShellDiscovery([], true, 'native host disconnected'));
 
-    await expect(previewLocalSkillSource('/Users/me/.codex/skills/demo')).rejects.toThrow(
-      'native host disconnected',
+    await expect(importLocalSkillSource({
+      rootPath: '/Users/me/.codex/skills/demo',
+      selectedPaths: ['SKILL.md'],
+    })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('native host disconnected'),
+      importBlock: {
+        code: 'shell_discovery_failed',
+        detail: 'native host disconnected',
+      },
+    });
+  });
+
+  it('allows safe selections when a sibling Skill needs an unavailable reader', async () => {
+    vi.mocked(executeMcpToolCall)
+      .mockResolvedValueOnce(createMixedLocalSkillToolResult())
+      .mockResolvedValueOnce(createSafeLocalSkillToolResult());
+    vi.mocked(refreshMcpServerDiscovery).mockResolvedValueOnce(
+      createShellDiscovery(['local_skill_preview', 'shell_exec']),
     );
+
+    const preview = await previewLocalSkillSource('/Users/me/.codex/skills/demo');
+
+    expect(preview.skills).toEqual([
+      expect.objectContaining({
+        path: 'SKILL.md',
+        importName: 'demo-local',
+        importBlock: {
+          code: 'shell_host_update_required',
+        },
+      }),
+      expect.objectContaining({
+        path: 'safe/SKILL.md',
+        importName: 'demo-local-2',
+        importBlock: undefined,
+      }),
+    ]);
+
+    const result = await importLocalSkillSource({
+      rootPath: '/Users/me/.codex/skills/demo',
+      selectedPaths: ['safe/SKILL.md'],
+      selectedImportNames: {
+        'safe/SKILL.md': preview.skills[1].importName,
+      },
+    });
+    expectImportSuccess(result);
+
+    expect(result.imported).toEqual([
+      expect.objectContaining({ name: preview.skills[1].importName }),
+    ]);
+    expect(refreshMcpServerDiscovery).toHaveBeenCalledTimes(1);
+    expect(executeMcpToolCall).toHaveBeenLastCalledWith(expect.objectContaining({
+      payload: {
+        rootPath: '/Users/me/.codex/skills/demo',
+        selectedPaths: ['safe/SKILL.md'],
+      },
+    }));
   });
 
   it('imports a BOM-prefixed SKILL.md without losing the frontmatter name (issue #296)', async () => {
@@ -296,6 +373,7 @@ describe('local Skill importer', () => {
       rootPath: 'D:\\skills\\ref-material-writing',
       selectedPaths: ['SKILL.md'],
     });
+    expectImportSuccess(result);
 
     expect(result.imported).toHaveLength(1);
     expect(result.imported[0].name).toBe('ref-material-writing');
@@ -338,11 +416,19 @@ describe('local Skill importer', () => {
       rootPath: 'D:\\写作助手',
       selectedPaths: ['SKILL.md'],
     });
+    expectImportSuccess(result);
 
     expect(result.imported).toHaveLength(1);
     expect(result.imported[0].name).toMatch(/^skill-[a-z0-9]{2,8}$/);
   });
 });
+
+function expectImportSuccess(
+  response: LocalSkillImportResponse,
+): asserts response is LocalSkillImportResult {
+  expect(response.ok).toBe(true);
+  if (!response.ok) throw new Error(response.error);
+}
 
 function createShellServer(toolNames: string[]): McpServerConfig {
   return {
@@ -488,6 +574,55 @@ function createLocalSkillWithOnDemandResourceToolResult() {
             bytes: 2048,
           }],
         }],
+      },
+    },
+  };
+}
+
+function createMixedLocalSkillToolResult() {
+  const result = createLocalSkillWithOnDemandResourceToolResult();
+  const safeContent = [
+    '---',
+    'name: demo-local',
+    'description: Safe local Skill',
+    '---',
+    '',
+    '# Safe',
+  ].join('\n');
+  return {
+    ...result,
+    output: {
+      ...result.output,
+      data: {
+        ...result.output.data,
+        skills: [
+          ...result.output.data.skills,
+          {
+            path: 'safe/SKILL.md',
+            directory: 'safe',
+            directoryPath: '/Users/me/.codex/skills/demo/safe',
+            content: safeContent,
+            bodyBytes: safeContent.length,
+            includedFiles: [],
+            omittedFiles: [],
+            scriptFiles: [],
+            warnings: [],
+          },
+        ],
+      },
+    },
+  };
+}
+
+function createSafeLocalSkillToolResult() {
+  const result = createMixedLocalSkillToolResult();
+  return {
+    ...result,
+    output: {
+      ...result.output,
+      data: {
+        ...result.output.data,
+        skills: result.output.data.skills.filter((skill) => skill.path === 'safe/SKILL.md'),
       },
     },
   };

--- a/tests/mcp-execution-policy.test.ts
+++ b/tests/mcp-execution-policy.test.ts
@@ -71,7 +71,16 @@ describe('MCP execution policy', () => {
                 name: 'sample_tool',
                 title: 'Sample Tool',
                 description: 'Sample MCP tool.',
-                inputSchema: { type: 'object', properties: {} },
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    group: {
+                      type: 'string',
+                      enum: ['playwright', 'filesystem'],
+                    },
+                  },
+                  required: ['group'],
+                },
               }],
             }
           : { protocolVersion: MCP_PROTOCOL_VERSION, capabilities: { tools: {} } },
@@ -96,6 +105,10 @@ describe('MCP execution policy', () => {
 
     expect(cache.health.status).toBe('ready');
     expect(cache.descriptors.map((descriptor) => descriptor.name)).toEqual(['sample_tool']);
+    expect(cache.descriptors[0].inputSchema.properties?.group).toEqual({
+      type: 'string',
+      enum: ['playwright', 'filesystem'],
+    });
     expect(requests.map((request) => request.method)).toEqual([
       'initialize',
       'notifications/initialized',

--- a/tests/mcp-execution-policy.test.ts
+++ b/tests/mcp-execution-policy.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MCP_PROTOCOL_VERSION } from '../core/mcp';
-import { executeMcpToolCall, refreshMcpServerDiscovery } from '../core/mcp/discovery';
-import { createMcpServer, saveMcpToolCache } from '../core/mcp/store';
+import { executeMcpToolCall, getMcpToolDescriptors, refreshMcpServerDiscovery } from '../core/mcp/discovery';
+import { createMcpServer, saveMcpToolCache, updateMcpServer } from '../core/mcp/store';
+import { renderToolSchemas } from '../core/prompt/augmentation';
 import type { McpServerConfig, ToolCall, ToolDescriptor } from '../core/types';
 
 let storage: Record<string, unknown>;
@@ -109,6 +110,8 @@ describe('MCP execution policy', () => {
       type: 'string',
       enum: ['playwright', 'filesystem'],
     });
+    const persistedDescriptors = await getMcpToolDescriptors({ includeDisabled: true });
+    expect(renderToolSchemas(persistedDescriptors)).toContain('"enum":["playwright","filesystem"]');
     expect(requests.map((request) => request.method)).toEqual([
       'initialize',
       'notifications/initialized',
@@ -188,6 +191,59 @@ describe('MCP execution policy', () => {
     expect(requests[1].headers.get('MCP-Protocol-Version')).toBe(MCP_PROTOCOL_VERSION);
     expect(requests[2].headers.get('MCP-Protocol-Version')).toBe(MCP_PROTOCOL_VERSION);
   });
+
+  it('exposes only policy-enabled auto MCP tools to the prompt runtime', async () => {
+    const server = await createMcpServer({
+      displayName: 'Policy MCP',
+      enabled: true,
+      transport: {
+        kind: 'native_messaging',
+        nativeHost: 'com.example.policy',
+      },
+      allowlist: {
+        mode: 'allow',
+        toolNames: ['local_file_read'],
+      },
+      execution: {
+        enabled: true,
+        mode: 'auto',
+      },
+    });
+    const descriptors = [
+      createMcpDescriptor(server, 'local_file_read'),
+      createMcpDescriptor(server, 'shell_exec'),
+    ];
+    await saveMcpToolCache({
+      serverId: server.id,
+      descriptors,
+      refreshedAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+      health: {
+        serverId: server.id,
+        status: 'ready',
+        checkedAt: Date.now(),
+        latencyMs: 1,
+        toolCount: descriptors.length,
+        error: null,
+      },
+    });
+
+    await expect(getMcpToolDescriptors()).resolves.toEqual([
+      expect.objectContaining({ name: 'local_file_read' }),
+    ]);
+
+    await updateMcpServer(server.id, {
+      allowlist: { mode: 'deny', toolNames: ['local_file_read'] },
+    });
+    await expect(getMcpToolDescriptors()).resolves.toEqual([
+      expect.objectContaining({ name: 'shell_exec' }),
+    ]);
+
+    await updateMcpServer(server.id, {
+      execution: { enabled: true, mode: 'manual' },
+    });
+    await expect(getMcpToolDescriptors()).resolves.toEqual([]);
+  });
 });
 
 function createMcpCall(serverId: string, descriptor?: ToolDescriptor): ToolCall {
@@ -206,19 +262,19 @@ function createMcpCall(serverId: string, descriptor?: ToolDescriptor): ToolCall 
   };
 }
 
-function createMcpDescriptor(server: McpServerConfig): ToolDescriptor {
+function createMcpDescriptor(server: McpServerConfig, name = 'sample_tool'): ToolDescriptor {
   return {
-    id: `mcp:${server.id}:sample_tool`,
+    id: `mcp:${server.id}:${name}`,
     provider: {
       kind: 'mcp',
       id: server.id,
       displayName: server.displayName,
       transport: server.transport.kind,
     },
-    name: 'sample_tool',
-    invocationName: `mcp_${server.id}_sample_tool`,
-    title: 'Sample Tool',
-    description: 'Sample MCP tool.',
+    name,
+    invocationName: `mcp_${server.id}_${name}`,
+    title: name,
+    description: `${name} MCP tool.`,
     inputSchema: {
       type: 'object',
       properties: {},

--- a/tests/shell-host-local-skill-preview.test.ts
+++ b/tests/shell-host-local-skill-preview.test.ts
@@ -34,6 +34,20 @@ describe('shell native host local_skill_preview', () => {
       expect.objectContaining({ path: 'nested/scripts/run.py' }),
     ]);
   });
+
+  it('returns excess supporting files as structured on-demand resources without a generic warning', async () => {
+    const root = createLargeResourceSkillFixture();
+    const response = await callNativeHost('local_skill_preview', { rootPath: root });
+
+    expect(response.error).toBeUndefined();
+    const data = response.result?.structuredContent?.data;
+    const skill = data.skills[0];
+    expect(skill.includedFiles).toHaveLength(16);
+    expect(skill.omittedFiles).toHaveLength(13);
+    expect(skill.omittedFiles[0]).toMatchObject({ path: 'references/17.md' });
+    expect(data.warnings).not.toContain('13 local supporting file(s) were omitted.');
+    expect(existsSync(join(root, 'references/29.md'))).toBe(true);
+  });
 });
 
 describe('shell native host local_folder_pick', () => {
@@ -161,6 +175,25 @@ function createNestedSkillFixture(): string {
   writeFileSync(join(root, 'nested/references/child.md'), 'Child reference.');
   writeFileSync(join(root, 'nested/scripts/run.py'), 'print("child")\n');
 
+  return root;
+}
+
+function createLargeResourceSkillFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), 'deepseek-pp-local-skill-large-'));
+  tempRoots.push(root);
+  mkdirSync(join(root, 'references'), { recursive: true });
+  writeFileSync(join(root, 'SKILL.md'), [
+    '---',
+    'name: large-resource-skill',
+    'description: Large resource Skill',
+    '---',
+    '',
+    'Use supporting references when needed.',
+  ].join('\n'));
+  for (let index = 1; index <= 29; index += 1) {
+    const filename = String(index).padStart(2, '0') + '.md';
+    writeFileSync(join(root, 'references', filename), `Reference ${index}.`);
+  }
   return root;
 }
 

--- a/tests/sidepanel-interactions.test.ts
+++ b/tests/sidepanel-interactions.test.ts
@@ -7,6 +7,7 @@ import {
   type PromptInjectionSettings,
 } from '../core/prompt/settings';
 import PromptControlPanel from '../entrypoints/sidepanel/components/PromptControlPanel';
+import LocalSkillImportPanel from '../entrypoints/sidepanel/components/LocalSkillImportPanel';
 import ChatPage from '../entrypoints/sidepanel/pages/ChatPage';
 import SavedPage from '../entrypoints/sidepanel/pages/SavedPage';
 
@@ -173,6 +174,55 @@ describe('sidepanel interactions', () => {
 
     expect(container.textContent).toContain('保存提示词设置失败：tabs permission unavailable');
     expect((memoryToggle as HTMLButtonElement).getAttribute('style')).toContain('var(--ds-blue)');
+  });
+
+  it('explains that non-bundled local Skill resources remain available on demand', async () => {
+    const legacyWarning = '13 local supporting file(s) were omitted.';
+    const sendMessage = vi.fn(async (message: { type: string }) => {
+      if (message.type !== 'PREVIEW_LOCAL_SKILL_SOURCE') return null;
+      return {
+        source: {
+          id: 'local:demo',
+          provider: 'local',
+          rootPath: '/Users/me/.codex/skills/demo',
+          displayName: 'demo',
+          directoryName: 'demo',
+          skillPaths: ['SKILL.md'],
+          importedSkillNames: ['demo'],
+          importedAt: 1,
+          updatedAt: 1,
+          warnings: [legacyWarning],
+        },
+        skills: [{
+          path: 'SKILL.md',
+          name: 'demo',
+          importName: 'demo',
+          description: 'Demo Skill',
+          bytes: 64000,
+          bodyBytes: 6000,
+          includedFiles: Array.from({ length: 16 }, (_, index) => ({ path: `references/${index + 1}.md`, bytes: 100 })),
+          omittedFiles: Array.from({ length: 13 }, (_, index) => ({ path: `references/${index + 17}.md`, bytes: 100 })),
+          scriptFiles: [],
+          warnings: [legacyWarning],
+          nameChanged: false,
+        }],
+        warnings: [legacyWarning],
+        truncated: false,
+      };
+    });
+    stubChrome(sendMessage);
+
+    await renderElement(React.createElement(LocalSkillImportPanel, {
+      onImported: vi.fn(),
+      onCancel: vi.fn(),
+    }));
+    await enterText('/Users/me/.codex/skills/my-skill', '/Users/me/.codex/skills/demo');
+    await clickButton('预览');
+    await flushPromises();
+
+    expect(container.textContent).toContain('按需读取 13');
+    expect(container.textContent).toContain('文件没有被删除');
+    expect(container.textContent).not.toContain(legacyWarning);
   });
 
   it('persists web model mode from sidepanel chat controls', async () => {

--- a/tests/sidepanel-interactions.test.ts
+++ b/tests/sidepanel-interactions.test.ts
@@ -225,6 +225,170 @@ describe('sidepanel interactions', () => {
     expect(container.textContent).not.toContain(legacyWarning);
   });
 
+  it('keeps safe local Skills selectable when a sibling needs an unavailable reader', async () => {
+    const source = {
+      id: 'local:demo',
+      provider: 'local' as const,
+      rootPath: '/Users/me/.codex/skills/demo',
+      displayName: 'demo',
+      directoryName: 'demo',
+      skillPaths: ['blocked/SKILL.md', 'safe/SKILL.md'],
+      importedSkillNames: ['blocked', 'safe'],
+      importedAt: 1,
+      updatedAt: 1,
+      warnings: [],
+    };
+    const sendMessage = vi.fn(async (message: { type: string; payload?: unknown }) => {
+      if (message.type === 'PREVIEW_LOCAL_SKILL_SOURCE') {
+        return {
+          source,
+          skills: [
+            {
+              path: 'blocked/SKILL.md',
+              name: 'blocked',
+              importName: 'blocked',
+              description: 'Needs an on-demand reader',
+              bytes: 64000,
+              bodyBytes: 6000,
+              includedFiles: Array.from({ length: 16 }, (_, index) => ({ path: `blocked/references/${index + 1}.md`, bytes: 100 })),
+              omittedFiles: [{ path: 'blocked/references/17.md', bytes: 100 }],
+              scriptFiles: [],
+              warnings: [],
+              importBlock: {
+                code: 'shell_reader_unavailable',
+              },
+              nameChanged: false,
+            },
+            {
+              path: 'safe/SKILL.md',
+              name: 'safe',
+              importName: 'safe',
+              description: 'Safe to import',
+              bytes: 1000,
+              bodyBytes: 1000,
+              includedFiles: [],
+              omittedFiles: [],
+              scriptFiles: [],
+              warnings: [],
+              nameChanged: false,
+            },
+          ],
+          warnings: [],
+          truncated: false,
+        };
+      }
+      if (message.type === 'IMPORT_LOCAL_SKILL_SOURCE') {
+        return {
+          ok: true,
+          source,
+          imported: [],
+          replaced: 0,
+          renamed: 0,
+          warnings: [],
+        };
+      }
+      return null;
+    });
+    stubChrome(sendMessage);
+
+    await renderElement(React.createElement(LocalSkillImportPanel, {
+      onImported: vi.fn(),
+      onCancel: vi.fn(),
+    }));
+    await enterText('/Users/me/.codex/skills/my-skill', '/Users/me/.codex/skills/demo');
+    await clickButton('预览');
+    await flushPromises();
+
+    const checkboxes = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'));
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes[0]).toMatchObject({ checked: false, disabled: true });
+    expect(checkboxes[1]).toMatchObject({ checked: true, disabled: false });
+    expect(container.textContent).toContain('按需读取器不可用');
+    expect(container.textContent).toContain('当前无法按需读取');
+    expect(container.textContent).toContain('请将 Shell Local 执行模式设为“自动”');
+    expect(container.textContent).not.toContain('Shell MCP on-demand file reading is not available to chat.');
+    expect(container.textContent).toContain('未内嵌 1');
+    expect(container.textContent).not.toContain('按需读取 1');
+
+    await clickButton('导入选中 Skill');
+    await flushPromises();
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: 'IMPORT_LOCAL_SKILL_SOURCE',
+      payload: {
+        rootPath: '/Users/me/.codex/skills/demo',
+        selectedPaths: ['safe/SKILL.md'],
+        selectedImportNames: {
+          'safe/SKILL.md': 'safe',
+        },
+      },
+    });
+  });
+
+  it('localizes reader failures detected again at import time', async () => {
+    const source = {
+      id: 'local:demo',
+      provider: 'local' as const,
+      rootPath: '/Users/me/.codex/skills/demo',
+      displayName: 'demo',
+      directoryName: 'demo',
+      skillPaths: ['SKILL.md'],
+      importedSkillNames: ['demo'],
+      importedAt: 1,
+      updatedAt: 1,
+      warnings: [],
+    };
+    const sendMessage = vi.fn(async (message: { type: string; payload?: unknown }) => {
+      if (message.type === 'PREVIEW_LOCAL_SKILL_SOURCE') {
+        return {
+          source,
+          skills: [{
+            path: 'SKILL.md',
+            name: 'demo',
+            importName: 'demo',
+            description: 'Reader was available during preview',
+            bytes: 64000,
+            bodyBytes: 6000,
+            includedFiles: [],
+            omittedFiles: [{ path: 'references/large.md', bytes: 58000 }],
+            scriptFiles: [],
+            warnings: [],
+            nameChanged: false,
+          }],
+          warnings: [],
+          truncated: false,
+        };
+      }
+      if (message.type === 'IMPORT_LOCAL_SKILL_SOURCE') {
+        return {
+          ok: false,
+          error: 'Shell MCP on-demand file reading is not available to chat.',
+          importBlock: {
+            code: 'shell_reader_unavailable',
+          },
+        };
+      }
+      return null;
+    });
+    const onImported = vi.fn();
+    stubChrome(sendMessage);
+
+    await renderElement(React.createElement(LocalSkillImportPanel, {
+      onImported,
+      onCancel: vi.fn(),
+    }));
+    await enterText('/Users/me/.codex/skills/my-skill', '/Users/me/.codex/skills/demo');
+    await clickButton('预览');
+    await flushPromises();
+    await clickButton('导入选中 Skill');
+    await flushPromises();
+
+    expect(container.textContent).toContain('按需读取器不可用');
+    expect(container.textContent).toContain('请将 Shell Local 执行模式设为“自动”');
+    expect(container.textContent).not.toContain('Shell MCP on-demand file reading is not available to chat.');
+    expect(onImported).not.toHaveBeenCalled();
+  });
+
   it('persists web model mode from sidepanel chat controls', async () => {
     const sendMessage = vi.fn(async (message: { type: string; payload?: unknown }) => {
       if (message.type === 'GET_AUTH_STATUS') return { available: true, provider: 'deepseek-web' };


### PR DESCRIPTION
## Summary

- clarify that supporting files beyond the preview budget stay in the local Skill folder and remain available on demand
- verify that the same Shell MCP server has a prompt-visible on-demand reader before promising that access
- keep multi-Skill previews usable when only some rows need an unavailable reader, and preserve previewed names across subset imports
- preserve MCP input-schema enums through discovery, persistence, cache reads, and prompt rendering
- localize reader remediation both during preview and when reader state changes before import

Root cause: the importer intentionally bundles at most 16 supporting files, but the UI described the remainder as “omitted” and did not prove that chat could read them later. The initial reader gate also ran before users selected rows, so one blocked Skill could prevent safe siblings from being imported.

Fixes #309
Refs #308

## PR Type

- [x] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

`git fetch origin && git merge-base --is-ancestor origin/main HEAD`

Verified base: `e87ff60621fb9cef1836a63cced073423c62a8bc`

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

GPT-5

Coding Agent tool(s) used:

Codex

## Local Validation

Commands run:

```bash
npx vitest run tests/local-skill-importer.test.ts tests/sidepanel-interactions.test.ts tests/mcp-execution-policy.test.ts tests/shell-host-local-skill-preview.test.ts
npm run compile
npm run verify:i18n
npm run ci:quality
npm run zip:sources && npm run verify:release-assets
```

Result summary:

- targeted regression suite passed: 4 files / 36 tests
- final `npm run ci:quality` passed: 62 files / 356 tests, production audit, prompt freeze, i18n, automation, MCP/Shell/PoW smoke checks, Chrome/Edge/Firefox builds, zips, and release-asset validation
- the first full quality run stopped because the npm audit endpoint dropped its TLS connection; an immediate standalone retry reported 0 vulnerabilities, and the complete quality run then passed
- committed source archive and release assets passed after `bfd5a1b`
- final findings-first diff review and two focused re-reviews reported no remaining findings

## Local Feature Evidence

Evidence:

<img width="360" height="768" alt="DeepSeek++ local Skill preview showing 16 bundled files and 303 files available on demand" src="https://github.com/user-attachments/assets/b87feb39-54f8-4e5f-9830-a7a8ba43a672" />

Local Chrome loaded the extension from this PR working tree and successfully previewed a large referenced Skill. The sidepanel shows 16 bundled files and 303 files retained for on-demand reads through Shell MCP. The final head additionally passed the automated reader-policy, mixed-folder selection, import-time state-change, and localization regressions above.