### PR TITLE
fix: restore tool authorization, MCP cache, and continuation

### DIFF
--- a/core/deepseek/chat-session.ts
+++ b/core/deepseek/chat-session.ts
@@ -1,0 +1,26 @@
+const DEEPSEEK_CHAT_SESSION_PATHNAME = /^\/(?:a\/)?chat\/s\/([^/?#]+)/;
+
+/**
+ * Reads a DeepSeek conversation identifier from a browser URL or pathname.
+ * Invalid percent-encoding is rejected so every caller observes the same
+ * browser-owned route identity.
+ */
+export function readDeepSeekChatSessionId(value: string | URL): string | null {
+  const pathname = typeof value === 'string' ? readPathname(value) : value.pathname;
+  const match = pathname.match(DEEPSEEK_CHAT_SESSION_PATHNAME);
+  if (!match?.[1]) return null;
+  try {
+    const sessionId = decodeURIComponent(match[1]);
+    return sessionId.trim() ? sessionId : null;
+  } catch {
+    return null;
+  }
+}
+
+function readPathname(value: string): string {
+  try {
+    return new URL(value, 'https://chat.deepseek.com').pathname;
+  } catch {
+    return value;
+  }
+}

--- a/core/i18n/resources/en.ts
+++ b/core/i18n/resources/en.ts
@@ -1072,6 +1072,7 @@ export const en = {
       invalidFormat: 'Invalid tool format',
       unknownTool: 'Unknown tool',
       authorizationRejected: 'Tool authorization rejected',
+      sessionBindingUnavailable: 'The new conversation did not receive a browser-owned session route in time. Please wait for the chat URL to update and try again.',
       incomplete: 'The response ended before this tool call completed.',
     },
     memory: {

--- a/core/i18n/resources/zh-CN.ts
+++ b/core/i18n/resources/zh-CN.ts
@@ -1072,6 +1072,7 @@ export const zhCN = {
       invalidFormat: '工具格式错误',
       unknownTool: '未知工具',
       authorizationRejected: '工具授权被拒绝',
+      sessionBindingUnavailable: '新对话未能及时获得浏览器会话路由。请等待聊天地址更新后重试。',
       incomplete: '响应已结束，但该工具调用尚未完成。',
     },
     memory: {

--- a/core/mcp/discovery.ts
+++ b/core/mcp/discovery.ts
@@ -7,7 +7,7 @@ import {
   getMcpServerById,
   getMcpToolCache,
   saveMcpToolCache,
-  updateMcpServer,
+  updateMcpServerHealth,
 } from './store';
 import { createMcpTransport } from './transports';
 import type {
@@ -251,7 +251,7 @@ async function discoverServerTools(
       health,
     };
     await saveMcpToolCache(entry);
-    await updateMcpServer(server.id, {
+    await updateMcpServerHealth(server.id, {
       status: 'ready',
       lastConnectedAt: completedAt,
       lastError: null,
@@ -277,7 +277,7 @@ async function discoverServerTools(
       health,
     };
     await saveMcpToolCache(entry);
-    await updateMcpServer(server.id, {
+    await updateMcpServerHealth(server.id, {
       status: 'error',
       lastError: message,
     });

--- a/core/mcp/index.ts
+++ b/core/mcp/index.ts
@@ -85,6 +85,7 @@ export {
   saveMcpToolCache,
   sanitizeMcpServerConfig,
   updateMcpServer,
+  updateMcpServerHealth,
 } from './store';
 
 export {

--- a/core/mcp/store.ts
+++ b/core/mcp/store.ts
@@ -126,6 +126,40 @@ export async function updateMcpServer(
   });
 }
 
+/**
+ * Records connection health without treating it as a configuration mutation.
+ *
+ * Discovery writes its cache immediately before this update. Running the
+ * configuration normalizer here can alter a valid legacy/sparse record and
+ * make the generic cache-invalidation path delete that freshly written cache.
+ */
+export async function updateMcpServerHealth(
+  id: McpServerId,
+  patch: Partial<Pick<McpServerConfig, 'status' | 'lastConnectedAt' | 'lastError'>>,
+): Promise<McpServerConfig | null> {
+  return mcpStorageOperations.run(async () => {
+    const state = await readStateAlreadyOwned();
+    let updated: McpServerConfig | null = null;
+    const servers = state.servers.map((server) => {
+      if (server.id !== id) return server;
+      updated = {
+        ...server,
+        status: resolveMcpServerHealthStatus(server, patch),
+        lastConnectedAt: patch.lastConnectedAt === undefined
+          ? server.lastConnectedAt
+          : patch.lastConnectedAt,
+        lastError: patch.lastError === undefined ? server.lastError : patch.lastError,
+        updatedAt: Date.now(),
+      };
+      return updated;
+    });
+
+    if (!updated) return null;
+    await writeStateAlreadyOwned({ ...state, servers });
+    return sanitizeMcpServerConfig(updated);
+  });
+}
+
 export async function deleteMcpServer(id: McpServerId): Promise<void> {
   await mcpStorageOperations.run(async () => {
     const state = await readStateAlreadyOwned();
@@ -255,12 +289,20 @@ function normalizeServerForMutation(raw: unknown): McpServerConfig {
 
 function resolvePatchedServerStatus(
   server: McpServerConfig,
-  patch: McpServerUpdateInput,
+  patch: Pick<McpServerUpdateInput, 'enabled' | 'status'>,
 ): McpServerStatus {
   if (patch.enabled === false) return 'disabled';
   if (patch.status) return patch.status;
   if (patch.enabled === true && (!server.enabled || server.status === 'disabled')) return 'unknown';
   return server.status;
+}
+
+function resolveMcpServerHealthStatus(
+  server: McpServerConfig,
+  patch: Partial<Pick<McpServerConfig, 'status'>>,
+): McpServerStatus {
+  if (!server.enabled) return 'disabled';
+  return patch.status ?? server.status;
 }
 
 function normalizeServerStatus(

--- a/core/messaging/runtime-boundary.ts
+++ b/core/messaging/runtime-boundary.ts
@@ -1,3 +1,5 @@
+import { readDeepSeekChatSessionId } from '../deepseek/chat-session';
+
 export const RUNTIME_BOUNDARY_ERROR_CODES = {
   invalidMessage: 'runtime_message_invalid',
   unauthorizedSender: 'runtime_message_unauthorized',
@@ -168,7 +170,7 @@ export function createRuntimeMessageContext(
     documentId: validDocumentId(sender.documentId),
     documentLifecycle: sender.documentLifecycle,
     documentSessionId: createDocumentSessionId('deepseek_content', sender, senderUrl, frameId ?? 0),
-    chatSessionId: readDeepSeekChatSessionId(senderUrl),
+    chatSessionId: readDeepSeekChatSessionId(senderUrl) ?? undefined,
   };
 }
 
@@ -270,16 +272,6 @@ function validOptionalFrameId(value: unknown): number | undefined {
   if (value === undefined) return undefined;
   if (typeof value === 'number' && Number.isInteger(value) && value >= 0) return value;
   throwUnauthorized('Runtime sender frame is invalid.');
-}
-
-function readDeepSeekChatSessionId(senderUrl: string): string | undefined {
-  const match = new URL(senderUrl).pathname.match(/^\/(?:a\/)?chat\/s\/([^/]+)/);
-  if (!match) return undefined;
-  try {
-    return decodeURIComponent(match[1]);
-  } catch {
-    return undefined;
-  }
 }
 
 function validDocumentId(value: unknown): string | undefined {

--- a/core/messaging/runtime-boundary.ts
+++ b/core/messaging/runtime-boundary.ts
@@ -28,6 +28,11 @@ export interface RuntimeMessageSenderLike {
   };
 }
 
+export interface RuntimeBrowserTabLike {
+  id?: number;
+  url?: string;
+}
+
 export type RuntimeMessageSurface = 'extension_context' | 'deepseek_content';
 
 export interface RuntimeMessageContext {
@@ -170,7 +175,41 @@ export function createRuntimeMessageContext(
     documentId: validDocumentId(sender.documentId),
     documentLifecycle: sender.documentLifecycle,
     documentSessionId: createDocumentSessionId('deepseek_content', sender, senderUrl, frameId ?? 0),
-    chatSessionId: readDeepSeekChatSessionId(senderUrl) ?? undefined,
+    // sender.url identifies the content document and may retain the initial
+    // URL across SPA navigation. The browser-owned tab URL is the current
+    // DeepSeek route after the origin check above, so it owns chat binding.
+    chatSessionId: readDeepSeekChatSessionId(tabUrl ?? senderUrl) ?? undefined,
+  };
+}
+
+/**
+ * Re-reads the receiver's current browser-owned tab route after a content
+ * message arrives. `MessageSender.tab` can retain a pre-navigation URL for a
+ * same-document SPA navigation, so it is not sufficient for grant binding.
+ */
+export function refreshDeepSeekContentRuntimeContext(
+  context: RuntimeMessageContext,
+  tab: RuntimeBrowserTabLike,
+  policy: Pick<RuntimeTrustPolicy, 'deepSeekOrigin'>,
+): RuntimeMessageContext {
+  if (context.surface !== 'deepseek_content') return context;
+  if (context.tabId === undefined || validTabId(tab.id) !== context.tabId) {
+    throwUnauthorized('Runtime sender browser tab does not match its receiving tab.');
+  }
+  if (!policy.deepSeekOrigin) {
+    throwUnauthorized('Runtime trust policy is missing the DeepSeek origin.');
+  }
+
+  const tabUrl = requiredBrowserTabUrl(tab.url);
+  const deepSeekOrigin = normalizeOrigin(policy.deepSeekOrigin);
+  if (readUrlOrigin(tabUrl) !== deepSeekOrigin) {
+    throwUnauthorized('Runtime sender browser tab is not a DeepSeek top-level document.');
+  }
+
+  return {
+    ...context,
+    tabUrl,
+    chatSessionId: readDeepSeekChatSessionId(tabUrl) ?? undefined,
   };
 }
 
@@ -243,6 +282,17 @@ function requiredUrl(value: unknown): string {
     return new URL(value).href;
   } catch {
     throwUnauthorized('Runtime sender URL is invalid.');
+  }
+}
+
+function requiredBrowserTabUrl(value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throwUnauthorized('Runtime sender browser tab URL is missing.');
+  }
+  try {
+    return new URL(value).href;
+  } catch {
+    throwUnauthorized('Runtime sender browser tab URL is invalid.');
   }
 }
 

--- a/core/messaging/tool-runtime-contracts.ts
+++ b/core/messaging/tool-runtime-contracts.ts
@@ -31,6 +31,22 @@ type DeclaredRuntimeRequest<TType extends MessageAction['type']> = Extract<
 type Ack = { ok: true };
 type DomainFailure = { ok: false; error: string };
 
+/**
+ * These commands authorize or consume a tool grant, so their receiver-owned
+ * chat identity must be refreshed from the current browser tab before they
+ * reach a privileged handler.
+ */
+export const TOOL_AUTHORIZATION_SUBJECT_RUNTIME_COMMANDS: ReadonlySet<string> = new Set([
+  'CREATE_TOOL_AUTHORIZATION',
+  'CLOSE_TOOL_AUTHORIZATION',
+  'APPEND_EXTERNAL_TOOL_PAYLOAD_CHUNK',
+  'EXECUTE_TOOL_CALL',
+]);
+
+export function requiresCurrentToolAuthorizationSubject(type: string): boolean {
+  return TOOL_AUTHORIZATION_SUBJECT_RUNTIME_COMMANDS.has(type);
+}
+
 export interface WebSearchDiagnostic {
   status: number;
   length: number;

--- a/core/sync/recovery-barrier.ts
+++ b/core/sync/recovery-barrier.ts
@@ -4,7 +4,7 @@ export interface SyncRecoveryResultLike {
 
 export interface SyncRecoveryBarrierOptions<TRecovery extends SyncRecoveryResultLike> {
   recover(): Promise<TRecovery>;
-  notifyReady(result: TRecovery): Promise<void>;
+  notifyRecovered(result: TRecovery): Promise<void>;
   onRecoveryFailure?(error: unknown): void;
   onNotificationFailure?(error: unknown): void;
 }
@@ -19,9 +19,11 @@ export function createSyncRecoveryBarrier<TRecovery extends SyncRecoveryResultLi
 ): SyncRecoveryBarrier {
   let ready: Promise<void> | null = null;
 
-  async function notifyAfterRecoveryCheck(result: TRecovery): Promise<void> {
+  async function notifyRecoveredState(result: TRecovery): Promise<void> {
+    if (!result.recovered) return;
+
     try {
-      await options.notifyReady(result);
+      await options.notifyRecovered(result);
     } catch (error) {
       options.onNotificationFailure?.(error);
     }
@@ -38,7 +40,7 @@ export function createSyncRecoveryBarrier<TRecovery extends SyncRecoveryResultLi
 
   async function recover(): Promise<void> {
     const result = await options.recover();
-    await notifyAfterRecoveryCheck(result);
+    await notifyRecoveredState(result);
   }
 
   return {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -234,9 +234,11 @@ import {
   createRuntimeBoundaryErrorResponse,
   createRuntimeMessageContext,
   decodeRuntimeMessageEnvelope,
+  RuntimeBoundaryError,
   type RuntimeMessageContext,
   type RuntimeMessageEnvelope,
 } from '../core/messaging/runtime-boundary';
+import { requiresCurrentToolAuthorizationSubject } from '../core/messaging/tool-runtime-contracts';
 import { createRuntimeCommandRegistry } from '../core/messaging/runtime-command-registry';
 import { createBootstrapRuntimeHandlers } from './background/bootstrap-handlers';
 import { createTrackedLocalStateMutationRunner } from './background/local-state-mutation-runner';
@@ -250,6 +252,7 @@ import {
 } from './background/chat-runtime-service';
 import { createDeepSeekRuntimeHandlers } from './background/deepseek-runtime-handlers';
 import { createBackgroundRuntimeHandlers } from './background/background-runtime-handlers';
+import { refreshRuntimeMessageContextFromBrowserTab } from './background/runtime-message-context';
 import { refreshDeepSeekAuthFromTabs } from './background/deepseek-auth-refresh';
 import { createSyncRuntimeService } from './background/sync-runtime-service';
 import {
@@ -690,14 +693,24 @@ export default defineBackground(() => {
       return false;
     }
 
-    syncLocalRecoveryBarrier.ensureReady()
-      .then(() => handleMessage(envelope, context))
+    const contextForDispatch = requiresCurrentToolAuthorizationSubject(envelope.type)
+      ? refreshRuntimeMessageContextFromBrowserTab(context, {
+        tabs: chrome.tabs,
+        deepSeekOrigin: new URL(DEEPSEEK_HOME_URL).origin,
+      })
+      : Promise.resolve(context);
+
+    contextForDispatch
+      .then((currentContext) => syncLocalRecoveryBarrier.ensureReady()
+        .then(() => handleMessage(envelope, currentContext)))
       .then(sendResponse)
-      .catch((error) => sendResponse(createBackgroundErrorResponse(
-        envelope,
-        error,
-        backgroundT('content.toolBlock.summaries.backgroundFailed'),
-      )));
+      .catch((error) => sendResponse(error instanceof RuntimeBoundaryError
+        ? createRuntimeBoundaryErrorResponse(error, envelope)
+        : createBackgroundErrorResponse(
+          envelope,
+          error,
+          backgroundT('content.toolBlock.summaries.backgroundFailed'),
+        )));
     return true;
   });
 

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -334,7 +334,7 @@ const chatRuntimeService = createChatRuntimeService({
 });
 const syncLocalRecoveryBarrier = createSyncRecoveryBarrier({
   recover: recoverPendingSyncLocalApply,
-  async notifyReady() {
+  async notifyRecovered() {
     await Promise.all([
       broadcastStateUpdate(),
       broadcastProjectContextUpdate(),

--- a/entrypoints/background/runtime-message-context.ts
+++ b/entrypoints/background/runtime-message-context.ts
@@ -1,0 +1,46 @@
+import {
+  RUNTIME_BOUNDARY_ERROR_CODES,
+  RuntimeBoundaryError,
+  refreshDeepSeekContentRuntimeContext,
+  type RuntimeBrowserTabLike,
+  type RuntimeMessageContext,
+} from '../../core/messaging/runtime-boundary';
+
+export interface RuntimeBrowserTabReader {
+  get(tabId: number): Promise<RuntimeBrowserTabLike>;
+}
+
+/**
+ * The background owns the only fresh browser-tab lookup in the content RPC
+ * path. The message sender proves the document/tab identity; this lookup only
+ * refreshes the route that Chrome currently owns for that same tab.
+ */
+export async function refreshRuntimeMessageContextFromBrowserTab(
+  context: RuntimeMessageContext,
+  dependencies: {
+    tabs: RuntimeBrowserTabReader;
+    deepSeekOrigin: string;
+  },
+): Promise<RuntimeMessageContext> {
+  if (context.surface !== 'deepseek_content') return context;
+  if (context.tabId === undefined) {
+    throw new RuntimeBoundaryError(
+      RUNTIME_BOUNDARY_ERROR_CODES.unauthorizedSender,
+      'Runtime content sender has no receiving browser tab.',
+    );
+  }
+
+  let tab: RuntimeBrowserTabLike;
+  try {
+    tab = await dependencies.tabs.get(context.tabId);
+  } catch {
+    throw new RuntimeBoundaryError(
+      RUNTIME_BOUNDARY_ERROR_CODES.unauthorizedSender,
+      'Runtime content sender browser tab is unavailable.',
+    );
+  }
+
+  return refreshDeepSeekContentRuntimeContext(context, tab, {
+    deepSeekOrigin: dependencies.deepSeekOrigin,
+  });
+}

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -39,6 +39,7 @@ import { containsInternalPromptMarker, sanitizeInternalPromptText } from '../cor
 import { createRestoredArtifactToolResult } from '../core/artifact';
 import type { ResponseCompletePayload, ResponseTokenSpeedPayload } from '../core/interceptor/fetch-hook';
 import { shouldIgnoreEmptyTokenSpeedProgress } from '../core/deepseek/stream-metrics';
+import { readDeepSeekChatSessionId } from '../core/deepseek/chat-session';
 import { createUsageProgressWriteCoordinator } from '../core/usage/progress-write-coordinator';
 import { runInlineAgentLoop } from '../core/inline-agent/loop';
 import {
@@ -176,6 +177,7 @@ import {
   type ContentMutationHub,
 } from './content/controllers/mutation-hub';
 import { notifyContentAuthStatusChanged } from './content/auth-status-notifier';
+import { bindNewChatToolCallToBrowserSession } from './content/tool-session-binding';
 
 const TOOL_BLOCK_ID = 'dpp-tool-block';
 const TOOL_BLOCK_STYLE_ID = 'dpp-tool-block-css';
@@ -1960,13 +1962,7 @@ function updateConversationExportProgress(progress: ConversationExportProgress |
 }
 
 function getCurrentChatSessionId(): string | null {
-  const match = location.pathname.match(/\/(?:a\/)?chat\/s\/([^/?#]+)/);
-  if (!match?.[1]) return null;
-  try {
-    return decodeURIComponent(match[1]);
-  } catch {
-    return match[1];
-  }
+  return readDeepSeekChatSessionId(location.pathname);
 }
 
 function getCurrentConversationTitle(): string {
@@ -5076,16 +5072,23 @@ async function executeToolCall(
     };
   }
 
-  const authorization = authorizationId ?? getToolAuthorizationForCall(call)?.id;
-  const result = await sendRuntimeToolCallMessage(call, authorization);
+  const grant = getToolAuthorizationForCall(call);
+  const authorization = authorizationId ?? grant?.id;
+  const executionCall = await bindNewChatToolCallToBrowserSession(call, grant?.chatSessionId, {
+    readChatSessionId: getCurrentChatSessionId,
+    signal: toolCapabilityScope?.signal,
+  });
+  if (!executionCall) return createUnboundToolSessionResult(call);
+
+  const result = await sendRuntimeToolCallMessage(executionCall, authorization);
   const normalized = normalizeRuntimeToolCallResult(result);
 
   if (normalized) {
-    if (shouldRequestWebFetchPermission(call, normalized)) {
-      const url = call.payload?.url;
+    if (shouldRequestWebFetchPermission(executionCall, normalized)) {
+      const url = executionCall.payload?.url;
       const granted = typeof url === 'string' ? await requestWebFetchPermission(url) : false;
       if (granted) {
-        const retryResult = await sendRuntimeToolCallMessage(call, authorization);
+        const retryResult = await sendRuntimeToolCallMessage(executionCall, authorization);
         const retryNormalized = normalizeRuntimeToolCallResult(retryResult);
         if (retryNormalized) return retryNormalized;
       }
@@ -5100,7 +5103,24 @@ async function executeToolCall(
       detail: contentT('content.extensionReloaded'),
     };
   }
-  return createInvalidRuntimeToolResult(call, result);
+  return createInvalidRuntimeToolResult(executionCall, result);
+}
+
+function createUnboundToolSessionResult(call: ToolCall): ToolCardResult {
+  const detail = contentT('tool.runtime.sessionBindingUnavailable');
+  return {
+    ok: false,
+    name: call.name,
+    provider: call.provider,
+    descriptorId: call.descriptorId,
+    summary: contentT('tool.runtime.authorizationRejected'),
+    detail,
+    error: {
+      code: 'tool_session_unavailable',
+      message: detail,
+      retryable: true,
+    },
+  };
 }
 
 async function sendRuntimeToolCallMessage(

--- a/entrypoints/content/adapters/project-sidebar-organizer.ts
+++ b/entrypoints/content/adapters/project-sidebar-organizer.ts
@@ -18,6 +18,7 @@ import { createEmptyHistoryOrganizerState } from '../../../core/history-organize
 import { injectInjectedThemeStyles } from '../../../core/ui/injected-theme';
 import { decodeProjectContextState } from '../../../core/project/codec';
 import { isUsableProjectConversationTitle } from '../../../core/project/title';
+import { isExtensionContextInvalidatedError } from '../../../core/platform/chrome-api';
 
 export interface ProjectSidebarOrganizerController {
   stop(): void;
@@ -319,7 +320,13 @@ export function startDeepSeekProjectSidebarOrganizer(
     stop() {
       stopped = true;
       observer.disconnect();
-      chrome.runtime.onMessage.removeListener(messageHandler);
+      try {
+        chrome.runtime.onMessage.removeListener(messageHandler);
+      } catch (error) {
+        // Reloading the extension invalidates an old content world before its
+        // pagehide cleanup runs; that listener is already gone in that case.
+        if (!isExtensionContextInvalidatedError(error)) throw error;
+      }
       document.removeEventListener('click', clickCaptureHandler, true);
       window.removeEventListener('dpp:navigation', navigationHandler);
       if (timer) clearTimeout(timer);

--- a/entrypoints/content/controllers/chat-controller.ts
+++ b/entrypoints/content/controllers/chat-controller.ts
@@ -13,6 +13,24 @@ export function createContentChatController(dependencies: {
 }): ContentChatController {
   let scope: ContentResourceScope | null = null;
   const pendingDispatches = new Set<Promise<void>>();
+  let dispatchTail = Promise.resolve();
+
+  const enqueueDispatch = (message: Record<string, unknown>): Promise<void> => {
+    const task = dispatchTail.then(async () => {
+      if (!scope?.active) return;
+      await dependencies.dispatch(message);
+    });
+
+    // A failed inbound event must be reported to its caller without preventing
+    // later events from completing their independent lifecycle work.
+    dispatchTail = task.catch(() => undefined);
+    pendingDispatches.add(task);
+    void task.then(
+      () => pendingDispatches.delete(task),
+      () => pendingDispatches.delete(task),
+    );
+    return task;
+  };
 
   return {
     id: 'chat-runtime',
@@ -27,13 +45,7 @@ export function createContentChatController(dependencies: {
     },
     async handle(message) {
       if (!scope?.active) return;
-      const task = Promise.resolve().then(() => dependencies.dispatch(message));
-      pendingDispatches.add(task);
-      try {
-        await task;
-      } finally {
-        pendingDispatches.delete(task);
-      }
+      await enqueueDispatch(message);
     },
   };
 }

--- a/entrypoints/content/tool-session-binding.ts
+++ b/entrypoints/content/tool-session-binding.ts
@@ -1,0 +1,68 @@
+import type { ToolCall } from '../../core/types';
+
+export const TOOL_SESSION_BINDING_TIMEOUT_MS = 5_000;
+const CONTENT_NAVIGATION_EVENT = 'dpp:navigation';
+
+interface ToolSessionBindingOptions {
+  readonly readChatSessionId: () => string | null;
+  readonly target?: EventTarget;
+  readonly signal?: AbortSignal;
+  readonly timeoutMs?: number;
+}
+
+/**
+ * A null grant is valid only while a new chat is awaiting its browser-owned
+ * route. Never use a streamed/page session claim to complete that binding.
+ */
+export async function bindNewChatToolCallToBrowserSession(
+  call: ToolCall,
+  authorizationChatSessionId: string | null | undefined,
+  options: ToolSessionBindingOptions,
+): Promise<ToolCall | null> {
+  if (authorizationChatSessionId !== null) return call;
+  if (!call.source) return null;
+
+  const chatSessionId = await waitForBrowserOwnedChatSession(options);
+  if (!chatSessionId) return null;
+  return {
+    ...call,
+    source: {
+      ...call.source,
+      chatSessionId,
+    },
+  };
+}
+
+export function waitForBrowserOwnedChatSession(
+  options: ToolSessionBindingOptions,
+): Promise<string | null> {
+  const existing = options.readChatSessionId();
+  if (existing) return Promise.resolve(existing);
+  if (options.signal?.aborted) return Promise.resolve(null);
+
+  const target = options.target ?? window;
+  const timeoutMs = options.timeoutMs ?? TOOL_SESSION_BINDING_TIMEOUT_MS;
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = (sessionId: string | null) => {
+      if (settled) return;
+      settled = true;
+      target.removeEventListener(CONTENT_NAVIGATION_EVENT, onNavigation);
+      options.signal?.removeEventListener('abort', onAbort);
+      if (timer !== null) clearTimeout(timer);
+      resolve(sessionId);
+    };
+    const onNavigation = () => {
+      const sessionId = options.readChatSessionId();
+      if (sessionId) finish(sessionId);
+    };
+    const onAbort = () => finish(null);
+
+    target.addEventListener(CONTENT_NAVIGATION_EVENT, onNavigation);
+    options.signal?.addEventListener('abort', onAbort, { once: true });
+    timer = setTimeout(() => finish(null), timeoutMs);
+    onNavigation();
+  });
+}

--- a/entrypoints/sidepanel/controllers/mcp-tools-controller.ts
+++ b/entrypoints/sidepanel/controllers/mcp-tools-controller.ts
@@ -78,8 +78,13 @@ export interface McpToolsController {
   requestHostPermission(origins: string[]): Promise<boolean>;
 }
 
+export interface SidepanelHostPermissionPort {
+  request(origins: readonly string[]): Promise<boolean>;
+}
+
 export function createMcpToolsController(
   runtimeClient: SidepanelRuntimeClient = sidepanelRuntimeClient,
+  hostPermissions: SidepanelHostPermissionPort = sidepanelHostPermissionPort,
 ): McpToolsController {
   const loadMcpServerState = async () => {
     const [servers, platform] = await Promise.all([
@@ -199,24 +204,23 @@ export function createMcpToolsController(
       { type: 'DIAGNOSE_WEB_SEARCH', payload: { query } },
       { decode: decodeWebSearchDiagnostics },
     ),
-    async requestHostPermission(origins) {
-      return runtimeClient.request(
-        { type: 'REQUEST_HOST_PERMISSION', payload: { origins } },
-        {
-          acceptFailure: true,
-          decode(value) {
-            const record = requireRecord(value, 'REQUEST_HOST_PERMISSION response');
-            if (typeof record.ok !== 'boolean') {
-              throw new Error('REQUEST_HOST_PERMISSION response.ok must be a boolean.');
-            }
-            return record.ok;
-          },
-        },
-      );
+    requestHostPermission(origins) {
+      // chrome.permissions.request must be called synchronously from the
+      // sidepanel click handler to preserve Chrome's required user gesture.
+      return hostPermissions.request(origins);
     },
   };
   return Object.freeze(controller);
 }
+
+const sidepanelHostPermissionPort: SidepanelHostPermissionPort = Object.freeze({
+  request(origins: readonly string[]) {
+    if (!chrome.permissions?.request) {
+      throw new Error('Browser host permission requests are unavailable.');
+    }
+    return chrome.permissions.request({ origins: [...origins] });
+  },
+});
 
 export const mcpToolsController = createMcpToolsController();
 

--- a/entrypoints/sidepanel/controllers/useToolsPageController.ts
+++ b/entrypoints/sidepanel/controllers/useToolsPageController.ts
@@ -29,7 +29,9 @@ export function useToolsPageController(t: Translator) {
   const [settingsError, setSettingsError] = useState('');
   const [permState, setPermState] = useState<ToolPermissionState>('idle');
   const [permUrl, setPermUrl] = useState('');
+  const [permissionError, setPermissionError] = useState('');
   const [allSitesState, setAllSitesState] = useState<ToolPermissionState>('idle');
+  const [allSitesError, setAllSitesError] = useState('');
   const [pythonServer, setPythonServer] = useState<McpServerConfig | null>(null);
   const [pythonCache, setPythonCache] = useState<McpToolCacheEntry | null>(null);
   const [pythonBusy, setPythonBusy] = useState<PythonBusyState>('idle');
@@ -184,6 +186,7 @@ export function useToolsPageController(t: Translator) {
   const updatePermissionUrl = useCallback((value: string) => {
     setPermUrl(value);
     setPermState('idle');
+    setPermissionError('');
   }, []);
 
   const grantPermission = useCallback(async () => {
@@ -193,27 +196,32 @@ export function useToolsPageController(t: Translator) {
       origin = normalizeHostPermissionOrigin(permUrl);
     } catch {
       setPermState('error');
+      setPermissionError('');
       return;
     }
     setPermState('granting');
+    setPermissionError('');
     try {
       const granted = await mcpToolsController.requestHostPermission([origin]);
       setPermState(granted ? 'granted' : 'denied');
-    } catch {
-      setPermState('denied');
+    } catch (error) {
+      setPermState('error');
+      setPermissionError(getRuntimeErrorMessage(error));
     }
   }, [permUrl]);
 
   const grantAllSites = useCallback(async () => {
     setAllSitesState('granting');
+    setAllSitesError('');
     try {
       const granted = await mcpToolsController.requestHostPermission([
         'http://*/*',
         'https://*/*',
       ]);
       setAllSitesState(granted ? 'granted' : 'denied');
-    } catch {
-      setAllSitesState('denied');
+    } catch (error) {
+      setAllSitesState('error');
+      setAllSitesError(getRuntimeErrorMessage(error));
     }
   }, []);
 
@@ -222,7 +230,9 @@ export function useToolsPageController(t: Translator) {
     settingsError,
     permState,
     permUrl,
+    permissionError,
     allSitesState,
+    allSitesError,
     pythonServer,
     pythonCache,
     pythonBusy,

--- a/entrypoints/sidepanel/pages/ToolsPage.tsx
+++ b/entrypoints/sidepanel/pages/ToolsPage.tsx
@@ -227,7 +227,9 @@ export default function ToolsPage() {
     settingsError,
     permState,
     permUrl,
+    permissionError,
     allSitesState,
+    allSitesError,
     pythonServer,
     pythonCache,
     pythonBusy,
@@ -345,7 +347,9 @@ export default function ToolsPage() {
           <StatusMessage tone="error">{t('sidepanel.toolsPage.permissionDenied')}</StatusMessage>
         )}
         {permState === 'error' && (
-          <StatusMessage tone="error">{t('sidepanel.toolsPage.permissionInvalidUrl')}</StatusMessage>
+          <StatusMessage tone="error">
+            {permissionError || t('sidepanel.toolsPage.permissionInvalidUrl')}
+          </StatusMessage>
         )}
 
         <div className="pt-1">
@@ -379,6 +383,14 @@ export default function ToolsPage() {
           <p className="text-[10px] mt-1.5 text-center" style={{ color: 'var(--ds-text-tertiary)' }}>
             {t('sidepanel.toolsPage.allSitesHelp')}
           </p>
+          {allSitesState === 'denied' && (
+            <StatusMessage tone="error">{t('sidepanel.toolsPage.permissionDenied')}</StatusMessage>
+          )}
+          {allSitesState === 'error' && (
+            <StatusMessage tone="error">
+              {allSitesError || t('sidepanel.toolsPage.permissionDenied')}
+            </StatusMessage>
+          )}
         </div>
       </SettingsSection>
     </div>

--- a/scripts/sidepanel-chunk-budget.mjs
+++ b/scripts/sidepanel-chunk-budget.mjs
@@ -34,8 +34,16 @@ const WAVE_2_CHAT_BASELINE = Object.freeze({
   ChatPage: { raw: 134_902, gzip: 40_039 },
 });
 
+// gzip size may vary slightly between supported Node/zlib releases even when
+// the built JavaScript bytes are identical. Keep the raw baseline exact and
+// bound this encoder-only variance to a small fixed allowance.
+const GZIP_ENCODER_VARIANCE_BYTES = 256;
+
 const BUDGET = Object.freeze({
-  initialShell: BASELINE.initialShell,
+  initialShell: {
+    raw: BASELINE.initialShell.raw,
+    gzip: BASELINE.initialShell.gzip + GZIP_ENCODER_VARIANCE_BYTES,
+  },
   firstChatScreen: { raw: 400_000, gzip: 122_000 },
   richRendererIncrement: { raw: 120_000, gzip: 36_000 },
   routeChunks: {
@@ -105,6 +113,7 @@ function verifyBrowserBuild(browser) {
   console.log(JSON.stringify({
     browser,
     baseline: BASELINE,
+    gzipEncoderVarianceBytes: GZIP_ENCODER_VARIANCE_BYTES,
     wave2ChatBaseline: WAVE_2_CHAT_BASELINE,
     current: {
       initialShell: initialMetric,

--- a/tests/background-persistence-recovery-integration.test.ts
+++ b/tests/background-persistence-recovery-integration.test.ts
@@ -44,7 +44,7 @@ describe('background persistence recovery composition', () => {
     });
     const firstBarrier = createSyncRecoveryBarrier({
       recover: firstCoordinator.recover,
-      notifyReady: async () => undefined,
+      notifyRecovered: async () => undefined,
     });
     const firstRunner = createTrackedLocalStateMutationRunner({
       runWithRecovery: createRunWithRecovery(firstCoordinator),
@@ -74,7 +74,7 @@ describe('background persistence recovery composition', () => {
     const restartEvents: string[] = [];
     const restartBarrier = createSyncRecoveryBarrier({
       recover: restartCoordinator.recover,
-      notifyReady: async (result) => {
+      notifyRecovered: async (result) => {
         restartEvents.push(result.recovered ? 'recovered' : 'ready');
       },
     });

--- a/tests/background-runtime-message-context.test.ts
+++ b/tests/background-runtime-message-context.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  RUNTIME_BOUNDARY_ERROR_CODES,
+  type RuntimeMessageContext,
+} from '../core/messaging/runtime-boundary';
+import { requiresCurrentToolAuthorizationSubject } from '../core/messaging/tool-runtime-contracts';
+import { refreshRuntimeMessageContextFromBrowserTab } from '../entrypoints/background/runtime-message-context';
+
+const DEEPSEEK_CONTEXT: RuntimeMessageContext = {
+  runtimeId: 'extension-id',
+  surface: 'deepseek_content',
+  senderUrl: 'https://chat.deepseek.com/',
+  senderOrigin: 'https://chat.deepseek.com',
+  tabId: 17,
+  tabUrl: 'https://chat.deepseek.com/',
+  frameId: 0,
+  documentId: 'document-1',
+  documentSessionId: 'document-1',
+};
+
+describe('background runtime message context refresh', () => {
+  it('refreshes only messages that consume a tool authorization subject', () => {
+    expect([
+      'CREATE_TOOL_AUTHORIZATION',
+      'CLOSE_TOOL_AUTHORIZATION',
+      'APPEND_EXTERNAL_TOOL_PAYLOAD_CHUNK',
+      'EXECUTE_TOOL_CALL',
+    ].every(requiresCurrentToolAuthorizationSubject)).toBe(true);
+    expect(requiresCurrentToolAuthorizationSubject('GET_TOOL_DESCRIPTORS')).toBe(false);
+  });
+
+  it('uses the current browser-owned tab route when a content sender snapshot is stale', async () => {
+    const get = vi.fn(async () => ({
+      id: 17,
+      url: 'https://chat.deepseek.com/a/chat/s/current-session',
+    }));
+
+    await expect(refreshRuntimeMessageContextFromBrowserTab(DEEPSEEK_CONTEXT, {
+      tabs: { get },
+      deepSeekOrigin: 'https://chat.deepseek.com',
+    })).resolves.toMatchObject({
+      tabUrl: 'https://chat.deepseek.com/a/chat/s/current-session',
+      chatSessionId: 'current-session',
+      documentSessionId: 'document-1',
+    });
+    expect(get).toHaveBeenCalledWith(17);
+  });
+
+  it('does not look up a browser tab for an extension context', async () => {
+    const get = vi.fn();
+    const extensionContext: RuntimeMessageContext = {
+      ...DEEPSEEK_CONTEXT,
+      surface: 'extension_context',
+      senderUrl: 'chrome-extension://extension-id/sidepanel.html',
+      senderOrigin: 'chrome-extension://extension-id',
+      tabId: undefined,
+      tabUrl: undefined,
+      frameId: undefined,
+      documentId: 'sidepanel-document-1',
+      documentSessionId: 'sidepanel-document-1',
+    };
+
+    await expect(refreshRuntimeMessageContextFromBrowserTab(extensionContext, {
+      tabs: { get },
+      deepSeekOrigin: 'https://chat.deepseek.com',
+    })).resolves.toBe(extensionContext);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the receiving tab can no longer be read', async () => {
+    await expect(refreshRuntimeMessageContextFromBrowserTab(DEEPSEEK_CONTEXT, {
+      tabs: { get: vi.fn(async () => { throw new Error('No tab with id: 17'); }) },
+      deepSeekOrigin: 'https://chat.deepseek.com',
+    })).rejects.toMatchObject({
+      code: RUNTIME_BOUNDARY_ERROR_CODES.unauthorizedSender,
+      message: 'Runtime content sender browser tab is unavailable.',
+    });
+  });
+});

--- a/tests/content-chat-controller.test.ts
+++ b/tests/content-chat-controller.test.ts
@@ -34,4 +34,37 @@ describe('Content chat controller', () => {
     expect(dispatch).toHaveBeenCalledOnce();
     expect(kernel.snapshot().resources.total).toBe(0);
   });
+
+  it('preserves response completion before its terminal cleanup', async () => {
+    let releaseCompletion!: () => void;
+    const order: string[] = [];
+    const dispatch = vi.fn(async (message: Record<string, unknown>) => {
+      order.push(`start:${message.type}`);
+      if (message.type === 'RESPONSE_COMPLETE') {
+        await new Promise<void>((resolve) => {
+          releaseCompletion = resolve;
+        });
+      }
+      order.push(`finish:${message.type}`);
+    });
+    const controller = createContentChatController({ dispatch });
+    const kernel = createContentLifecycleKernel([controller]);
+    await kernel.start();
+
+    const complete = controller.handle({ type: 'RESPONSE_COMPLETE' });
+    const terminal = controller.handle({ type: 'REQUEST_TERMINAL' });
+    await Promise.resolve();
+
+    expect(order).toEqual(['start:RESPONSE_COMPLETE']);
+    releaseCompletion();
+    await Promise.all([complete, terminal]);
+
+    expect(order).toEqual([
+      'start:RESPONSE_COMPLETE',
+      'finish:RESPONSE_COMPLETE',
+      'start:REQUEST_TERMINAL',
+      'finish:REQUEST_TERMINAL',
+    ]);
+    await kernel.stop('manual');
+  });
 });

--- a/tests/content-controller-ownership.test.ts
+++ b/tests/content-controller-ownership.test.ts
@@ -38,6 +38,11 @@ describe('Content controller ownership contract', () => {
     expect(contentSource).not.toContain('toolBlockRouteTimer');
   });
 
+  it('waits for the shared navigation event before executing an unbound new-chat tool', () => {
+    expect(contentSource).toContain('bindNewChatToolCallToBrowserSession(call, grant?.chatSessionId');
+    expect(contentSource).toContain("from './content/tool-session-binding'");
+  });
+
   it('routes both worlds through the shared document lifecycle instead of entrypoint listeners', () => {
     expect(contentSource).toContain('replaceContentDocumentLifecycle({');
     expect(mainWorldSource).toContain('replaceContentDocumentLifecycle({');

--- a/tests/content-tool-session-binding.test.ts
+++ b/tests/content-tool-session-binding.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  bindNewChatToolCallToBrowserSession,
+} from '../entrypoints/content/tool-session-binding';
+import type { ToolCall } from '../core/types';
+
+const TOOL_CALL: ToolCall = {
+  id: 'call-1',
+  name: 'web_search',
+  payload: { query: 'DeepSeek++' },
+  raw: '<web_search>{"query":"DeepSeek++"}</web_search>',
+  source: {
+    trigger: 'manual_chat',
+    requestId: 'request-1',
+    chatSessionId: 'page-claimed-session',
+  },
+};
+
+describe('content new-chat tool session binding', () => {
+  it('replaces a page session claim only after the browser-owned route arrives', async () => {
+    const target = new EventTarget();
+    let browserSessionId: string | null = null;
+    const pending = bindNewChatToolCallToBrowserSession(TOOL_CALL, null, {
+      target,
+      timeoutMs: 100,
+      readChatSessionId: () => browserSessionId,
+    });
+
+    browserSessionId = 'browser-session';
+    target.dispatchEvent(new Event('dpp:navigation'));
+
+    await expect(pending).resolves.toEqual({
+      ...TOOL_CALL,
+      source: {
+        ...TOOL_CALL.source,
+        chatSessionId: 'browser-session',
+      },
+    });
+    expect(TOOL_CALL.source?.chatSessionId).toBe('page-claimed-session');
+  });
+
+  it('does not delay or rewrite a grant that is already browser-bound', async () => {
+    const result = await bindNewChatToolCallToBrowserSession(TOOL_CALL, 'existing-session', {
+      readChatSessionId: () => 'other-session',
+    });
+
+    expect(result).toBe(TOOL_CALL);
+  });
+
+  it('refuses to prepare a new-chat execution when no browser-owned route appears', async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = bindNewChatToolCallToBrowserSession(TOOL_CALL, null, {
+        target: new EventTarget(),
+        timeoutMs: 100,
+        readChatSessionId: () => null,
+      });
+      await vi.advanceTimersByTimeAsync(100);
+
+      await expect(pending).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops waiting when the content lifecycle is aborted', async () => {
+    const abort = new AbortController();
+    const pending = bindNewChatToolCallToBrowserSession(TOOL_CALL, null, {
+      target: new EventTarget(),
+      signal: abort.signal,
+      readChatSessionId: () => null,
+    });
+
+    abort.abort();
+
+    await expect(pending).resolves.toBeNull();
+  });
+});

--- a/tests/deepseek-chat-session.test.ts
+++ b/tests/deepseek-chat-session.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { readDeepSeekChatSessionId } from '../core/deepseek/chat-session';
+
+describe('DeepSeek chat session route', () => {
+  it.each([
+    ['https://chat.deepseek.com/a/chat/s/session-1', 'session-1'],
+    ['https://chat.deepseek.com/chat/s/session%202', 'session 2'],
+    ['/a/chat/s/session-3?from=history', 'session-3'],
+    ['/a/chat/s/%E0%A4%A', null],
+    ['/a/chat/s/', null],
+    ['/prefix/a/chat/s/session-4', null],
+  ])('reads %s as %s', (route, expected) => {
+    expect(readDeepSeekChatSessionId(route)).toBe(expected);
+  });
+});

--- a/tests/mcp-execution-policy.test.ts
+++ b/tests/mcp-execution-policy.test.ts
@@ -9,6 +9,7 @@ import {
   saveMcpToolCache,
   updateMcpServer,
 } from '../core/mcp/store';
+import { MCP_STORAGE_KEY } from '../core/mcp/storage-codec';
 import { renderToolSchemas } from '../core/prompt/augmentation';
 import type { McpServerConfig, ToolCall, ToolDescriptor } from '../core/types';
 
@@ -110,6 +111,14 @@ describe('MCP execution policy', () => {
       },
     });
 
+    const sparseState = structuredClone(storage[MCP_STORAGE_KEY]) as {
+      servers: Array<{ id: string; secrets: unknown }>;
+    };
+    const sparseServer = sparseState.servers.find((item) => item.id === server.id);
+    if (!sparseServer) throw new Error('Missing persisted MCP server.');
+    sparseServer.secrets = [{ kind: 'bearer', value: '' }];
+    storage[MCP_STORAGE_KEY] = sparseState;
+
     const cache = await refreshMcpServerDiscovery(server.id);
 
     expect(cache.health.status).toBe('ready');
@@ -120,6 +129,13 @@ describe('MCP execution policy', () => {
     });
     const persistedDescriptors = await getMcpToolDescriptors({ includeDisabled: true });
     expect(renderToolSchemas(persistedDescriptors)).toContain('"enum":["playwright","filesystem"]');
+    expect(await getMcpToolCache(server.id)).toMatchObject({
+      serverId: server.id,
+      descriptors: [expect.objectContaining({ name: 'sample_tool' })],
+      health: { status: 'ready', toolCount: 1 },
+    });
+    expect((storage[MCP_STORAGE_KEY] as { servers: Array<{ id: string; secrets: unknown }> }).servers
+      .find((item) => item.id === server.id)?.secrets).toEqual([{ kind: 'bearer', value: '' }]);
     expect(requests.map((request) => request.method)).toEqual([
       'initialize',
       'notifications/initialized',

--- a/tests/mcp-persistence-contract.test.ts
+++ b/tests/mcp-persistence-contract.test.ts
@@ -6,6 +6,7 @@ import {
   getAllMcpServers,
   getMcpServerById,
   updateMcpServer,
+  updateMcpServerHealth,
 } from '../core/mcp/store';
 import {
   decodeMcpStorageState,
@@ -121,7 +122,7 @@ describe('MCP persisted-config contract', () => {
     delete shellServer.secrets[0].id;
     storage[MCP_STORAGE_KEY] = sparseState;
 
-    await updateMcpServer(MCP_SERVER_IDS.shell, {
+    await updateMcpServerHealth(MCP_SERVER_IDS.shell, {
       status: 'ready',
       lastConnectedAt: MCP_STORAGE_V2.toolCaches[0].health.checkedAt + 1,
       lastError: null,
@@ -133,6 +134,45 @@ describe('MCP persisted-config contract', () => {
       id: MCP_SERVER_IDS.shell,
       status: 'ready',
     });
+  });
+
+  it('keeps valid sparse configuration untouched while recording health', async () => {
+    const sparseState = structuredClone(MCP_STORAGE_V2);
+    const shellServer = sparseState.servers.find((server) => server.id === MCP_SERVER_IDS.shell);
+    if (!shellServer) throw new Error('Missing Shell MCP fixture.');
+    shellServer.secrets = [{ kind: 'bearer', value: '' }];
+    storage[MCP_STORAGE_KEY] = sparseState;
+
+    await updateMcpServerHealth(MCP_SERVER_IDS.shell, {
+      status: 'error',
+      lastError: 'connection refused',
+    });
+
+    const state = decodeMcpStorageState(storage[MCP_STORAGE_KEY]);
+    expect(state.toolCaches).toEqual([MCP_CACHE_ENTRY]);
+    expect(state.servers.find((server) => server.id === MCP_SERVER_IDS.shell)).toMatchObject({
+      id: MCP_SERVER_IDS.shell,
+      secrets: [{ kind: 'bearer', value: '' }],
+      status: 'error',
+      lastError: 'connection refused',
+    });
+  });
+
+  it('keeps a disabled server disabled when discovery records connection health', async () => {
+    const disabledState = structuredClone(MCP_STORAGE_V2);
+    const shellServer = disabledState.servers.find((server) => server.id === MCP_SERVER_IDS.shell);
+    if (!shellServer) throw new Error('Missing Shell MCP fixture.');
+    shellServer.enabled = false;
+    shellServer.status = 'disabled';
+    storage[MCP_STORAGE_KEY] = disabledState;
+
+    await updateMcpServerHealth(MCP_SERVER_IDS.shell, {
+      status: 'ready',
+      lastConnectedAt: MCP_STORAGE_V2.toolCaches[0].health.checkedAt + 1,
+      lastError: null,
+    });
+
+    expect((await getMcpServerById(MCP_SERVER_IDS.shell))?.status).toBe('disabled');
   });
 
   it('accepts current v2 cache collisions so the user can clear or refresh them', () => {

--- a/tests/project-sidebar-organizer.test.ts
+++ b/tests/project-sidebar-organizer.test.ts
@@ -410,6 +410,23 @@ describe('DeepSeek project sidebar organizer', () => {
     expect(document.querySelector<HTMLElement>('[data-testid="session-one-row"]')?.style.getPropertyValue('display')).toBe('');
   });
 
+  it('finishes teardown when an extension reload has invalidated the runtime listener', async () => {
+    const state = createProjectState();
+    sendMessage.mockResolvedValue(state);
+    mountHistoryDom();
+
+    const controller = startDeepSeekProjectSidebarOrganizer(() => labels);
+    await flushProjectSidebar();
+    const removeListener = chrome.runtime.onMessage.removeListener as ReturnType<typeof vi.fn>;
+    removeListener.mockImplementationOnce(() => {
+      throw new Error('Extension context invalidated.');
+    });
+
+    expect(() => controller.stop()).not.toThrow();
+    expect(document.getElementById('dpp-project-sidebar')).toBeNull();
+    expect(document.querySelector<HTMLElement>('[data-testid="session-one-row"]')?.hidden).toBe(false);
+  });
+
   it('toggles a project as the pending context for the next new conversation', async () => {
     const state = createProjectState({ conversations: [] });
     sendMessage.mockImplementation(async (message) => {

--- a/tests/runtime-boundary.test.ts
+++ b/tests/runtime-boundary.test.ts
@@ -9,6 +9,7 @@ import {
   createRuntimeMessageContext,
   decodeRuntimeMessageEnvelope,
   DEEPSEEK_CONTENT_RUNTIME_COMMANDS,
+  refreshDeepSeekContentRuntimeContext,
   RUNTIME_BOUNDARY_ERROR_CODES,
   type RuntimeMessageSenderLike,
 } from '../core/messaging/runtime-boundary';
@@ -90,9 +91,10 @@ describe('runtime sender and envelope boundary', () => {
     });
   });
 
-  it('accepts a same-origin DeepSeek route change for an existing content document', () => {
+  it('uses the browser-owned current tab route across a same-origin DeepSeek SPA navigation', () => {
     const context = createRuntimeMessageContext({
       ...DEEPSEEK_SENDER,
+      url: 'https://chat.deepseek.com/',
       tab: {
         id: 17,
         url: 'https://chat.deepseek.com/a/chat/s/new-session',
@@ -101,11 +103,43 @@ describe('runtime sender and envelope boundary', () => {
 
     expect(context).toMatchObject({
       surface: 'deepseek_content',
-      senderUrl: DEEPSEEK_SENDER.url,
+      senderUrl: 'https://chat.deepseek.com/',
       tabUrl: 'https://chat.deepseek.com/a/chat/s/new-session',
       documentSessionId: 'deepseek-document-1',
-      chatSessionId: 'session-contract',
+      chatSessionId: 'new-session',
     });
+  });
+
+  it('refreshes a stale sender tab snapshot from the current browser tab before grant binding', () => {
+    const staleContext = createRuntimeMessageContext({
+      ...DEEPSEEK_SENDER,
+      url: 'https://chat.deepseek.com/',
+      tab: {
+        id: 17,
+        url: 'https://chat.deepseek.com/',
+      },
+    }, POLICY);
+
+    const context = refreshDeepSeekContentRuntimeContext(staleContext, {
+      id: 17,
+      url: 'https://chat.deepseek.com/a/chat/s/live-session',
+    }, POLICY);
+
+    expect(context).toMatchObject({
+      senderUrl: 'https://chat.deepseek.com/',
+      documentSessionId: 'deepseek-document-1',
+      tabUrl: 'https://chat.deepseek.com/a/chat/s/live-session',
+      chatSessionId: 'live-session',
+    });
+  });
+
+  it.each([
+    ['another tab', { id: 18, url: 'https://chat.deepseek.com/a/chat/s/live-session' }],
+    ['another origin', { id: 17, url: 'https://example.test/a/chat/s/live-session' }],
+    ['missing URL', { id: 17 }],
+  ])('rejects a refreshed browser tab from %s', (_name, tab) => {
+    const context = createRuntimeMessageContext(DEEPSEEK_SENDER, POLICY);
+    expect(() => refreshDeepSeekContentRuntimeContext(context, tab, POLICY)).toThrow();
   });
 
   it('accepts a missing Firefox frameId only with matching top-level tab evidence', () => {
@@ -196,7 +230,7 @@ describe('runtime sender and envelope boundary', () => {
       'decodeRuntimeMessageEnvelope(message)',
       'createRuntimeMessageContext(sender',
       'authorizeRuntimeMessage(envelope, context)',
-      'handleMessage(envelope, context)',
+      'handleMessage(envelope, currentContext)',
     ]);
     expectInOrder(content, [
       'decodeRuntimeMessageEnvelope(message)',

--- a/tests/sidepanel-mcp-tools-controller.test.ts
+++ b/tests/sidepanel-mcp-tools-controller.test.ts
@@ -108,6 +108,26 @@ describe('sidepanel MCP and Tools controller', () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
+  it('requests host permission directly from the sidepanel click boundary', async () => {
+    const sendMessage = vi.fn(async () => {
+      throw new Error('Host permission requests must not cross the runtime bridge.');
+    });
+    const permissions = {
+      request: vi.fn(async () => true),
+    };
+    const controller = createMcpToolsController(
+      createSidepanelRuntimeClient(sendMessage),
+      permissions,
+    );
+
+    await expect(controller.requestHostPermission([
+      'http://*/*',
+      'https://*/*',
+    ])).resolves.toBe(true);
+    expect(permissions.request).toHaveBeenCalledWith(['http://*/*', 'https://*/*']);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it('centralizes tool allowlist and Python provider policy', () => {
     expect(isMcpToolEnabled(server, pythonTool)).toBe(true);
     expect(nextMcpToolAllowlist(server.allowlist, pythonTool, false)).toEqual({

--- a/tests/sidepanel-tools-page.test.ts
+++ b/tests/sidepanel-tools-page.test.ts
@@ -1,0 +1,85 @@
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ToolsPage from '../entrypoints/sidepanel/pages/ToolsPage';
+
+let container: HTMLDivElement;
+let root: Root | null;
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement('div');
+  document.body.append(container);
+  root = null;
+});
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount());
+  }
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('Tools page host permission controls', () => {
+  it('keeps the all-sites request in the sidepanel and makes denial visible', async () => {
+    const sendMessage = vi.fn(async (message: { type: string }) => {
+      if (message.type === 'GET_WEB_TOOL_SETTINGS') {
+        return { web_search: true, web_fetch: true };
+      }
+      if (message.type === 'GET_MCP_SERVERS') return [];
+      if (message.type === 'GET_PLATFORM_CAPABILITIES') {
+        return {
+          kind: 'browser_extension',
+          name: 'WebExtension',
+          capabilities: { nativeMessaging: false },
+        };
+      }
+      throw new Error(`Unexpected runtime command: ${message.type}`);
+    });
+    const request = vi.fn(async () => false);
+    vi.stubGlobal('chrome', {
+      runtime: {
+        sendMessage,
+        onMessage: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        },
+      },
+      permissions: { request },
+    });
+
+    await render();
+    await flushPromises();
+    await clickButton('授权全部网站');
+
+    expect(request).toHaveBeenCalledWith({ origins: ['http://*/*', 'https://*/*'] });
+    expect(sendMessage).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: 'REQUEST_HOST_PERMISSION',
+    }));
+    expect(container.textContent).toContain('权限被拒绝，请重试或前往 chrome://extensions 手动添加');
+  });
+});
+
+async function render() {
+  await act(async () => {
+    root = createRoot(container);
+    root.render(React.createElement(ToolsPage));
+  });
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function clickButton(label: string) {
+  const button = Array.from(container.querySelectorAll('button'))
+    .find((candidate) => candidate.textContent === label);
+  expect(button).toBeTruthy();
+  await act(async () => {
+    button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}

--- a/tests/sync-background-recovery-contract.test.ts
+++ b/tests/sync-background-recovery-contract.test.ts
@@ -27,7 +27,7 @@ describe('background sync recovery integration', () => {
   it('establishes the recovery barrier before startup mutation and runtime dispatch', () => {
     const startup = background.indexOf('void syncLocalRecoveryBarrier.ensureReady()');
     const archive = background.indexOf('.then(() => archiveStaleMemories()');
-    const runtimeDispatch = background.indexOf('.then(() => handleMessage(envelope, context))');
+    const runtimeDispatch = background.indexOf('.then(() => handleMessage(envelope, currentContext))');
     const automationScan = background.indexOf('.then(() => scanDueAutomationsFromWake()');
 
     expect(startup).toBeGreaterThan(-1);

--- a/tests/sync-recovery-barrier.test.ts
+++ b/tests/sync-recovery-barrier.test.ts
@@ -9,7 +9,7 @@ describe('sync recovery barrier', () => {
     const onRecoveryFailure = vi.fn();
     const barrier = createSyncRecoveryBarrier({
       recover,
-      notifyReady: vi.fn(),
+      notifyRecovered: vi.fn(),
       onRecoveryFailure,
     });
 
@@ -26,7 +26,7 @@ describe('sync recovery barrier', () => {
     const notifyRecovered = vi.fn().mockRejectedValue(notificationError);
     const barrier = createSyncRecoveryBarrier({
       recover,
-      notifyReady: notifyRecovered,
+      notifyRecovered,
       onNotificationFailure,
     });
 
@@ -34,30 +34,20 @@ describe('sync recovery barrier', () => {
     await Promise.resolve();
     await expect(barrier.ensureReady()).resolves.toBeUndefined();
     expect(recover).toHaveBeenCalledOnce();
+    expect(notifyRecovered).toHaveBeenCalledWith({ recovered: true });
     expect(onNotificationFailure).toHaveBeenCalledWith(notificationError);
   });
 
-  it('waits for a state refresh even when the recovery check finds no journal', async () => {
-    let finishNotification!: () => void;
-    const notifyReady = vi.fn(() => new Promise<void>((resolve) => {
-      finishNotification = resolve;
-    }));
+  it('does not broadcast when the recovery check finds no journal', async () => {
+    const notifyRecovered = vi.fn();
     const barrier = createSyncRecoveryBarrier({
       recover: vi.fn().mockResolvedValue({ recovered: false }),
-      notifyReady,
+      notifyRecovered,
     });
 
-    const ready = barrier.ensureReady();
-    const settled = vi.fn();
-    void ready.then(settled);
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(notifyReady).toHaveBeenCalledWith({ recovered: false });
-    expect(settled).not.toHaveBeenCalled();
+    await expect(barrier.ensureReady()).resolves.toBeUndefined();
 
-    finishNotification();
-    await ready;
-    expect(settled).toHaveBeenCalledOnce();
+    expect(notifyRecovered).not.toHaveBeenCalled();
   });
 
   it('blocks later dispatch on recovery after a failed apply', async () => {
@@ -67,7 +57,7 @@ describe('sync recovery barrier', () => {
     }));
     const barrier = createSyncRecoveryBarrier({
       recover,
-      notifyReady: vi.fn().mockResolvedValue(undefined),
+      notifyRecovered: vi.fn().mockResolvedValue(undefined),
     });
 
     const apply = barrier.trackApply(Promise.reject(new Error('apply failed')));

--- a/tests/tool-authorization.test.ts
+++ b/tests/tool-authorization.test.ts
@@ -17,6 +17,7 @@ import type {
   ToolResult,
 } from '../core/tool/types';
 import { createWebSearchToolDescriptors } from '../core/tool/web-search';
+import { bindNewChatToolCallToBrowserSession } from '../entrypoints/content/tool-session-binding';
 import { executeRuntimeToolCall } from './helpers/production-tool-runtime';
 
 let sessionStorage: Record<string, unknown>;
@@ -497,6 +498,41 @@ describe('tool authorization context', () => {
       { kind: 'grant', grantId: grant.id, subject: { ...SUBJECT, chatSessionId: 'chat-other' } },
       [descriptor],
     )).resolves.toMatchObject({ descriptor });
+  });
+
+  it('binds a streamed new-chat tool call to the navigation-owned browser route', async () => {
+    const descriptor = makeDescriptor();
+    const newChatSubject = { ...SUBJECT, chatSessionId: null };
+    const grant = await createToolAuthorization({
+      requestId: 'request-1',
+      trigger: 'manual_chat',
+      chatSessionId: 'page-claimed-session',
+      subject: newChatSubject,
+      descriptors: [descriptor],
+    });
+    const target = new EventTarget();
+    let browserSessionId: string | null = null;
+    const pending = bindNewChatToolCallToBrowserSession(makeCall({
+      source: { trigger: 'manual_chat', requestId: 'request-1', chatSessionId: 'page-claimed-session' },
+    }), grant.chatSessionId, {
+      target,
+      timeoutMs: 100,
+      readChatSessionId: () => browserSessionId,
+    });
+
+    browserSessionId = 'chat-1';
+    target.dispatchEvent(new Event('dpp:navigation'));
+    const call = await pending;
+    if (!call) throw new Error('Expected the browser-owned route to bind the tool call.');
+
+    await expect(authorizeToolExecution(
+      call,
+      { kind: 'grant', grantId: grant.id, subject: SUBJECT },
+      [descriptor],
+    )).resolves.toMatchObject({
+      descriptor,
+      call: { source: { chatSessionId: 'chat-1' } },
+    });
   });
 
   it('atomically rejects sequential and concurrent replay', async () => {


### PR DESCRIPTION
## Summary

Restore existing tool authorization, MCP discovery cache, and inline-agent continuation behavior after reloads and DeepSeek SPA navigation. The changes also make direct side-panel permission requests visible to the user and stabilize the cross-runtime gzip budget check.

Fixes #429
Fixes #430
Fixes #431

## PR Type

- [x] Bug fix
- [x] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

```bash
git fetch origin main
# origin/main 1f84a10dec2adc06ef322b6fc7ea1b8cb0bf7f0c is the merge base of PR head 84b377d33ccab5d748bf55027e66b688cb6243a4
```

## AI Coding Disclosure

- [x] Partially AI-assisted: AI helped write or modify some programming changes.

AI model(s) used:

OpenAI Codex

Coding Agent tool(s) used:

Codex

## Local Validation

Commands run:

```bash
npm run compile
npm run prompt:freeze
npm run build:all
npm run ci:quality
```

Result summary:

- 6 targeted regression files / 48 tests passed.
- `npm run compile`, `npm run prompt:freeze`, and `npm run build:all` passed.
- `npm run ci:quality` passed: 173 test files / 1,255 tests; Chrome, Edge, and Firefox builds; package, manifest, UTF-8, and offline Pyodide checks.
- Local Chrome verification on the PR head completed a DeepSeek web-search request through four tool calls, two web fetches, and a final assistant response, without an authorization rejection or premature stop.

## Local Feature Evidence

Evidence:

N/A — this PR restores existing behavior and introduces no new user-facing feature.