### PR TITLE
fix(mcp): verify tool cache persistence after write and surface failures

### DIFF
--- a/core/mcp/discovery.ts
+++ b/core/mcp/discovery.ts
@@ -251,11 +251,21 @@ async function discoverServerTools(
       health,
     };
     await saveMcpToolCache(entry);
-    await updateMcpServerHealth(server.id, {
-      status: 'ready',
-      lastConnectedAt: completedAt,
-      lastError: null,
-    });
+    // 防御：确认缓存已持久化，否则记录明确错误而非静默返回空缓存
+    const caches = await getAllMcpToolCaches();
+    const persisted = caches.some((cache) => cache.serverId === entry.serverId);
+    if (persisted) {
+      await updateMcpServerHealth(server.id, {
+        status: 'ready',
+        lastConnectedAt: completedAt,
+        lastError: null,
+      });
+    } else {
+      // 持久化未落盘：仅写 lastError，不覆盖为 ready（避免 UI 静默误显成功）
+      await updateMcpServerHealth(server.id, {
+        lastError: 'tool cache failed to persist (storage write not durable)',
+      });
+    }
     return entry;
   } catch (err) {
     throwIfMcpExecutionAborted(options?.signal);

--- a/core/mcp/store.ts
+++ b/core/mcp/store.ts
@@ -188,10 +188,17 @@ export async function getAllMcpToolCaches(): Promise<McpToolCacheEntry[]> {
 export async function saveMcpToolCache(entry: McpToolCacheEntry): Promise<void> {
   await mcpStorageOperations.run(async () => {
     const state = await readStateAlreadyOwned();
-    await writeStateAlreadyOwned({
+    const nextState = {
       ...state,
       toolCaches: [entry, ...state.toolCaches.filter((cache) => cache.serverId !== entry.serverId)],
-    });
+    };
+    await writeStateAlreadyOwned(nextState);
+    // 写后校验：确认本次写入已 durable 提交，防御 MV3 SW 回收打断未提交
+    const verify = await readStateAlreadyOwned();
+    const persisted = verify.toolCaches.some((cache) => cache.serverId === entry.serverId);
+    if (!persisted) {
+      await writeStateAlreadyOwned(nextState); // 重试一次
+    }
   });
 }
 

--- a/core/mcp/store.ts
+++ b/core/mcp/store.ts
@@ -193,11 +193,12 @@ export async function saveMcpToolCache(entry: McpToolCacheEntry): Promise<void> 
       toolCaches: [entry, ...state.toolCaches.filter((cache) => cache.serverId !== entry.serverId)],
     };
     await writeStateAlreadyOwned(nextState);
-    // 写后校验：确认本次写入已 durable 提交，防御 MV3 SW 回收打断未提交
+    // Post-write verification: confirm the write was durably committed, guarding
+    // against MV3 service-worker eviction interrupting before the commit lands.
     const verify = await readStateAlreadyOwned();
     const persisted = verify.toolCaches.some((cache) => cache.serverId === entry.serverId);
     if (!persisted) {
-      await writeStateAlreadyOwned(nextState); // 重试一次
+      await writeStateAlreadyOwned(nextState); // retry once
     }
   });
 }


### PR DESCRIPTION
## 根因分析（Bug1：MCP 工具缓存未持久化，导致工具授权被拒绝）

### 现象
用户在 DeepSeek++ 中配置 MCP 服务器并完成工具发现后，执行工具授权时偶发被拒绝（"工具授权被拒绝"）。该问题具有随机性，难以稳定复现。

### 根因
1. **MV3 Service Worker 生命周期不确定**：`core/mcp/store.ts` 的 `saveMcpToolCache` 通过 `chrome.storage.local.set` 写入缓存，但 Service Worker (SW) 可能在写入尚未 durable 提交前被浏览器回收，造成缓存未真正落盘。
2. **成功分支无条件标记 ready**：`core/mcp/discovery.ts` 的 `discoverServerTools` 在调用 `saveMcpToolCache` 后**无条件**将服务器健康状态标记为 `ready`，UI 静默误显"连接成功"。实际 `toolCaches` 可能为空。
3. **授权执行时查不到工具**：当工具授权执行路径查询工具缓存时，查不到该服务器工具，授权因此被拒绝。

### 上游原始代码（修复前，佐证分析）

`core/mcp/store.ts`（修复前）：

```typescript
export async function saveMcpToolCache(entry: McpToolCacheEntry): Promise<void> {
  await mcpStorageOperations.run(async () => {
    const state = await readStateAlreadyOwned();
    await writeStateAlreadyOwned({
      ...state,
      toolCaches: [entry, ...state.toolCaches.filter((cache) => cache.serverId !== entry.serverId)],
    });
  });
}
```

`core/mcp/discovery.ts`（修复前）：

```typescript
    await saveMcpToolCache(entry);
    await updateMcpServerHealth(server.id, {
      status: 'ready',
      lastConnectedAt: completedAt,
      lastError: null,
    });
    return entry;
```

### 修改方案 / 修改思路
1. **写后校验 + 重试**（`core/mcp/store.ts`）：`saveMcpToolCache` 写入 `nextState` 后，立即回读 `readStateAlreadyOwned` 校验本次写入是否 durable 落盘；若未落盘（SW 回收打断），重试一次。
2. **成功分支改为写后校验 if/else**（`core/mcp/discovery.ts`）：确认 `getAllMcpToolCaches` 中存在该 `serverId` 的缓存才算持久化成功，此时才标记 `ready`；否则仅写 `lastError`（不覆盖为 `ready`），避免 UI 静默误显成功。

### 影响范围
仅涉及 MCP 工具缓存写入与服务器健康状态判定逻辑，不改动授权协议、消息名、存储键、MCP 合约。

### 验证
- 改动已通过本地类型检查与全量测试（远程 CI 将再次执行质量门禁）。
- 两个源文件 +24/−7，无测试文件变更，风险面小。
