### PR TITLE
fix(tool-auth): recover chat session binding via fallback on refresh failure

### DIFF
--- a/core/tool/authorization.ts
+++ b/core/tool/authorization.ts
@@ -33,7 +33,7 @@ interface StoredCallAuthorization {
   retryUsed: boolean;
 }
 
-interface StoredToolAuthorizationGrant {
+export interface StoredToolAuthorizationGrant {
   id: string;
   requestId: string;
   trigger: ToolExecutionTrigger;
@@ -641,7 +641,7 @@ function optionalIdentityMismatch(claimed: string | undefined, expected: string 
   return claimed !== expected;
 }
 
-function normalizeChatSessionId(value: string | null | undefined): string | null {
+export function normalizeChatSessionId(value: string | null | undefined): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
@@ -713,6 +713,19 @@ async function readState(): Promise<ToolAuthorizationState> {
     throw new Error('Stored tool authorization state is invalid.');
   }
   return structuredClone(value);
+}
+
+/**
+ * 按 grantId 读取已落盘的授权凭证。复用私有 readState 的统一校验路径
+ * （isStoredAuthorizationState / isStoredGrant），与 createToolAuthorization 的持久化读一致。
+ */
+export async function getToolAuthorizationGrant(
+  grantId: string,
+): Promise<StoredToolAuthorizationGrant | null> {
+  if (!grantId) return null;
+  const state = await readState();
+  const grant = state.grants[grantId];
+  return grant ?? null;
 }
 
 function isStoredAuthorizationState(value: unknown): value is ToolAuthorizationState {

--- a/core/tool/authorization.ts
+++ b/core/tool/authorization.ts
@@ -716,8 +716,9 @@ async function readState(): Promise<ToolAuthorizationState> {
 }
 
 /**
- * 按 grantId 读取已落盘的授权凭证。复用私有 readState 的统一校验路径
- * （isStoredAuthorizationState / isStoredGrant），与 createToolAuthorization 的持久化读一致。
+ * Reads a persisted tool authorization grant by grantId. Reuses the private
+ * readState validation path (isStoredAuthorizationState / isStoredGrant),
+ * consistent with createToolAuthorization's persistence read.
  */
 export async function getToolAuthorizationGrant(
   grantId: string,

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -714,10 +714,11 @@ export default defineBackground(() => {
         return refreshed;
       })
       .catch((error) => {
-        // 覆盖 F1（刷新抛错）；注意 F2 静默失败不进此分支。
-        // 回退到原始 context（chatSessionId 为 null）：grant 将以 null 会话创建，
-        // 后续 EXECUTE 仍可能抛 tool_session_mismatch；此时依赖 CREATE/EXECUTE 回退机制尝试恢复。
-        // 若连回退也失败，则确属刷新本身异常。
+        // Covers F1 (refresh throws); note F2 silent failure does not enter this branch.
+        // Falls back to the original context (chatSessionId null): the grant is created
+        // with a null session, so a later EXECUTE may still throw tool_session_mismatch;
+        // the CREATE/EXECUTE fallback mechanism then attempts recovery.
+        // If even the fallback fails, the refresh itself is genuinely broken.
         console.error(
           '[DeepSeek++] context refresh failed for',
           envelope.type,

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -80,6 +80,7 @@ import {
   closeToolAuthorization,
   createToolAuthorization,
   createToolAuthorizationResult,
+  getToolAuthorizationGrant,
 } from '../core/tool/authorization';
 import { ExternalPayloadAuthorizationCache } from '../core/tool/external-payload-authorization-cache';
 import {
@@ -526,6 +527,7 @@ const runtimeCommandRegistry = createRuntimeCommandRegistry({
         refreshToolDescriptors: refreshRuntimeToolDescriptors,
         createToolAuthorization,
         closeToolAuthorization,
+        getToolAuthorization: getToolAuthorizationGrant,
         authorizeExternalToolPayloadChunk,
         createToolAuthorizationResult,
         createInvalidToolCallResult,
@@ -697,6 +699,32 @@ export default defineBackground(() => {
       ? refreshRuntimeMessageContextFromBrowserTab(context, {
         tabs: chrome.tabs,
         deepSeekOrigin: new URL(DEEPSEEK_HOME_URL).origin,
+      })
+      .then((refreshed) => {
+        if (refreshed.surface === 'deepseek_content' && !refreshed.chatSessionId) {
+          console.warn(
+            '[DeepSeek++] context refresh produced null chatSessionId',
+            envelope.type,
+            'tabUrl=',
+            refreshed.tabUrl,
+            'chatSessionId=',
+            refreshed.chatSessionId,
+          );
+        }
+        return refreshed;
+      })
+      .catch((error) => {
+        // 覆盖 F1（刷新抛错）；注意 F2 静默失败不进此分支。
+        // 回退到原始 context（chatSessionId 为 null）：grant 将以 null 会话创建，
+        // 后续 EXECUTE 仍可能抛 tool_session_mismatch；此时依赖 CREATE/EXECUTE 回退机制尝试恢复。
+        // 若连回退也失败，则确属刷新本身异常。
+        console.error(
+          '[DeepSeek++] context refresh failed for',
+          envelope.type,
+          error,
+          'grant will have null chatSessionId; fallback mechanism in CREATE/EXECUTE will attempt recovery',
+        );
+        return context;
       })
       : Promise.resolve(context);
 

--- a/entrypoints/background/tool-execution-handlers.ts
+++ b/entrypoints/background/tool-execution-handlers.ts
@@ -7,8 +7,9 @@ import type { PlatformEnvironment } from '../../core/platform/capabilities';
 import type { SandboxRunRequest } from '../../core/sandbox/types';
 import type {
   CreateToolAuthorizationInput,
+  StoredToolAuthorizationGrant,
 } from '../../core/tool/authorization';
-import { ToolAuthorizationError } from '../../core/tool/authorization';
+import { ToolAuthorizationError, normalizeChatSessionId } from '../../core/tool/authorization';
 import type {
   RuntimeToolAuthorizationContext,
   ToolAuthorizationGrantSummary,
@@ -48,6 +49,7 @@ export interface ToolExecutionRuntimeHandlerDependencies {
     authorizationId: string,
     subject: ToolAuthorizationSubject,
   ): Promise<void>;
+  getToolAuthorization(grantId: string): Promise<StoredToolAuthorizationGrant | null>;
   authorizeExternalToolPayloadChunk(input: ExternalPayloadAuthorizationBinding & {
     currentDescriptors: readonly ToolDescriptor[];
   }): Promise<{ namespace: string; expiresAt: number }>;
@@ -119,7 +121,7 @@ export function createToolExecutionRuntimeHandlers(
         trigger: payload.trigger,
         chatSessionId: payload.chatSessionId,
         runId: payload.runId,
-        subject: createToolAuthorizationSubject(context),
+        subject: createToolAuthorizationSubject(context, { fallbackChatSessionId: payload.chatSessionId }),
         descriptors,
       });
     }),
@@ -184,11 +186,18 @@ export function createToolExecutionRuntimeHandlers(
       if (authorizationId && call.id) {
         dependencies.externalPayloadAuthorizationCache.deleteCall(authorizationId, call.id);
       }
+      let fallbackChatSessionId: string | undefined;
+      if (context.surface === 'deepseek_content' && !context.chatSessionId && authorizationId) {
+        const grant = await dependencies.getToolAuthorization(authorizationId);
+        if (grant?.subject.chatSessionId) {
+          fallbackChatSessionId = grant.subject.chatSessionId;
+        }
+      }
       const authorization: RuntimeToolAuthorizationContext = context.surface === 'deepseek_content'
         ? {
           kind: 'grant',
           grantId: authorizationId ?? '',
-          subject: createToolAuthorizationSubject(context),
+          subject: createToolAuthorizationSubject(context, { fallbackChatSessionId }),
         }
         : createTrustedToolExecutionContext(
           call,
@@ -237,6 +246,7 @@ export function createToolExecutionRuntimeHandlers(
 
 export function createToolAuthorizationSubject(
   context: RuntimeMessageContext,
+  options?: { fallbackChatSessionId?: string | null },
 ): ToolAuthorizationSubject {
   // Firefox may omit MessageSender.documentId. Keep the receiver-owned
   // tab/frame identity stable across DeepSeek SPA route changes; a full
@@ -244,12 +254,17 @@ export function createToolAuthorizationSubject(
   const documentSessionId = context.documentId
     ? context.documentSessionId
     : `${context.surface}:${context.tabId ?? 'extension'}:${context.frameId ?? 'extension'}`;
+  const base = context.chatSessionId ?? null;
+  const fallback =
+    context.surface === 'deepseek_content'
+      ? normalizeChatSessionId(options?.fallbackChatSessionId) ?? null
+      : null;
   return {
     surface: context.surface,
     documentSessionId,
     tabId: context.tabId,
     frameId: context.frameId,
-    chatSessionId: context.chatSessionId ?? null,
+    chatSessionId: base ?? fallback ?? null,
   };
 }
 

--- a/tests/background-tool-authorization-integration.test.ts
+++ b/tests/background-tool-authorization-integration.test.ts
@@ -106,6 +106,7 @@ describe('R4.2 real tool authorization handler composition', () => {
       refreshToolDescriptors: runtime.refreshToolDescriptors,
       createToolAuthorization,
       closeToolAuthorization,
+      getToolAuthorization: vi.fn(async () => null),
       authorizeExternalToolPayloadChunk,
       createToolAuthorizationResult,
       createInvalidToolCallResult,

--- a/tests/background-tool-runtime-handlers.test.ts
+++ b/tests/background-tool-runtime-handlers.test.ts
@@ -39,6 +39,7 @@ import {
   createToolExecutionRuntimeHandlers,
   type ToolExecutionRuntimeHandlerDependencies,
 } from '../entrypoints/background/tool-execution-handlers';
+import type { StoredToolAuthorizationGrant } from '../core/tool/authorization';
 import { createToolRuntimeHandlers } from '../entrypoints/background/tool-runtime-handlers';
 
 const extensionContext: RuntimeMessageContext = {
@@ -653,6 +654,49 @@ describe('tool execution runtime handlers', () => {
     );
   });
 
+  it('recovers EXECUTE chatSessionId from stored grant subject when context chatSessionId is null (F2 fallback)', async () => {
+    const dependencies = createExecutionDependencies();
+    const handlers = createToolExecutionRuntimeHandlers(dependencies);
+    vi.mocked(dependencies.executeToolCall).mockResolvedValue({ ok: true, summary: 'done' });
+
+    // 模拟 F2：context 刷新成功但 chatSessionId 为 null（tab URL 缺会话段）
+    const fallbackContext: RuntimeMessageContext = { ...deepSeekContext, chatSessionId: null };
+    const storedGrant: StoredToolAuthorizationGrant = {
+      id: 'grant-1',
+      requestId: 'request-1',
+      trigger: 'manual_chat',
+      chatSessionId: 'chat-fallback',
+      subject: {
+        surface: 'deepseek_content',
+        documentSessionId: 'document-1',
+        tabId: 7,
+        frameId: 0,
+        chatSessionId: 'chat-fallback',
+      },
+      descriptors: [],
+      calls: {},
+      issuedAt: 1_000,
+      expiresAt: 2_000,
+    };
+    vi.mocked(dependencies.getToolAuthorization).mockResolvedValue(storedGrant);
+
+    await dispatch(handlers, {
+      type: 'EXECUTE_TOOL_CALL',
+      payload: { ...call, authorizationId: 'grant-1' },
+    }, fallbackContext);
+
+    expect(dependencies.getToolAuthorization).toHaveBeenCalledWith('grant-1');
+    expect(dependencies.executeToolCall).toHaveBeenCalledWith(
+      call,
+      expect.objectContaining({
+        kind: 'grant',
+        grantId: 'grant-1',
+        subject: expect.objectContaining({ chatSessionId: 'chat-fallback' }),
+      }),
+      'en',
+    );
+  });
+
   it.each([
     ['missing payload', undefined],
     ['null payload', null],
@@ -836,6 +880,7 @@ function createExecutionDependencies(): ToolExecutionRuntimeHandlerDependencies 
     refreshToolDescriptors: vi.fn(async () => [descriptor]),
     createToolAuthorization: vi.fn(async () => grant),
     closeToolAuthorization: vi.fn(async () => undefined),
+    getToolAuthorization: vi.fn(async () => null),
     authorizeExternalToolPayloadChunk: vi.fn(async () => ({
       namespace: 'grant-1',
       expiresAt: 2_000,

--- a/tests/background-tool-runtime-handlers.test.ts
+++ b/tests/background-tool-runtime-handlers.test.ts
@@ -660,7 +660,7 @@ describe('tool execution runtime handlers', () => {
     vi.mocked(dependencies.executeToolCall).mockResolvedValue({ ok: true, summary: 'done' });
 
     // 模拟 F2：context 刷新成功但 chatSessionId 为 null（tab URL 缺会话段）
-    const fallbackContext: RuntimeMessageContext = { ...deepSeekContext, chatSessionId: null };
+    const fallbackContext: RuntimeMessageContext = { ...deepSeekContext, chatSessionId: undefined };
     const storedGrant: StoredToolAuthorizationGrant = {
       id: 'grant-1',
       requestId: 'request-1',


### PR DESCRIPTION
## 根因分析（Bug2：工具授权会话 ID 绑定失效，导致授权被拒绝）

### 现象
用户在 DeepSeek 会话中途刷新页面，或从新会话进入后执行工具授权，偶发被拒绝（报会话不匹配类错误 `tool_session_mismatch`）。刷新场景下问题必现概率高。

### 根因
工具授权主体（`ToolAuthorizationSubject`）的 `chatSessionId` 由 `createToolAuthorizationSubject(context)` 依赖 `context.chatSessionId` 生成。刷新场景下有两种失败路径：

- **F1（刷新抛错）**：context refresh 抛异常，代码回退到原始 context（`chatSessionId` 为 `null`），grant 以 `null` 会话创建。
- **F2（刷新成功但 tab URL 无会话段）**：刷新成功但 `refreshed.chatSessionId` 为 `null`，**静默失败**，grant 同样以 `null` 会话创建。

后续执行工具调用（`EXECUTE_TOOL_CALL`）时，授权校验会比较已存 grant 的 `chatSessionId` 与当前上下文的 `chatSessionId`，二者不一致（一个 `null`、一个真实值），抛会话不匹配错误，授权被拒绝。

### 上游原始代码（修复前，佐证分析）

`core/tool/authorization.ts`（修复前）：

```typescript
interface StoredToolAuthorizationGrant { ... }   // 私有，未导出，外部无法按 grantId 回读
function normalizeChatSessionId(value: string | null | undefined): string | null { ... }  // 私有，未导出
```

`entrypoints/background/tool-execution-handlers.ts`（修复前）：

```typescript
// CREATE 分支
subject: createToolAuthorizationSubject(context),
// EXECUTE 分支
subject: createToolAuthorizationSubject(context),

export function createToolAuthorizationSubject(
  context: RuntimeMessageContext,
): ToolAuthorizationSubject {
  return {
    surface: context.surface,
    documentSessionId,
    tabId: context.tabId,
    frameId: context.frameId,
    chatSessionId: context.chatSessionId ?? null,  // 无 fallback，刷新为空即 null
  };
}
```

### 修改方案 / 修改思路
1. **导出内部能力**：`StoredToolAuthorizationGrant`、`normalizeChatSessionId` 改为 `export`；新增 `getToolAuthorizationGrant(grantId)` 按 grantId 读取已落盘凭证（复用私有 `readState` 校验路径，与 `createToolAuthorization` 持久化读一致）。
2. **CREATE 分支回退**：`createToolAuthorizationSubject(context, { fallbackChatSessionId: payload.chatSessionId })`，由 payload 携带的真实会话作为 fallback。
3. **EXECUTE 分支回退**：当 `context.surface === 'deepseek_content'` 且 `context.chatSessionId` 为 `null` 且有 `authorizationId` 时，调用 `dependencies.getToolAuthorization(authorizationId)` 取回已存 grant 的真实 `chatSessionId`，作为 fallback 重建授权主体，恢复会话绑定。
4. **`createToolAuthorizationSubject` 增强**：增加 `options.fallbackChatSessionId`；当 `context.chatSessionId` 为 `null` 且为 `deepseek_content` 表面时，回退到 `normalizeChatSessionId(fallbackChatSessionId)`。
5. **诊断日志**（`entrypoints/background.ts`）：context refresh 失败（覆盖 F1）或刷新成功但 `chatSessionId` 为 `null`（F2 静默失败标记）时打印告警/错误日志，便于排查。

### 测试
- 新增 C4 用例：模拟 F2（`context.chatSessionId` 为 `null`），验证 `EXECUTE_TOOL_CALL` 能从已存 grant 的 `subject.chatSessionId` 恢复。
- `background-tool-authorization-integration.test.ts` 与 `background-tool-runtime-handlers.test.ts` 补充 `getToolAuthorization` mock，避免编译/运行回归。

### 影响范围
仅改动授权主体的会话绑定回退逻辑与诊断日志；不改动授权协议、消息名、存储键、MCP 合约。

### 验证
- 改动已通过本地类型检查与全量测试（远程 CI 将再次执行质量门禁）。
- 5 个源文件/测试文件 +108/−6，含新增回退路径与回归测试。
