### PR TITLE
fix: stabilize MCP discovery, permissions, and request interception

### DIFF
--- a/core/interceptor/request-augmentation.ts
+++ b/core/interceptor/request-augmentation.ts
@@ -43,13 +43,19 @@ export function augmentRequestBody(
   bodyStr: string,
   state: RequestAugmentationState,
 ): RequestBodyAugmentationResult | null {
-  let body: DeepSeekRequestBody;
+  const body = decodeAugmentableDeepSeekRequestBody(bodyStr);
+  if (!body) return null;
+  return augmentDecodedRequestBody(body, state);
+}
+
+export function decodeAugmentableDeepSeekRequestBody(
+  bodyStr: string,
+): DeepSeekRequestBody | null {
   try {
-    body = decodeDeepSeekRequestBody(bodyStr);
+    return decodeDeepSeekRequestBody(bodyStr);
   } catch {
     return null;
   }
-  return augmentDecodedRequestBody(body, state);
 }
 
 export function decodeDeepSeekRequestBody(bodyStr: string): DeepSeekRequestBody {

--- a/core/mcp/discovery.ts
+++ b/core/mcp/discovery.ts
@@ -18,11 +18,29 @@ import type {
 } from './types';
 
 const DEFAULT_CACHE_TTL_MS = 5 * 60_000;
+const discoveryTails = new Map<McpServerId, Promise<void>>();
 
 export async function refreshMcpServerDiscovery(
   serverId: McpServerId,
   options?: { cacheTtlMs?: number; signal?: AbortSignal },
 ): Promise<McpToolCacheEntry> {
+  const previous = discoveryTails.get(serverId) ?? Promise.resolve();
+  const operation = previous.then(
+    () => discoverServerToolsById(serverId, options),
+    () => discoverServerToolsById(serverId, options),
+  );
+  const tail = operation.then(() => undefined, () => undefined);
+  discoveryTails.set(serverId, tail);
+  return operation.finally(() => {
+    if (discoveryTails.get(serverId) === tail) discoveryTails.delete(serverId);
+  });
+}
+
+async function discoverServerToolsById(
+  serverId: McpServerId,
+  options?: { cacheTtlMs?: number; signal?: AbortSignal },
+): Promise<McpToolCacheEntry> {
+  throwIfMcpExecutionAborted(options?.signal);
   const server = await getMcpServerById(serverId, { includeSecrets: true });
   if (!server) throw new Error(`MCP server not found: ${serverId}`);
   return discoverServerTools(server, options);
@@ -261,19 +279,23 @@ async function discoverServerTools(
     throwIfMcpExecutionAborted(options?.signal);
     const completedAt = Date.now();
     const message = err instanceof Error ? err.message : String(err);
+    const previousCache = await getMcpToolCache(server.id);
+    throwIfMcpExecutionAborted(options?.signal);
+    const descriptors = previousCache?.descriptors ?? [];
     const health: McpServerHealth = {
       serverId: server.id,
       status: 'error',
       checkedAt: completedAt,
       latencyMs: completedAt - startedAt,
-      toolCount: 0,
+      toolCount: descriptors.length,
       error: message,
     };
     const entry: McpToolCacheEntry = {
       serverId: server.id,
-      descriptors: [],
-      refreshedAt: completedAt,
-      expiresAt: completedAt + Math.min(options?.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS, 30_000),
+      descriptors,
+      refreshedAt: previousCache?.refreshedAt ?? completedAt,
+      expiresAt: previousCache?.expiresAt
+        ?? completedAt + Math.min(options?.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS, 30_000),
       health,
     };
     await saveMcpToolCache(entry);

--- a/core/mcp/index.ts
+++ b/core/mcp/index.ts
@@ -119,7 +119,6 @@ export {
   normalizeJsonRpcResponse,
   readJsonRpcResponse,
   readSseJsonRpcResponse,
-  requestMcpServerOriginPermission,
 } from './transports';
 
 export type {

--- a/core/mcp/index.ts
+++ b/core/mcp/index.ts
@@ -115,6 +115,7 @@ export {
   fetchWithTimeout,
   getMcpEndpointUrl,
   getMcpOriginPattern,
+  hasMcpServerOriginPermission,
   normalizeJsonRpcResponse,
   readJsonRpcResponse,
   readSseJsonRpcResponse,

--- a/core/mcp/transports/common.ts
+++ b/core/mcp/transports/common.ts
@@ -34,17 +34,6 @@ export function getMcpOriginPattern(server: McpServerConfig): string {
   return `${url.protocol}//${url.host}/*`;
 }
 
-export async function requestMcpServerOriginPermission(server: McpServerConfig): Promise<boolean> {
-  const origins = [getMcpOriginPattern(server)];
-  if (!chrome.permissions?.request) return false;
-
-  const granted = chrome.permissions.contains
-    ? await chrome.permissions.contains({ origins }).catch(() => false)
-    : false;
-  if (granted) return true;
-  return chrome.permissions.request({ origins }).catch(() => false);
-}
-
 export async function hasMcpServerOriginPermission(server: McpServerConfig): Promise<boolean> {
   const origin = getMcpOriginPattern(server);
   if (!chrome.permissions?.contains) {

--- a/core/mcp/transports/common.ts
+++ b/core/mcp/transports/common.ts
@@ -36,15 +36,37 @@ export function getMcpOriginPattern(server: McpServerConfig): string {
 
 export async function requestMcpServerOriginPermission(server: McpServerConfig): Promise<boolean> {
   const origins = [getMcpOriginPattern(server)];
-  if (!chrome.permissions?.contains || !chrome.permissions?.request) return true;
+  if (!chrome.permissions?.request) return false;
 
-  const granted = await chrome.permissions.contains({ origins }).catch(() => false);
+  const granted = chrome.permissions.contains
+    ? await chrome.permissions.contains({ origins }).catch(() => false)
+    : false;
   if (granted) return true;
   return chrome.permissions.request({ origins }).catch(() => false);
 }
 
+export async function hasMcpServerOriginPermission(server: McpServerConfig): Promise<boolean> {
+  const origin = getMcpOriginPattern(server);
+  if (!chrome.permissions?.contains) {
+    throw new McpTransportError(
+      'mcp_origin_permission_check_unavailable',
+      `Host permission cannot be verified for ${origin}.`,
+      { retryable: false },
+    );
+  }
+  try {
+    return await chrome.permissions.contains({ origins: [origin] });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new McpTransportError(
+      'mcp_origin_permission_check_failed',
+      `Host permission could not be verified for ${origin}: ${message}`,
+    );
+  }
+}
+
 export async function ensureMcpServerOriginPermission(server: McpServerConfig): Promise<void> {
-  const granted = await requestMcpServerOriginPermission(server);
+  const granted = await hasMcpServerOriginPermission(server);
   if (!granted) {
     throw new McpTransportError(
       'mcp_origin_permission_denied',

--- a/core/mcp/transports/index.ts
+++ b/core/mcp/transports/index.ts
@@ -5,6 +5,7 @@ export {
   fetchWithTimeout,
   getMcpEndpointUrl,
   getMcpOriginPattern,
+  hasMcpServerOriginPermission,
   normalizeJsonRpcResponse,
   readJsonRpcResponse,
   readSseJsonRpcResponse,

--- a/core/mcp/transports/index.ts
+++ b/core/mcp/transports/index.ts
@@ -9,7 +9,6 @@ export {
   normalizeJsonRpcResponse,
   readJsonRpcResponse,
   readSseJsonRpcResponse,
-  requestMcpServerOriginPermission,
 } from './common';
 
 export type {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -147,7 +147,7 @@ import {
   updateMcpServer,
 } from '../core/mcp/store';
 import { refreshMcpServerDiscovery } from '../core/mcp/discovery';
-import { getMcpOriginPattern, requestMcpServerOriginPermission } from '../core/mcp/transports';
+import { getMcpOriginPattern, hasMcpServerOriginPermission } from '../core/mcp/transports';
 import {
   buildShellAllowlistUpgrade,
   createShellMcpPresetInput,
@@ -500,7 +500,7 @@ const runtimeCommandRegistry = createRuntimeCommandRegistry({
         getMcpToolCache,
         refreshMcpServerDiscovery,
         getMcpOriginPattern,
-        requestMcpServerOriginPermission,
+        hasMcpServerOriginPermission,
         broadcastMcpServersUpdate,
         broadcastToolDescriptorsUpdate,
       },

--- a/entrypoints/background/mcp-handlers.ts
+++ b/entrypoints/background/mcp-handlers.ts
@@ -34,7 +34,7 @@ export interface McpRuntimeHandlerDependencies {
   getMcpToolCache(serverId: string): Promise<McpToolCacheEntry | null>;
   refreshMcpServerDiscovery(serverId: string): Promise<McpToolCacheEntry>;
   getMcpOriginPattern(server: McpServerConfig): string;
-  requestMcpServerOriginPermission(server: McpServerConfig): Promise<boolean>;
+  hasMcpServerOriginPermission(server: McpServerConfig): Promise<boolean>;
   broadcastMcpServersUpdate(excludeTabId?: number): Promise<void>;
   broadcastToolDescriptorsUpdate(excludeTabId?: number): Promise<void>;
 }
@@ -90,6 +90,9 @@ export function createMcpRuntimeHandlers(
       await notifyMcpAndTools(context.tabId);
       return cache;
     }),
+    // Keep the released command for compatibility, but never request a new
+    // host permission from a runtime message: the Side Panel owns that user
+    // gesture. Background callers may only observe the current grant.
     defineToolPayloadRuntimeCommandHandler('REQUEST_MCP_SERVER_PERMISSION', async (payload) => {
       const server = await dependencies.getMcpServerById(payload.serverId);
       if (!server) return { ok: false as const, error: 'mcp_server_not_found' };
@@ -98,7 +101,7 @@ export function createMcpRuntimeHandlers(
       }
       try {
         const origin = dependencies.getMcpOriginPattern(server);
-        const ok = await dependencies.requestMcpServerOriginPermission(server);
+        const ok = await dependencies.hasMcpServerOriginPermission(server);
         return { ok, origin };
       } catch (error) {
         return permissionFailure(error);

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -32,7 +32,7 @@ import {
 } from '../core/interceptor/tool-parser';
 import {
   augmentDecodedRequestBody,
-  decodeDeepSeekRequestBody,
+  decodeAugmentableDeepSeekRequestBody,
   type DeepSeekRequestBody,
 } from '../core/interceptor/request-augmentation';
 import { containsInternalPromptMarker, sanitizeInternalPromptText } from '../core/prompt';
@@ -1097,10 +1097,19 @@ async function handleAugmentRequestBody(data: {
     if (typeof data.body !== 'string') {
       throw new Error('Request body must be a string.');
     }
+    const decodedBody = decodeAugmentableDeepSeekRequestBody(data.body);
+    if (!decodedBody) {
+      postToMainWorld({
+        type: 'AUGMENT_REQUEST_BODY_RESULT',
+        id,
+        ok: true,
+        result: null,
+      });
+      return;
+    }
     if (!mainRequestId) {
       throw new Error('Request authorization identity is missing.');
     }
-    const decodedBody = decodeDeepSeekRequestBody(data.body);
     if (
       toolAuthorizationRequestAliases.has(mainRequestId) ||
       !pendingToolAuthorizationCorrelations.begin(mainRequestId)

--- a/entrypoints/sidepanel/controllers/mcp-tools-controller.ts
+++ b/entrypoints/sidepanel/controllers/mcp-tools-controller.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../core/multimodal';
 import { decodeMcpCapabilitySettings } from '../../../core/mcp/capability-settings';
 import { decodeMcpStorageState, MCP_STORAGE_VERSION } from '../../../core/mcp/storage-codec';
+import { getMcpOriginPattern } from '../../../core/mcp/transports';
 import {
   getSupportedMcpTransportKinds,
   isShellNativeHostSupported,
@@ -65,7 +66,7 @@ export interface McpToolsController {
     mode: McpCapabilityExposureMode;
     pinnedDescriptorIds?: readonly string[];
   }): Promise<McpCapabilitySettings>;
-  requestServerPermission(serverId: string): Promise<McpPermissionResult>;
+  requestServerPermission(server: McpServerConfig): Promise<McpPermissionResult>;
   connectServer(server: McpServerConfig, action: McpConnectionAction): Promise<McpToolCacheEntry>;
   getWebToolSettings(): Promise<WebToolSettings>;
   setWebToolEnabled(name: WebSearchToolName, enabled: boolean): Promise<void>;
@@ -104,6 +105,25 @@ export function createMcpToolsController(
     { type: 'GET_MCP_TOOL_CACHE', payload: { serverId: server.id } },
     { decode: (value) => decodeMcpToolCache(value, server) },
   );
+
+  const requestServerPermission = async (
+    server: McpServerConfig,
+  ): Promise<McpPermissionResult> => {
+    if (!mcpServerNeedsOriginPermission(server)) return { ok: true, origin: null };
+    const origin = getMcpOriginPattern(server);
+    try {
+      return {
+        ok: await hostPermissions.request([origin]),
+        origin,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        origin,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  };
 
   const controller: McpToolsController = {
     async loadMcpSnapshot() {
@@ -162,16 +182,10 @@ export function createMcpToolsController(
       },
       { decode: decodeMcpCapabilitySettings },
     ),
-    requestServerPermission: (serverId) => runtimeClient.request(
-      { type: 'REQUEST_MCP_SERVER_PERMISSION', payload: { serverId } },
-      { acceptFailure: true, decode: decodeMcpPermissionResult },
-    ),
+    requestServerPermission,
     async connectServer(server, action) {
       if (mcpServerNeedsOriginPermission(server)) {
-        const permission = await runtimeClient.request(
-          { type: 'REQUEST_MCP_SERVER_PERMISSION', payload: { serverId: server.id } },
-          { acceptFailure: true, decode: decodeMcpPermissionResult },
-        );
+        const permission = await requestServerPermission(server);
         if (!permission.ok) {
           throw new McpPermissionError(permission.origin, permission.error);
         }
@@ -380,24 +394,6 @@ function decodeMcpConnectionResponse(
     throw new Error('TEST_MCP_SERVER_CONNECTION response.ok must be a boolean.');
   }
   return decodeRequiredMcpToolCache(record.cache, server);
-}
-
-function decodeMcpPermissionResult(value: unknown): McpPermissionResult {
-  const record = requireRecord(value, 'REQUEST_MCP_SERVER_PERMISSION response');
-  if (typeof record.ok !== 'boolean') {
-    throw new Error('REQUEST_MCP_SERVER_PERMISSION response.ok must be a boolean.');
-  }
-  if (record.origin !== null && typeof record.origin !== 'string' && record.origin !== undefined) {
-    throw new Error('REQUEST_MCP_SERVER_PERMISSION response.origin is invalid.');
-  }
-  if (record.error !== undefined && typeof record.error !== 'string') {
-    throw new Error('REQUEST_MCP_SERVER_PERMISSION response.error is invalid.');
-  }
-  return {
-    ok: record.ok,
-    origin: typeof record.origin === 'string' ? record.origin : null,
-    ...(typeof record.error === 'string' ? { error: record.error } : {}),
-  };
 }
 
 function decodePlatformEnvironment(value: unknown): PlatformEnvironment {

--- a/entrypoints/sidepanel/controllers/useMcpPageController.ts
+++ b/entrypoints/sidepanel/controllers/useMcpPageController.ts
@@ -226,7 +226,7 @@ export function useMcpPageController(t: Translator, confirm: Confirm) {
     setBusyState(server.id, 'permission');
     clearBanner();
     try {
-      const result = await mcpToolsController.requestServerPermission(server.id);
+      const result = await mcpToolsController.requestServerPermission(server);
       if (result.ok) {
         showBanner('success', t('sidepanel.mcpPage.messages.permissionGranted', {
           origin: result.origin ?? t('sidepanel.mcpPage.localHost'),

--- a/packages/shell-host/lib/host-files.mjs
+++ b/packages/shell-host/lib/host-files.mjs
@@ -14,6 +14,7 @@ export const REQUIRED_HOST_RUNTIME_FILES = [
   'picker-provider.mjs',
   'process-provider.mjs',
   'router.mjs',
+  'runtime-dispatcher.mjs',
   'session-provider.mjs',
   'shell-mcp-host.mjs',
   'skill-provider.mjs',

--- a/packages/shell-host/native/framing.mjs
+++ b/packages/shell-host/native/framing.mjs
@@ -12,6 +12,7 @@ export function createNativeMessageChannel({
   let messageResolve = null;
   const messageQueue = [];
   let inputEnded = false;
+  let writeTail = Promise.resolve();
 
   function settleEnd() {
     inputEnded = true;
@@ -66,16 +67,18 @@ export function createNativeMessageChannel({
       return new Promise(resolve => { messageResolve = resolve; });
     },
     writeMessage(message) {
-      return new Promise(resolve => {
+      const write = () => new Promise(resolve => {
         const body = Buffer.from(JSON.stringify(message), 'utf8');
         if (body.length > Math.floor(MAX_NATIVE_MESSAGE_BYTES * 0.95)) {
           logLine(`writeNativeMessage WARNING body=${body.length} bytes approaches the ${MAX_NATIVE_MESSAGE_BYTES} native messaging cap; Chrome may truncate this response.`);
         }
         const header = Buffer.alloc(4);
         header.writeUInt32LE(body.length, 0);
-        output.write(header);
-        output.write(body, resolve);
+        output.write(Buffer.concat([header, body]), resolve);
       });
+      const result = writeTail.then(write, write);
+      writeTail = result.then(() => undefined, () => undefined);
+      return result;
     },
   };
 }

--- a/packages/shell-host/native/os-adapter.mjs
+++ b/packages/shell-host/native/os-adapter.mjs
@@ -1,8 +1,11 @@
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { homedir, platform, release as osRelease } from 'node:os';
 import { dirname, resolve } from 'node:path';
+import { promisify } from 'node:util';
 import { DEFAULT_SHELL, WINDOWS_POWERSHELL_UTF8_PREAMBLE } from './contracts.mjs';
+
+const execFileAsync = promisify(execFile);
 
 export const PATH_SEPARATOR = platform() === 'win32' ? ';' : ':';
 export const localAppData = process.env.LOCALAPPDATA || resolve(homedir(), 'AppData', 'Local');
@@ -43,15 +46,22 @@ export function initializeHostEnvironment(packageRoot, logLine) {
       ];
   const managedPathDirs = new Set([nodeBinDir, ...localBinDirs, ...userBinDirs]);
   const existingPathDirs = splitPath(currentPath).filter(directory => !managedPathDirs.has(directory));
-  const hostPath = dedupePathDirs([
+  const buildHostPath = (windowsPathDirs) => dedupePathDirs([
     nodeBinDir,
     ...userBinDirs,
-    ...readWindowsUserMachinePathDirs(logLine),
+    ...windowsPathDirs,
     ...existingPathDirs,
     ...localBinDirs,
   ]).join(PATH_SEPARATOR);
-  setEnvironmentPath(process.env, hostPath);
-  return hostPath;
+  const initialPath = buildHostPath([]);
+  setEnvironmentPath(process.env, initialPath);
+  if (platform() !== 'win32') return initialPath;
+
+  return readWindowsUserMachinePathDirs(logLine).then((windowsPathDirs) => {
+    const hostPath = buildHostPath(windowsPathDirs);
+    setEnvironmentPath(process.env, hostPath);
+    return hostPath;
+  });
 }
 
 export function createChildEnv(extraEnv) {
@@ -160,7 +170,7 @@ function dedupePathDirs(dirs) {
   return result;
 }
 
-function readWindowsUserMachinePathDirs(logLine) {
+async function readWindowsUserMachinePathDirs(logLine) {
   if (platform() !== 'win32') return [];
   const command = [
     "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
@@ -168,7 +178,7 @@ function readWindowsUserMachinePathDirs(logLine) {
     "$paths | Where-Object { $_ } | ForEach-Object { [Environment]::ExpandEnvironmentVariables($_) }",
   ].join('; ');
   try {
-    const output = execFileSync('powershell.exe', [
+    const { stdout } = await execFileAsync('powershell.exe', [
       '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command,
     ], {
       encoding: 'utf8',
@@ -176,7 +186,7 @@ function readWindowsUserMachinePathDirs(logLine) {
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
     });
-    return splitPath(output.replace(/\r?\n/g, PATH_SEPARATOR));
+    return splitPath(stdout.replace(/\r?\n/g, PATH_SEPARATOR));
   } catch (error) {
     logLine(`Could not read Windows User/Machine PATH: ${error instanceof Error ? error.message : String(error)}`);
     return [];

--- a/packages/shell-host/native/picker-provider.mjs
+++ b/packages/shell-host/native/picker-provider.mjs
@@ -1,13 +1,16 @@
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { homedir, platform } from 'node:os';
+import { promisify } from 'node:util';
 import { DEFAULT_TIMEOUT_MS, WINDOWS_POWERSHELL_UTF8_PREAMBLE } from './contracts.mjs';
 import { resolveLocalPath, safeStat } from './file-provider.mjs';
+
+const execFileAsync = promisify(execFile);
 
 export function createPickerToolHandlers() {
   return [{ name: 'local_folder_pick', handle: createLocalFolderPickResult }];
 }
 
-function createLocalFolderPickResult(args) {
+async function createLocalFolderPickResult(args) {
   const title = typeof args?.title === 'string' && args.title.trim()
     ? args.title.trim()
     : 'Choose a local Skill folder';
@@ -16,7 +19,7 @@ function createLocalFolderPickResult(args) {
     : '';
 
   try {
-    const selectedPath = pickLocalFolder({ title, defaultPath });
+    const selectedPath = await pickLocalFolder({ title, defaultPath });
     const normalizedPath = resolveLocalPath(selectedPath);
     const selectedStat = safeStat(normalizedPath);
     if (!selectedStat || !selectedStat.isDirectory()) {
@@ -31,14 +34,14 @@ function createLocalFolderPickResult(args) {
   }
 }
 
-function pickLocalFolder({ title, defaultPath }) {
+async function pickLocalFolder({ title, defaultPath }) {
   const hostPlatform = platform();
   if (hostPlatform === 'darwin') return pickLocalFolderOnMac(title, defaultPath);
   if (hostPlatform === 'win32') return pickLocalFolderOnWindows(title, defaultPath);
   return pickLocalFolderOnLinux(title, defaultPath);
 }
 
-function pickLocalFolderOnMac(title, defaultPath) {
+async function pickLocalFolderOnMac(title, defaultPath) {
   const script = [
     'on run argv',
     '  set promptText to item 1 of argv',
@@ -51,12 +54,13 @@ function pickLocalFolderOnMac(title, defaultPath) {
     '  return POSIX path of chosenFolder',
     'end run',
   ].join('\n');
-  return execFileSync('osascript', ['-e', script, title, defaultPath || ''], {
+  const { stdout } = await execFileAsync('osascript', ['-e', script, title, defaultPath || ''], {
     encoding: 'utf8', timeout: DEFAULT_TIMEOUT_MS, windowsHide: true,
-  }).trim();
+  });
+  return stdout.trim();
 }
 
-function pickLocalFolderOnWindows(title, defaultPath) {
+async function pickLocalFolderOnWindows(title, defaultPath) {
   const script = [
     WINDOWS_POWERSHELL_UTF8_PREAMBLE,
     'Add-Type -AssemblyName System.Windows.Forms',
@@ -71,19 +75,20 @@ function pickLocalFolderOnWindows(title, defaultPath) {
     '  [Environment]::Exit(2)',
     '}',
   ].join('; ');
-  return execFileSync('powershell.exe', ['-NoProfile', '-STA', '-EncodedCommand', encodePowerShellCommand(script)], {
+  const { stdout } = await execFileAsync('powershell.exe', ['-NoProfile', '-STA', '-EncodedCommand', encodePowerShellCommand(script)], {
     encoding: 'utf8',
     env: { ...process.env, DPP_FOLDER_PICK_TITLE: title, DPP_FOLDER_PICK_DEFAULT_PATH: defaultPath || '' },
     timeout: DEFAULT_TIMEOUT_MS,
     windowsHide: false,
-  }).trim();
+  });
+  return stdout.trim();
 }
 
 function encodePowerShellCommand(script) {
   return Buffer.from(script, 'utf16le').toString('base64');
 }
 
-function pickLocalFolderOnLinux(title, defaultPath) {
+async function pickLocalFolderOnLinux(title, defaultPath) {
   const linuxPickers = [
     {
       command: 'zenity',
@@ -94,9 +99,10 @@ function pickLocalFolderOnLinux(title, defaultPath) {
   const missing = [];
   for (const picker of linuxPickers) {
     try {
-      return execFileSync(picker.command, picker.args, {
+      const { stdout } = await execFileAsync(picker.command, picker.args, {
         encoding: 'utf8', timeout: DEFAULT_TIMEOUT_MS, windowsHide: true,
-      }).trim();
+      });
+      return stdout.trim();
     } catch (error) {
       if (error?.code === 'ENOENT') {
         missing.push(picker.command);

--- a/packages/shell-host/native/runtime-dispatcher.mjs
+++ b/packages/shell-host/native/runtime-dispatcher.mjs
@@ -1,0 +1,54 @@
+import { jsonRpcError } from './router.mjs';
+
+export function createNativeEnvelopeDispatcher({
+  router,
+  channel,
+  logger,
+  hostEnvironmentReady,
+}) {
+  const environmentReady = Promise.resolve(hostEnvironmentReady);
+  const inFlight = new Set();
+  let toolCallTail = Promise.resolve();
+
+  function scheduleEnvelope(envelope) {
+    const toolCall = isToolCallEnvelope(envelope);
+    const run = () => handleEnvelope(envelope, toolCall);
+    const task = toolCall
+      ? toolCallTail.then(run, run)
+      : run();
+    if (toolCall) {
+      toolCallTail = task.then(() => undefined, () => undefined);
+    }
+    inFlight.add(task);
+    void task.then(
+      () => inFlight.delete(task),
+      () => inFlight.delete(task),
+    );
+  }
+
+  async function handleEnvelope(envelope, waitForHostEnvironment) {
+    try {
+      if (waitForHostEnvironment) await environmentReady;
+      const response = await router.handleEnvelope(envelope);
+      if (response) await channel.writeMessage(response);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.logLine(`Error: ${message}`);
+      await channel.writeMessage(jsonRpcError(null, -32603, message || 'Internal error'));
+    }
+  }
+
+  return Object.freeze({
+    scheduleEnvelope,
+    async settle() {
+      await Promise.allSettled([...inFlight]);
+    },
+  });
+}
+
+function isToolCallEnvelope(envelope) {
+  return envelope?.protocol === 'deepseek-pp-mcp-native'
+    && envelope?.version === 1
+    && envelope?.message?.jsonrpc === '2.0'
+    && envelope?.message?.method === 'tools/call';
+}

--- a/packages/shell-host/native/shell-mcp-host.mjs
+++ b/packages/shell-host/native/shell-mcp-host.mjs
@@ -9,14 +9,15 @@ import { initializeHostEnvironment } from './os-adapter.mjs';
 import { readShellHostPackageMetadata } from './package-metadata.mjs';
 import { createPickerToolHandlers } from './picker-provider.mjs';
 import { createProcessToolHandlers } from './process-provider.mjs';
-import { createNativeRouter, jsonRpcError } from './router.mjs';
+import { createNativeRouter } from './router.mjs';
+import { createNativeEnvelopeDispatcher } from './runtime-dispatcher.mjs';
 import { createSessionProvider } from './session-provider.mjs';
 import { createSkillToolHandlers } from './skill-provider.mjs';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const packageMetadata = readShellHostPackageMetadata();
 const logger = createHostLogger();
-initializeHostEnvironment(packageRoot, logger.logLine);
+const hostEnvironmentReady = Promise.resolve(initializeHostEnvironment(packageRoot, logger.logLine));
 
 const sessionProvider = createSessionProvider({ logLine: logger.logLine });
 const router = createNativeRouter({
@@ -32,50 +33,21 @@ const router = createNativeRouter({
   serverVersion: packageMetadata.version,
 });
 const channel = createNativeMessageChannel({ logLine: logger.logLine });
-const inFlight = new Set();
-let toolCallTail = Promise.resolve();
+const dispatcher = createNativeEnvelopeDispatcher({
+  router,
+  channel,
+  logger,
+  hostEnvironmentReady,
+});
 
 async function main() {
   while (true) {
     const envelope = await channel.readMessage();
     if (envelope === NATIVE_EOF) break;
-    scheduleEnvelope(envelope);
+    dispatcher.scheduleEnvelope(envelope);
   }
-  await Promise.allSettled([...inFlight]);
+  await dispatcher.settle();
   sessionProvider.shutdown();
-}
-
-function scheduleEnvelope(envelope) {
-  const run = () => handleEnvelope(envelope);
-  const task = isToolCallEnvelope(envelope)
-    ? toolCallTail.then(run, run)
-    : run();
-  if (isToolCallEnvelope(envelope)) {
-    toolCallTail = task.then(() => undefined, () => undefined);
-  }
-  inFlight.add(task);
-  void task.then(
-    () => inFlight.delete(task),
-    () => inFlight.delete(task),
-  );
-}
-
-async function handleEnvelope(envelope) {
-  try {
-    const response = await router.handleEnvelope(envelope);
-    if (response) await channel.writeMessage(response);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger.logLine(`Error: ${message}`);
-    await channel.writeMessage(jsonRpcError(null, -32603, message || 'Internal error'));
-  }
-}
-
-function isToolCallEnvelope(envelope) {
-  return envelope?.protocol === 'deepseek-pp-mcp-native'
-    && envelope?.version === 1
-    && envelope?.message?.jsonrpc === '2.0'
-    && envelope?.message?.method === 'tools/call';
 }
 
 main().catch(error => {

--- a/packages/shell-host/native/shell-mcp-host.mjs
+++ b/packages/shell-host/native/shell-mcp-host.mjs
@@ -32,21 +32,50 @@ const router = createNativeRouter({
   serverVersion: packageMetadata.version,
 });
 const channel = createNativeMessageChannel({ logLine: logger.logLine });
+const inFlight = new Set();
+let toolCallTail = Promise.resolve();
 
 async function main() {
   while (true) {
     const envelope = await channel.readMessage();
     if (envelope === NATIVE_EOF) break;
-    try {
-      const response = await router.handleEnvelope(envelope);
-      if (response) await channel.writeMessage(response);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger.logLine(`Error: ${message}`);
-      await channel.writeMessage(jsonRpcError(null, -32603, message || 'Internal error'));
-    }
+    scheduleEnvelope(envelope);
   }
+  await Promise.allSettled([...inFlight]);
   sessionProvider.shutdown();
+}
+
+function scheduleEnvelope(envelope) {
+  const run = () => handleEnvelope(envelope);
+  const task = isToolCallEnvelope(envelope)
+    ? toolCallTail.then(run, run)
+    : run();
+  if (isToolCallEnvelope(envelope)) {
+    toolCallTail = task.then(() => undefined, () => undefined);
+  }
+  inFlight.add(task);
+  void task.then(
+    () => inFlight.delete(task),
+    () => inFlight.delete(task),
+  );
+}
+
+async function handleEnvelope(envelope) {
+  try {
+    const response = await router.handleEnvelope(envelope);
+    if (response) await channel.writeMessage(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.logLine(`Error: ${message}`);
+    await channel.writeMessage(jsonRpcError(null, -32603, message || 'Internal error'));
+  }
+}
+
+function isToolCallEnvelope(envelope) {
+  return envelope?.protocol === 'deepseek-pp-mcp-native'
+    && envelope?.version === 1
+    && envelope?.message?.jsonrpc === '2.0'
+    && envelope?.message?.method === 'tools/call';
 }
 
 main().catch(error => {

--- a/tests/background-tool-runtime-handlers.test.ts
+++ b/tests/background-tool-runtime-handlers.test.ts
@@ -238,10 +238,10 @@ describe('MCP runtime handlers', () => {
       type: 'REQUEST_MCP_SERVER_PERMISSION',
       payload: { serverId: 'server-1' },
     })).resolves.toEqual({ ok: true, origin: null });
-    expect(dependencies.requestMcpServerOriginPermission).not.toHaveBeenCalled();
+    expect(dependencies.hasMcpServerOriginPermission).not.toHaveBeenCalled();
 
     vi.mocked(dependencies.getMcpServerById).mockResolvedValue(createMcpServer());
-    vi.mocked(dependencies.requestMcpServerOriginPermission)
+    vi.mocked(dependencies.hasMcpServerOriginPermission)
       .mockResolvedValueOnce(false)
       .mockRejectedValueOnce(new Error('permissions API unavailable'));
     await expect(dispatch(handlers, {
@@ -796,7 +796,7 @@ function createMcpDependencies(): McpRuntimeHandlerDependencies {
     getMcpToolCache: vi.fn(async () => createMcpCache()),
     refreshMcpServerDiscovery: vi.fn(async () => createMcpCache()),
     getMcpOriginPattern: vi.fn(() => 'https://example.test/*'),
-    requestMcpServerOriginPermission: vi.fn(async () => true),
+    hasMcpServerOriginPermission: vi.fn(async () => true),
     broadcastMcpServersUpdate: vi.fn(async () => undefined),
     broadcastToolDescriptorsUpdate: vi.fn(async () => undefined),
   };

--- a/tests/mcp-execution-policy.test.ts
+++ b/tests/mcp-execution-policy.test.ts
@@ -180,6 +180,104 @@ describe('MCP execution policy', () => {
     });
   });
 
+  it('keeps the last successful tool snapshot when a refresh fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new TypeError('provider offline');
+    }));
+    const server = await createMcpServer({
+      displayName: 'Cached MCP',
+      enabled: true,
+      transport: { kind: 'http', url: 'http://127.0.0.1:48127/mcp' },
+    });
+    const descriptor = createMcpDescriptor(server, 'cached_tool');
+    await saveMcpToolCache({
+      serverId: server.id,
+      descriptors: [descriptor],
+      refreshedAt: 1_000,
+      expiresAt: 2_000,
+      health: {
+        serverId: server.id,
+        status: 'ready',
+        checkedAt: 1_000,
+        latencyMs: 10,
+        toolCount: 1,
+        error: null,
+      },
+    });
+
+    const failed = await refreshMcpServerDiscovery(server.id);
+
+    expect(failed).toMatchObject({
+      descriptors: [expect.objectContaining({ name: 'cached_tool' })],
+      refreshedAt: 1_000,
+      expiresAt: 2_000,
+      health: { status: 'error', toolCount: 1 },
+    });
+    await expect(getMcpToolCache(server.id)).resolves.toEqual(failed);
+    await expect(getMcpToolDescriptors({ includeDisabled: true })).resolves.toEqual([
+      expect.objectContaining({ name: 'cached_tool' }),
+    ]);
+    await expect(getMcpServerById(server.id)).resolves.toMatchObject({
+      status: 'error',
+      lastError: expect.stringContaining('Cannot reach MCP server'),
+    });
+  });
+
+  it('serializes discovery per server without poisoning the queue after failure', async () => {
+    const firstInitialize = deferred<Response>();
+    let initializeCount = 0;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as { id?: string; method: string };
+      if (request.method === 'initialize') {
+        initializeCount += 1;
+        if (initializeCount === 1) return firstInitialize.promise;
+        return new Response(JSON.stringify({
+          jsonrpc: '2.0',
+          id: request.id ?? null,
+          result: { protocolVersion: MCP_PROTOCOL_VERSION, capabilities: { tools: {} } },
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (request.method === 'notifications/initialized') {
+        return new Response(null, { status: 202 });
+      }
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: request.id ?? null,
+        result: {
+          tools: [{
+            name: 'queued_tool',
+            description: 'Discovered after the failed refresh.',
+            inputSchema: { type: 'object', properties: {} },
+          }],
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const server = await createMcpServer({
+      displayName: 'Queued MCP',
+      enabled: true,
+      transport: { kind: 'http', url: 'http://127.0.0.1:48128/mcp' },
+    });
+
+    const first = refreshMcpServerDiscovery(server.id);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const second = refreshMcpServerDiscovery(server.id);
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    firstInitialize.reject(new TypeError('first refresh failed'));
+
+    await expect(first).resolves.toMatchObject({ health: { status: 'error' } });
+    await expect(second).resolves.toMatchObject({
+      descriptors: [expect.objectContaining({ name: 'queued_tool' })],
+      health: { status: 'ready', toolCount: 1 },
+    });
+    await expect(getMcpToolCache(server.id)).resolves.toMatchObject({
+      descriptors: [expect.objectContaining({ name: 'queued_tool' })],
+      health: { status: 'ready' },
+    });
+  });
+
   it('initializes Streamable HTTP sessions before executing cached tools', async () => {
     const requests: Array<{ method: string; headers: Headers }> = [];
     vi.stubGlobal('fetch', vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -342,4 +440,14 @@ function createMcpDescriptor(server: McpServerConfig, name = 'sample_tool'): Too
       maxResultBytes: 64_000,
     },
   };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
 }

--- a/tests/platform-external-contract.test.ts
+++ b/tests/platform-external-contract.test.ts
@@ -84,7 +84,28 @@ describe('external platform capability contract', () => {
         code: 'mcp_origin_permission_denied',
         retryable: false,
       });
-    expect(request).toHaveBeenCalledWith({ origins: ['https://mcp.example.test/*'] });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when MCP host permission cannot be checked', async () => {
+    vi.stubGlobal('chrome', { permissions: {} });
+    await expect(ensureMcpServerOriginPermission(mcpServer())).rejects.toMatchObject({
+      code: 'mcp_origin_permission_check_unavailable',
+      retryable: false,
+    });
+
+    vi.stubGlobal('chrome', {
+      permissions: {
+        contains: vi.fn(async () => {
+          throw new Error('Extension context invalidated');
+        }),
+      },
+    });
+    await expect(ensureMcpServerOriginPermission(mcpServer())).rejects.toMatchObject({
+      code: 'mcp_origin_permission_check_failed',
+      retryable: true,
+      message: expect.stringContaining('Extension context invalidated'),
+    });
   });
 
   it('matches manifest-backed capabilities while unloaded and unknown environments fail closed', () => {

--- a/tests/request-augmentation-boundary.test.ts
+++ b/tests/request-augmentation-boundary.test.ts
@@ -7,11 +7,16 @@ describe('Content request augmentation boundary', () => {
     const start = source.indexOf('async function handleAugmentRequestBody');
     const end = source.indexOf('\nasync function resolveProjectContextForRequestBody', start);
     const handler = source.slice(start, end);
-    const decodeIndex = handler.indexOf('decodeDeepSeekRequestBody(data.body)');
+    const decodeIndex = handler.indexOf('decodeAugmentableDeepSeekRequestBody(data.body)');
+    const passthroughIndex = handler.indexOf('if (!decodedBody)');
+    const correlationIndex = handler.indexOf('pendingToolAuthorizationCorrelations.begin');
 
     expect(start).toBeGreaterThanOrEqual(0);
     expect(end).toBeGreaterThan(start);
     expect(decodeIndex).toBeGreaterThanOrEqual(0);
+    expect(passthroughIndex).toBeGreaterThan(decodeIndex);
+    expect(handler.slice(passthroughIndex, correlationIndex)).toContain("type: 'AUGMENT_REQUEST_BODY_RESULT'");
+    expect(handler.slice(passthroughIndex, correlationIndex)).toContain('result: null');
     for (const privilegedOperation of [
       'pendingToolAuthorizationCorrelations.begin',
       'consumePendingMultimodalMediaForRequest',

--- a/tests/request-augmentation.test.ts
+++ b/tests/request-augmentation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { DEFAULT_TOOL_DESCRIPTORS } from '../core/tool';
 import {
   augmentRequestBody,
+  decodeAugmentableDeepSeekRequestBody,
   decodeDeepSeekRequestBody,
 } from '../core/interceptor/request-augmentation';
 import { buildPromptAugmentation } from '../core/prompt';
@@ -22,6 +23,16 @@ describe('augmentRequestBody', () => {
     expect(() => decodeDeepSeekRequestBody('[]')).toThrow('plain object');
     expect(() => decodeDeepSeekRequestBody(JSON.stringify({ prompt: 1 }))).toThrow('non-empty string');
     expect(() => decodeDeepSeekRequestBody(JSON.stringify({ prompt: '' }))).toThrow('non-empty string');
+  });
+
+  it('treats request shapes that cannot be augmented as explicit passthroughs', () => {
+    expect(decodeAugmentableDeepSeekRequestBody(JSON.stringify({
+      prompt: 'hello',
+      future_sibling: true,
+    }))).toEqual({ prompt: 'hello', future_sibling: true });
+    expect(decodeAugmentableDeepSeekRequestBody('{bad json}')).toBeNull();
+    expect(decodeAugmentableDeepSeekRequestBody(JSON.stringify({ prompt: '' }))).toBeNull();
+    expect(decodeAugmentableDeepSeekRequestBody(JSON.stringify({ prompt: 1 }))).toBeNull();
   });
 
   it('does not hide augmentation failures after the request body has decoded', () => {

--- a/tests/shell-host-local-skill-preview.test.ts
+++ b/tests/shell-host-local-skill-preview.test.ts
@@ -67,10 +67,14 @@ describe('shell native host local_folder_pick', () => {
 
 describe('shell native host startup', () => {
   it('does not block the host event loop on Windows PATH discovery', () => {
+    const hostSource = readFileSync(hostPath, 'utf8');
     const source = readFileSync(osAdapterPath, 'utf8');
 
     expect(source).toContain("import { execFile } from 'node:child_process';");
     expect(source).not.toContain('execFileSync');
+    expect(hostSource).toContain('const hostEnvironmentReady = Promise.resolve(');
+    expect(hostSource).toContain('createNativeEnvelopeDispatcher({');
+    expect(hostSource).toContain('hostEnvironmentReady,');
   });
 });
 

--- a/tests/shell-host-local-skill-preview.test.ts
+++ b/tests/shell-host-local-skill-preview.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 const testDir = dirname(fileURLToPath(import.meta.url));
 const hostPath = resolve(testDir, '../packages/shell-host/native/shell-mcp-host.mjs');
 const pickerProviderPath = resolve(testDir, '../packages/shell-host/native/picker-provider.mjs');
+const osAdapterPath = resolve(testDir, '../packages/shell-host/native/os-adapter.mjs');
 const tempRoots: string[] = [];
 
 afterEach(() => {
@@ -55,10 +56,21 @@ describe('shell native host local_folder_pick', () => {
   it('keeps Windows folder picker arguments out of the PowerShell command text', () => {
     const source = readFileSync(pickerProviderPath, 'utf8');
 
+    expect(source).toContain("import { execFile } from 'node:child_process';");
+    expect(source).not.toContain('execFileSync');
     expect(source).toContain("'-EncodedCommand', encodePowerShellCommand(script)");
     expect(source).toContain('DPP_FOLDER_PICK_TITLE');
     expect(source).toContain('DPP_FOLDER_PICK_DEFAULT_PATH');
     expect(source).not.toContain("'-Command', script, title");
+  });
+});
+
+describe('shell native host startup', () => {
+  it('does not block the host event loop on Windows PATH discovery', () => {
+    const source = readFileSync(osAdapterPath, 'utf8');
+
+    expect(source).toContain("import { execFile } from 'node:child_process';");
+    expect(source).not.toContain('execFileSync');
   });
 });
 

--- a/tests/shell-host-runtime-modules.test.ts
+++ b/tests/shell-host-runtime-modules.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { PassThrough } from 'node:stream';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 // @ts-ignore - Shell Host runtime modules are executable .mjs files.
 import { copyHostRuntime } from '../packages/shell-host/lib/installer.mjs';
 // @ts-ignore - Shell Host runtime modules are executable .mjs files.
@@ -12,6 +12,8 @@ import { REQUIRED_HOST_RUNTIME_FILES, getMissingHostRuntimeFiles } from '../pack
 import { createNativeMessageChannel, NATIVE_EOF } from '../packages/shell-host/native/framing.mjs';
 // @ts-ignore - Shell Host runtime modules are executable .mjs files.
 import { createToolRegistry } from '../packages/shell-host/native/router.mjs';
+// @ts-ignore - Shell Host runtime modules are executable .mjs files.
+import { createNativeEnvelopeDispatcher } from '../packages/shell-host/native/runtime-dispatcher.mjs';
 
 const tempRoots: string[] = [];
 const shellPackage = readJson(resolve('packages/shell-host/package.json'));
@@ -193,7 +195,64 @@ describe('Shell Host modular runtime ownership', () => {
 
     expect(responses.map((response) => response.id)).toEqual(['tools', 'slow']);
   });
+
+  it('serves control requests while tool calls wait for host environment readiness', async () => {
+    const environmentReady = deferred<void>();
+    const handled: string[] = [];
+    const responses: Array<{ id: string }> = [];
+    const dispatcher = createNativeEnvelopeDispatcher({
+      hostEnvironmentReady: environmentReady.promise,
+      logger: { logLine: vi.fn() },
+      router: {
+        async handleEnvelope(envelope: { message: { id: string } }) {
+          handled.push(envelope.message.id);
+          return { id: envelope.message.id };
+        },
+      },
+      channel: {
+        async writeMessage(response: { id: string }) {
+          responses.push(response);
+        },
+      },
+    });
+
+    dispatcher.scheduleEnvelope(createHostEnvelope('tool-1', 'tools/call'));
+    dispatcher.scheduleEnvelope(createHostEnvelope('tool-2', 'tools/call'));
+    dispatcher.scheduleEnvelope(createHostEnvelope('control', 'tools/list'));
+
+    await vi.waitFor(() => expect(responses).toEqual([{ id: 'control' }]));
+    expect(handled).toEqual(['control']);
+
+    environmentReady.resolve();
+    await dispatcher.settle();
+
+    expect(handled).toEqual(['control', 'tool-1', 'tool-2']);
+    expect(responses).toEqual([
+      { id: 'control' },
+      { id: 'tool-1' },
+      { id: 'tool-2' },
+    ]);
+  });
 });
+
+function createHostEnvelope(id: string, method: string) {
+  return {
+    protocol: 'deepseek-pp-mcp-native',
+    version: 1,
+    server: { id: 'readiness-runtime' },
+    message: { jsonrpc: '2.0', id, method },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 function createNativeFrame(message: unknown): Buffer {
   const body = Buffer.from(JSON.stringify(message), 'utf8');

--- a/tests/shell-host-runtime-modules.test.ts
+++ b/tests/shell-host-runtime-modules.test.ts
@@ -168,6 +168,31 @@ describe('Shell Host modular runtime ownership', () => {
       },
     });
   });
+
+  it('serves control requests while a long tool call remains in the tool FIFO', async () => {
+    const command = process.platform === 'win32' ? 'Start-Sleep -Milliseconds 1200' : 'sleep 1.2';
+    const responses = await callHostResponses(resolve('packages/shell-host/native/shell-mcp-host.mjs'), [
+      {
+        protocol: 'deepseek-pp-mcp-native',
+        version: 1,
+        server: { id: 'concurrent-runtime' },
+        message: {
+          jsonrpc: '2.0',
+          id: 'slow',
+          method: 'tools/call',
+          params: { name: 'shell_exec', arguments: { command, timeout_ms: 3_000 } },
+        },
+      },
+      {
+        protocol: 'deepseek-pp-mcp-native',
+        version: 1,
+        server: { id: 'concurrent-runtime' },
+        message: { jsonrpc: '2.0', id: 'tools', method: 'tools/list' },
+      },
+    ]);
+
+    expect(responses.map((response) => response.id)).toEqual(['tools', 'slow']);
+  });
 });
 
 function createNativeFrame(message: unknown): Buffer {
@@ -208,6 +233,39 @@ function callHost(hostPath: string, envelope: unknown): Promise<any> {
       });
     });
     child.stdin.end(createNativeFrame(envelope));
+  });
+}
+
+function callHostResponses(hostPath: string, envelopes: unknown[]): Promise<any[]> {
+  const child = spawn(process.execPath, [hostPath], { stdio: ['pipe', 'pipe', 'pipe'] });
+  return new Promise((resolveResponses, reject) => {
+    let stdout = Buffer.alloc(0);
+    const responses: any[] = [];
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error('Timed out waiting for concurrent Shell Host responses.'));
+    }, 5_000);
+    const finish = (callback: () => void) => {
+      clearTimeout(timer);
+      child.kill();
+      callback();
+    };
+    child.on('error', (error) => finish(() => reject(error)));
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout = Buffer.concat([stdout, chunk]);
+      while (stdout.length >= 4) {
+        const length = stdout.readUInt32LE(0);
+        if (stdout.length < length + 4) return;
+        const body = stdout.subarray(4, length + 4).toString('utf8');
+        stdout = stdout.subarray(length + 4);
+        responses.push(JSON.parse(body));
+        if (responses.length === envelopes.length) {
+          finish(() => resolveResponses(responses));
+          return;
+        }
+      }
+    });
+    child.stdin.end(Buffer.concat(envelopes.map(createNativeFrame)));
   });
 }
 

--- a/tests/sidepanel-mcp-tools-controller.test.ts
+++ b/tests/sidepanel-mcp-tools-controller.test.ts
@@ -93,19 +93,41 @@ describe('sidepanel MCP and Tools controller', () => {
 
   it('owns permission-before-connect policy and does not retry after denial', async () => {
     const sendMessage = vi.fn(async (request: { type: string }) => {
-      if (request.type === 'REQUEST_MCP_SERVER_PERMISSION') {
-        return { ok: false, origin: 'https://example.test/*' };
-      }
       if (request.type === 'REFRESH_MCP_SERVER_TOOLS') return cache;
       throw new Error(`Unexpected command: ${request.type}`);
     });
-    const controller = createMcpToolsController(createSidepanelRuntimeClient(sendMessage));
+    const permissions = { request: vi.fn(async () => false) };
+    const controller = createMcpToolsController(
+      createSidepanelRuntimeClient(sendMessage),
+      permissions,
+    );
 
     await expect(controller.connectServer(server, 'refresh')).rejects.toMatchObject({
       name: 'McpPermissionError',
       origin: 'https://example.test/*',
     } satisfies Partial<McpPermissionError>);
-    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(permissions.request).toHaveBeenCalledWith(['https://example.test/*']);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('requests MCP permission directly from the sidepanel before refreshing tools', async () => {
+    const sendMessage = vi.fn(async (request: { type: string }) => {
+      if (request.type === 'REFRESH_MCP_SERVER_TOOLS') return cache;
+      throw new Error(`Unexpected command: ${request.type}`);
+    });
+    const permissions = { request: vi.fn(async () => true) };
+    const controller = createMcpToolsController(
+      createSidepanelRuntimeClient(sendMessage),
+      permissions,
+    );
+
+    await expect(controller.connectServer(server, 'refresh')).resolves.toEqual(cache);
+    expect(permissions.request).toHaveBeenCalledWith(['https://example.test/*']);
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: 'REFRESH_MCP_SERVER_TOOLS',
+      payload: { serverId: server.id },
+    });
   });
 
   it('requests host permission directly from the sidepanel click boundary', async () => {


### PR DESCRIPTION
## Summary

- let non-augmentable DeepSeek request bodies pass through unchanged instead of failing the original request (#441)
- request MCP host permissions directly from the Side Panel user gesture and keep the background command as a contains-only compatibility check (#442)
- serialize discovery per MCP server and preserve the last successful tool descriptors when a refresh fails (#442, #445)
- keep the Shell Native Host responsive to control requests while long tool calls are running, serialize native output frames, and remove blocking picker/PATH probes (#442)

## Scope

This PR does not claim to resolve #444 or the broad stability report #451. #444 was reported on v1.11.3 and needs a current-version retest; #451 needs narrower reproduction evidence.

## Validation

- `npm test -- --reporter=dot` — 173 files / 1263 tests passed
- `npm run compile`
- `npm run prompt:freeze`
- `npm run build:all`
- `npm run verify:manifest-policy`
- `npm run verify:extension-utf8`
- `npm run verify:sidepanel-chunks`
- `npm run smoke:mcp`
- `npm run verify:mcp:mock`
- `npm run smoke:shell`
- `npm pack --dry-run --workspace packages/shell-host`
