### PR TITLE
fix: serialize sync generation staging

### DIFF
--- a/core/sync/generation.ts
+++ b/core/sync/generation.ts
@@ -84,15 +84,22 @@ export async function uploadSyncGeneration(
   };
   const pointerContent = JSON.stringify(pointer);
 
-  const stagedWrites = await Promise.allSettled(sourceFiles.map(async (sourceFile) => {
-    await backend.put(
-      getSyncGenerationFileKey(generationId, sourceFile.key),
-      sourceFile.content,
-    );
-  }));
-  const stagedFailures = stagedWrites.flatMap((result, index) => result.status === 'rejected'
-    ? [{ key: sourceFiles[index].key, reason: result.reason }]
-    : []);
+  // Keep staging writes ordered. Some WebDAV and cloud backends apply a very
+  // small write-concurrency limit; parallel payload uploads can otherwise
+  // reject one member of a complete generation with a transient 503. We still
+  // attempt every payload so an error reports the full staging outcome, but a
+  // failure prevents both manifest and current-pointer publication.
+  const stagedFailures: Array<{ key: SyncFileKey; reason: unknown }> = [];
+  for (const sourceFile of sourceFiles) {
+    try {
+      await backend.put(
+        getSyncGenerationFileKey(generationId, sourceFile.key),
+        sourceFile.content,
+      );
+    } catch (reason) {
+      stagedFailures.push({ key: sourceFile.key, reason });
+    }
+  }
   if (stagedFailures.length > 0) {
     const detail = stagedFailures
       .map(({ key, reason }) => `${key}: ${errorMessage(reason)}`)

--- a/tests/sync-generation.test.ts
+++ b/tests/sync-generation.test.ts
@@ -123,6 +123,28 @@ describe('sync generation publication', () => {
     );
   });
 
+  it('serializes staging writes before publishing the generation', async () => {
+    let activeWrites = 0;
+    let maximumActiveWrites = 0;
+    const backend: StorageBackend = {
+      async test() {},
+      async ensureStore() {},
+      async get() { return null; },
+      async put() {
+        activeWrites += 1;
+        maximumActiveWrites = Math.max(maximumActiveWrites, activeWrites);
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+        activeWrites -= 1;
+      },
+    };
+
+    await expect(uploadSyncGeneration(backend, sourceFiles('serialized'), {
+      now: () => CREATED_AT,
+      createGenerationId: () => GENERATION_ID,
+    })).resolves.toBeDefined();
+    expect(maximumActiveWrites).toBe(1);
+  });
+
   it('turns a synchronous backend throw into one settled staged failure', async () => {
     const putCalls: string[] = [];
     const backend: StorageBackend = {


### PR DESCRIPTION
Fixes #456

## Summary

Serialize the six generation payload uploads before publishing the manifest and `sync-current.json` pointer.

## Root cause

Generation staging issued all payload writes concurrently. Backends with a small write-concurrency limit could reject an individual file with HTTP 503, even though the generation must be complete before it can be published.

## Behavior

- Stages one payload at a time while retaining full error aggregation.
- Any staging failure still prevents manifest and current-pointer publication.
- Adds a regression test proving staging writes do not overlap.

## Validation

- `npm test -- --run tests/sync-generation.test.ts tests/sync-cloud-backends.test.ts tests/sync-operation-coordinator.test.ts`
- `npm run compile`
- `npm run build:all`