### PR TITLE
fix: serialize sync generation downloads

### DIFF
--- a/core/sync/generation.ts
+++ b/core/sync/generation.ts
@@ -134,7 +134,12 @@ export async function readCurrentSyncGeneration(
     throw new Error('Sync generation pointer and manifest IDs do not match');
   }
 
-  const contents = await Promise.all(manifest.files.map(async (file) => {
+  // Read the generation in the same bounded order as it was staged. A
+  // low-concurrency WebDAV or cloud backend can reject one of six simultaneous
+  // payload reads with a transient 503. All files are still validated before
+  // this complete snapshot is returned to the local-apply caller.
+  const contents = new Map<SyncFileKey, string>();
+  for (const file of manifest.files) {
     const remoteKey = getSyncGenerationFileKey(manifest.generationId, file.key);
     const content = await backend.get(remoteKey);
     if (content === null) throw new Error(`Sync generation file is missing: ${file.key}`);
@@ -143,10 +148,10 @@ export async function readCurrentSyncGeneration(
       throw new Error(`Sync generation file size does not match: ${file.key}`);
     }
     await assertSha256Checksum(`Sync generation file ${file.key}`, content, file.checksum);
-    return [file.key, content] as const;
-  }));
+    contents.set(file.key, content);
+  }
 
-  return new Map(contents);
+  return contents;
 }
 
 async function createFileRecord(sourceFile: SyncGenerationSourceFile): Promise<SyncGenerationFileRecord> {

--- a/tests/sync-generation.test.ts
+++ b/tests/sync-generation.test.ts
@@ -198,6 +198,26 @@ describe('sync generation publication', () => {
 });
 
 describe('sync generation reader', () => {
+  it('serializes generation payload reads', async () => {
+    const backend = await publishedBackend();
+    const originalGet = backend.get.bind(backend);
+    let activeReads = 0;
+    let maximumActiveReads = 0;
+    backend.get = async (key) => {
+      activeReads += 1;
+      maximumActiveReads = Math.max(maximumActiveReads, activeReads);
+      await new Promise<void>((resolve) => queueMicrotask(resolve));
+      try {
+        return await originalGet(key);
+      } finally {
+        activeReads -= 1;
+      }
+    };
+
+    await expect(readCurrentSyncGeneration(backend)).resolves.toBeDefined();
+    expect(maximumActiveReads).toBe(1);
+  });
+
   it('reads the independent raw schema-v1 generation fixture', async () => {
     const backend = new MemoryStorageBackend();
     for (const file of SYNC_GENERATION_V1_FIXTURE.files) {


### PR DESCRIPTION
## Summary

Serialize generation payload downloads after validating the current pointer and manifest. This completes the upload-side concurrency fix from #463 for the matching download path.

Fixes #456.

## PR Type

- [ ] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

`422ab8af5325d903e5ada19f7d4e6654cbd7d1af`

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

OpenAI GPT-5

Coding Agent tool(s) used:

Codex

## Root Cause

The reader still fetched all six generation payloads with `Promise.all`. A low-concurrency WebDAV or cloud backend can return HTTP 503 for one payload, as reported for `saved-items.json`.

## Behavior

- Reads and validates one generation payload at a time.
- Preserves the complete-snapshot boundary: no local application receives data until every payload has passed byte-length and checksum validation.
- Adds a regression test proving reads do not overlap.

## Local Validation

Commands run:

```bash
npm test -- --run tests/sync-generation.test.ts tests/sync-cloud-backends.test.ts tests/sync-operation-coordinator.test.ts
npm run compile
npm run build:all
```

Result summary:

All 61 targeted sync tests passed. TypeScript compilation passed. Chrome, Edge, and Firefox production builds passed.

## Local Feature Evidence

Evidence:

N/A — this is an internal sync transport reliability fix with no new UI or user interaction surface.