### PR TITLE
fix: prevent IME Enter from submitting floating chat

### DIFF
--- a/entrypoints/sidepanel/chat-composer.ts
+++ b/entrypoints/sidepanel/chat-composer.ts
@@ -1,0 +1,13 @@
+export interface ChatComposerKeydown {
+  key: string;
+  shiftKey: boolean;
+  isComposing: boolean;
+  keyCode: number;
+}
+
+export function shouldSubmitChatComposer(event: ChatComposerKeydown): boolean {
+  return event.key === 'Enter' &&
+    !event.shiftKey &&
+    !event.isComposing &&
+    event.keyCode !== 229;
+}

--- a/entrypoints/sidepanel/pages/ChatPage.tsx
+++ b/entrypoints/sidepanel/pages/ChatPage.tsx
@@ -26,6 +26,7 @@ import type { ChatMessage as ChatMessageType, ModelType } from '../../../core/ty
 import ChatMessage from '../components/ChatMessage';
 import { StatusMessage, useConfirm } from '../components/settings/feedback-primitives';
 import { createRequestGenerationFence } from '../async-state';
+import { shouldSubmitChatComposer } from '../chat-composer';
 import {
   chatController,
   getChatProviderCapabilities,
@@ -508,7 +509,12 @@ export default function ChatPage() {
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (shouldSubmitChatComposer({
+      key: e.key,
+      shiftKey: e.shiftKey,
+      isComposing: e.nativeEvent.isComposing,
+      keyCode: e.keyCode,
+    })) {
       e.preventDefault();
       sendMessage();
     }

--- a/tests/sidepanel-chat-composer.test.ts
+++ b/tests/sidepanel-chat-composer.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { shouldSubmitChatComposer } from '../entrypoints/sidepanel/chat-composer';
+
+describe('sidepanel chat composer keyboard handling', () => {
+  it('submits a plain Enter key press', () => {
+    expect(shouldSubmitChatComposer({
+      key: 'Enter',
+      shiftKey: false,
+      isComposing: false,
+      keyCode: 13,
+    })).toBe(true);
+  });
+
+  it('does not submit while an IME composition is active', () => {
+    expect(shouldSubmitChatComposer({
+      key: 'Enter',
+      shiftKey: false,
+      isComposing: true,
+      keyCode: 13,
+    })).toBe(false);
+  });
+
+  it('does not submit legacy IME key events reported with keyCode 229', () => {
+    expect(shouldSubmitChatComposer({
+      key: 'Enter',
+      shiftKey: false,
+      isComposing: false,
+      keyCode: 229,
+    })).toBe(false);
+  });
+
+  it('keeps Shift+Enter and non-Enter keys as editor input', () => {
+    expect(shouldSubmitChatComposer({
+      key: 'Enter',
+      shiftKey: true,
+      isComposing: false,
+      keyCode: 13,
+    })).toBe(false);
+    expect(shouldSubmitChatComposer({
+      key: 'a',
+      shiftKey: false,
+      isComposing: false,
+      keyCode: 65,
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Ignore Enter keydown events while the floating-chat textarea is in an IME composition.
- Keep a `keyCode === 229` fallback for browser IME events that do not expose `isComposing`.
- Preserve plain Enter submission and Shift+Enter line breaks.

Fixes #465.

## PR Type

- [ ] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

`b23bb78ec05b022500102942ee709fa24bcb3c4a`

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

OpenAI GPT-5.6

Coding Agent tool(s) used:

Codex

## Root Cause

The floating chat reuses the sidepanel `ChatPage` composer. Its keydown handler submitted every unshifted Enter event without checking whether the browser was using that event to confirm an IME composition.

## Behavior

- IME composition Enter events remain editor input.
- Legacy IME events reported with key code 229 remain editor input.
- Plain Enter still submits, and Shift+Enter still inserts a line break.

## Local Validation

Commands run:

```bash
vitest run tests/sidepanel-chat-composer.test.ts
npm run compile
npm run build:all
```

Result summary:

All 4 targeted composer tests passed. TypeScript compilation passed. Chrome, Edge, and Firefox production builds passed.

## Local Feature Evidence

Evidence:

N/A — this is a focused keyboard-event bug fix with no new UI surface; deterministic IME composition regression coverage is included.