### PR TITLE
fix: accept CRLF in MCP SSE streams

### DIFF
--- a/core/mcp/transports/common.ts
+++ b/core/mcp/transports/common.ts
@@ -246,15 +246,18 @@ export interface SseEvent {
 }
 
 export function drainSseEvents(buffer: string): { events: SseEvent[]; remainder: string } {
-  const boundary = buffer.lastIndexOf('\n\n');
-  if (boundary === -1) return { events: [], remainder: buffer };
-  const complete = buffer.slice(0, boundary);
-  const remainder = buffer.slice(boundary + 2);
-  const events = complete
-    .split('\n\n')
-    .map(parseSseEvent)
-    .filter((event): event is SseEvent => event !== null);
-  return { events, remainder };
+  const events: SseEvent[] = [];
+  const boundaryPattern = /(?:\r\n|\r(?!\n)|\n)(?:\r\n|\r(?!\n)|\n)/g;
+  let blockStart = 0;
+  let boundary: RegExpExecArray | null;
+
+  while ((boundary = boundaryPattern.exec(buffer)) !== null) {
+    const event = parseSseEvent(buffer.slice(blockStart, boundary.index));
+    if (event) events.push(event);
+    blockStart = boundary.index + boundary[0].length;
+  }
+
+  return { events, remainder: buffer.slice(blockStart) };
 }
 
 export function normalizeJsonRpcResponse<TResult>(
@@ -364,7 +367,7 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function parseSseEvent(block: string): SseEvent | null {
-  const lines = block.split('\n');
+  const lines = block.split(/\r\n|\r|\n/);
   let event = 'message';
   const data: string[] = [];
   for (const line of lines) {

--- a/tests/mcp-transport-common.test.ts
+++ b/tests/mcp-transport-common.test.ts
@@ -2,18 +2,109 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   MCP_PROTOCOL_VERSION,
   createMcpRequest,
+  createMcpSseTransport,
   createMcpTransport,
   createMcpStreamableHttpTransport,
   initializeMcpServer,
   type McpServerConfig,
 } from '../core/mcp';
-import { McpTransportError, readJsonRpcResponse } from '../core/mcp/transports/common';
+import {
+  McpTransportError,
+  drainSseEvents,
+  readJsonRpcResponse,
+} from '../core/mcp/transports/common';
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe('MCP transport response limits', () => {
+  it('parses SSE events with LF, CRLF, and CR line endings', () => {
+    for (const lineEnding of ['\n', '\r\n', '\r']) {
+      expect(drainSseEvents([
+        'event: endpoint',
+        'data: /messages?session_id=line-endings',
+        '',
+        '',
+      ].join(lineEnding))).toEqual({
+        events: [{
+          event: 'endpoint',
+          data: '/messages?session_id=line-endings',
+        }],
+        remainder: '',
+      });
+    }
+  });
+
+  it('handles CRLF endpoint and response events split across stream chunks', async () => {
+    vi.stubGlobal('chrome', {
+      permissions: {
+        contains: vi.fn(async () => true),
+        request: vi.fn(async () => true),
+      },
+    });
+
+    const encoder = new TextEncoder();
+    let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
+    const requests: Array<{ url: string; method: string; body: unknown }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      if (method === 'GET') {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            streamController = controller;
+            controller.enqueue(encoder.encode('event: endpoint\r'));
+            controller.enqueue(encoder.encode('\ndata: /messages?session_id=crlf\r\n\r\n'));
+          },
+        });
+        return new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      }
+
+      const request = JSON.parse(String(init?.body));
+      requests.push({ url: String(input), method, body: request });
+      const response = {
+        jsonrpc: '2.0',
+        id: request.id,
+        result: { protocolVersion: MCP_PROTOCOL_VERSION, capabilities: { tools: {} } },
+      };
+      streamController?.enqueue(encoder.encode([
+        'event: message',
+        `data: ${JSON.stringify(response)}`,
+        '',
+        '',
+      ].join('\r\n')));
+      streamController?.close();
+      return new Response(null, { status: 202 });
+    }));
+
+    const server = {
+      ...createServerConfig(),
+      transport: {
+        kind: 'sse' as const,
+        url: 'http://127.0.0.1:48123/sse',
+      },
+    };
+    const request = createMcpRequest('initialize', {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: { tools: {} },
+      clientInfo: { name: 'test', version: '0.0.0' },
+    });
+
+    await expect(createMcpSseTransport(server).request(request)).resolves.toMatchObject({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: { protocolVersion: MCP_PROTOCOL_VERSION },
+    });
+    expect(requests).toEqual([{
+      url: 'http://127.0.0.1:48123/messages?session_id=crlf',
+      method: 'POST',
+      body: request,
+    }]);
+  });
+
   it('fails before parsing oversized JSON-RPC HTTP bodies', async () => {
     const body = JSON.stringify({ jsonrpc: '2.0', id: '1', result: { text: 'too large' } });
     const response = new Response(body, {


### PR DESCRIPTION
## Summary

- Parse MCP SSE event boundaries using LF, CRLF, or CR line endings.
- Avoid treating the two bytes of one CRLF as two separate blank lines.
- Cover CRLF boundaries split across network chunks.
- Verify the legacy SSE endpoint flow resolves a relative POST URL and receives the matching CRLF response.

Refs #469.

## PR Type

- [ ] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

`b23bb78ec05b022500102942ee709fa24bcb3c4a`

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

OpenAI GPT-5.6

Coding Agent tool(s) used:

Codex

## Root Cause

The shared MCP SSE parser only drained events separated by `\n\n`. Servers emitting standard CRLF-delimited events left the endpoint event buffered until the stream ended, producing `MCP SSE stream did not provide a POST endpoint.` The same parser is used for Streamable HTTP SSE responses.

## Behavior

- Accepts LF, CRLF, CR, and mixed standard SSE line endings.
- Preserves incomplete event data across network chunks.
- Resolves the advertised relative POST endpoint before sending JSON-RPC.

## Local Validation

Commands run:

```bash
vitest run tests/mcp-transport-common.test.ts
npm run compile
npm run smoke:mcp
npm run verify:mcp:mock
npm run build:all
```

Result summary:

All 9 targeted MCP transport tests passed. TypeScript compilation, MCP smoke, MCP live mock, and Chrome, Edge, and Firefox production builds passed.

## Local Feature Evidence

Evidence:

N/A — this is an internal MCP transport compatibility fix with no new UI or user interaction surface.

## Follow-up

This addresses the concrete shared SSE parsing defect. The reporter's direct Streamable HTTP timeout and local proxy HTTP 400 still need verification against the private endpoint before treating them as the same failure.