### PR TITLE
Fix inflated model output speed statistics

### DIFF
--- a/core/deepseek/stream-metrics.ts
+++ b/core/deepseek/stream-metrics.ts
@@ -72,13 +72,6 @@ export function createResponseTokenSpeedTracker(
     return Number.isFinite(elapsedMs) && elapsedMs > 0 ? elapsedMs : null;
   };
 
-  const getServerTokensPerSecond = (): number | null => {
-    if (serverAccumulatedTokens === null) return null;
-    const elapsedMs = getServerElapsedMs();
-    if (elapsedMs === null) return null;
-    return (serverAccumulatedTokens / elapsedMs) * 1000;
-  };
-
   const emit = (active: boolean, force = false) => {
     if (finished && active) return;
 
@@ -87,18 +80,20 @@ export function createResponseTokenSpeedTracker(
     lastEmitAt = now;
 
     const estimatedTokens = Math.round(totalTokenUnits);
-    const serverTokensPerSecond = getServerTokensPerSecond();
     const serverElapsedMs = getServerElapsedMs();
     const elapsedMs = serverElapsedMs ?? Math.max(now - startedAt, 1);
     onProgress({
       active,
       estimatedTokens,
       accumulatedTokens: serverAccumulatedTokens === null ? null : Math.round(serverAccumulatedTokens),
-      tokensPerSecond: serverTokensPerSecond ?? getAverageTokensPerSecond(now),
+      // DeepSeek's accumulated usage includes prompt/context tokens. Keep it
+      // for total-usage reporting, but never use it as decoded output when
+      // calculating generation speed.
+      tokensPerSecond: getAverageTokensPerSecond(now),
       elapsedMs: Math.round(elapsedMs),
       textLength,
       tokenSource: serverAccumulatedTokens === null ? 'estimated' : 'server',
-      speedSource: serverTokensPerSecond === null ? 'estimated' : 'server',
+      speedSource: 'estimated',
       modelType,
     });
   };

--- a/tests/deepseek-adapter-stream.test.ts
+++ b/tests/deepseek-adapter-stream.test.ts
@@ -123,12 +123,12 @@ describe('DeepSeek web adapter streaming', () => {
       active: false,
       accumulatedTokens: 3302,
       tokenSource: 'server',
-      speedSource: 'server',
+      speedSource: 'estimated',
       modelType: 'vision',
       chatSessionId: 'session-1',
       assistantMessageId: 2,
     });
-    expect(final?.tokensPerSecond).toBeCloseTo(3302 / 3.11, 5);
+    expect(final?.tokensPerSecond).toBeCloseTo(1.5, 5);
   });
 
   it('creates PoW headers for the requested DeepSeek target path', async () => {

--- a/tests/token-speed.test.ts
+++ b/tests/token-speed.test.ts
@@ -80,23 +80,25 @@ describe('createResponseTokenSpeedTracker', () => {
     tracker.finish();
   });
 
-  it('uses server token usage and server timestamps when available', () => {
+  it('keeps output speed based on streamed output when server usage includes context tokens', () => {
     const { tracker, payloads, advanceTo } = setupTracker();
     advanceTo(100);
     tracker.updateServerStats({ modelType: 'vision', insertedAt: 1000 });
-    tracker.append('hello world');
-    tracker.updateServerStats({ accumulatedTokenUsage: 3302 });
+    tracker.append('你好');
+    advanceTo(1100);
+    tracker.append('世界');
+    tracker.updateServerStats({ accumulatedTokenUsage: 49_794 });
     tracker.finish();
     tracker.updateServerStats({ updatedAt: 1003.11 });
 
     const final = payloads[payloads.length - 1];
     expect(final.active).toBe(false);
     expect(final.modelType).toBe('vision');
-    expect(final.accumulatedTokens).toBe(3302);
+    expect(final.accumulatedTokens).toBe(49_794);
     expect(final.tokenSource).toBe('server');
-    expect(final.speedSource).toBe('server');
+    expect(final.speedSource).toBe('estimated');
     expect(final.elapsedMs).toBe(3110);
-    expect(final.tokensPerSecond).toBeCloseTo(3302 / 3.11, 5);
+    expect(final.tokensPerSecond).toBeCloseTo(1.2, 5);
   });
 
   it('keeps estimated TPS until the server time window is complete', () => {
@@ -117,7 +119,7 @@ describe('createResponseTokenSpeedTracker', () => {
     expect(final.tokensPerSecond).toBeCloseTo(1.2, 5);
   });
 
-  it('handles server token usage and completion time from the same stats patch', () => {
+  it('does not turn server usage into output speed without streamed output', () => {
     const { tracker, payloads } = setupTracker();
     tracker.updateServerStats({ insertedAt: 2000 });
     tracker.finish();
@@ -125,8 +127,8 @@ describe('createResponseTokenSpeedTracker', () => {
 
     const final = payloads[payloads.length - 1];
     expect(final.accumulatedTokens).toBe(120);
-    expect(final.speedSource).toBe('server');
-    expect(final.tokensPerSecond).toBe(60);
+    expect(final.speedSource).toBe('estimated');
+    expect(final.tokensPerSecond).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Keep DeepSeek's server-reported accumulated usage for total token accounting, but calculate output speed only from text observed in the response stream. This prevents prompt/context tokens from inflating the displayed generation rate in long conversations.

Fixes #477

## PR Type

- [ ] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

`git fetch --prune origin`; based on `b23bb78ec05b022500102942ee709fa24bcb3c4a`.

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

OpenAI GPT-5.6

Coding Agent tool(s) used:

Codex

## Local Validation

Commands run:

```bash
npx vitest run tests/token-speed.test.ts tests/deepseek-adapter-stream.test.ts
npm run compile
npm run build:all
```

Result summary:

All 26 targeted tests passed. TypeScript compilation and Chrome/Edge/Firefox production builds passed.

## Local Feature Evidence

Evidence:

N/A — this is a metric-correction bug fix with no new UI. The regression tests cover a 49,794-token accumulated context and verify that tok/s remains based on streamed output only.