### PR TITLE
fix: keep MCP tool selection stable in manual mode

### DIFF
--- a/core/i18n/resources/en.ts
+++ b/core/i18n/resources/en.ts
@@ -586,6 +586,7 @@ export const en = {
       multimodal: 'Multimodal',
       addServer: 'Add',
       enabled: 'Enabled',
+      selected: 'Selected',
       auto: 'Auto',
       disabled: 'Disabled',
       success: 'Success',

--- a/core/i18n/resources/zh-CN.ts
+++ b/core/i18n/resources/zh-CN.ts
@@ -586,6 +586,7 @@ export const zhCN = {
       multimodal: '多模态',
       addServer: '新增',
       enabled: '启用',
+      selected: '已选择',
       auto: '自动',
       disabled: '禁用',
       success: '成功',

--- a/entrypoints/sidepanel/controllers/mcp-tools-controller.ts
+++ b/entrypoints/sidepanel/controllers/mcp-tools-controller.ts
@@ -288,13 +288,17 @@ export function getAllowedMcpTransportKinds(
   return getSupportedMcpTransportKinds([...candidates], platform);
 }
 
-export function isMcpToolEnabled(server: McpServerConfig, tool: ToolDescriptor): boolean {
-  if (!server.enabled || !server.execution.enabled || server.execution.mode !== 'auto') return false;
+export function isMcpToolSelected(server: McpServerConfig, tool: ToolDescriptor): boolean {
   const selected = server.allowlist.toolNames.includes(tool.name)
     || server.allowlist.toolNames.includes(tool.invocationName);
   if (server.allowlist.mode === 'allow') return selected;
   if (server.allowlist.mode === 'deny') return !selected;
   return true;
+}
+
+export function isMcpToolEnabled(server: McpServerConfig, tool: ToolDescriptor): boolean {
+  if (!server.enabled || !server.execution.enabled || server.execution.mode !== 'auto') return false;
+  return isMcpToolSelected(server, tool);
 }
 
 export function countEnabledMcpTools(

--- a/entrypoints/sidepanel/controllers/useMcpPageController.ts
+++ b/entrypoints/sidepanel/controllers/useMcpPageController.ts
@@ -19,7 +19,7 @@ import {
   findMcpPreset,
   getMcpPresetInput,
   isMcpNativeMessagingSupported,
-  isMcpToolEnabled,
+  isMcpToolSelected,
   mcpToolsController,
   nextMcpToolAllowlist,
   type McpConnectionAction,
@@ -275,9 +275,9 @@ export function useMcpPageController(t: Translator, confirm: Confirm) {
   }, [clearBanner, load, setBusyState, showBanner, t]);
 
   const toggleTool = useCallback(async (server: McpServerConfig, tool: ToolDescriptor) => {
-    const enabled = isMcpToolEnabled(server, tool);
+    const selected = isMcpToolSelected(server, tool);
     await patchServer(server, {
-      allowlist: nextMcpToolAllowlist(server.allowlist, tool, !enabled),
+      allowlist: nextMcpToolAllowlist(server.allowlist, tool, !selected),
     });
   }, [patchServer]);
 

--- a/entrypoints/sidepanel/pages/McpPage.tsx
+++ b/entrypoints/sidepanel/pages/McpPage.tsx
@@ -26,6 +26,7 @@ import {
   getAllowedMcpTransportKinds,
   isMcpNativeMessagingSupported,
   isMcpToolEnabled,
+  isMcpToolSelected,
   isMultimodalMcpServer,
   isShellMcpServer,
   mcpServerNeedsOriginPermission,
@@ -1023,6 +1024,7 @@ function ToolRow({
   t: Translator;
 }) {
   const enabled = isMcpToolEnabled(server, tool);
+  const selected = isMcpToolSelected(server, tool);
   return (
     <div className="ds-card rounded-lg px-3 py-2">
       <div className="flex items-start justify-between gap-2">
@@ -1040,8 +1042,12 @@ function ToolRow({
             {pinned ? t('sidepanel.mcpPage.detail.unpin') : t('sidepanel.mcpPage.detail.pin')}
           </button>
           <ToggleRow
-            title={enabled ? t('sidepanel.mcpPage.auto') : t('sidepanel.mcpPage.disabled')}
-            enabled={enabled}
+            title={enabled
+              ? t('sidepanel.mcpPage.auto')
+              : selected
+                ? t('sidepanel.mcpPage.selected')
+                : t('sidepanel.mcpPage.disabled')}
+            enabled={selected}
             onToggle={onToggle}
           />
         </div>

--- a/tests/mcp-page-collapse.test.ts
+++ b/tests/mcp-page-collapse.test.ts
@@ -13,6 +13,7 @@ import McpPage from '../entrypoints/sidepanel/pages/McpPage';
 let container: HTMLDivElement;
 let root: Root | null;
 let historyResponse: unknown;
+let serversResponse: McpServerConfig[];
 
 beforeEach(() => {
   (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -20,12 +21,13 @@ beforeEach(() => {
   document.body.append(container);
   root = null;
   historyResponse = [];
+  serversResponse = [multimodalServer];
 
   vi.stubGlobal('chrome', {
     runtime: {
       getManifest: vi.fn(() => ({ version: '0.7.5' })),
       sendMessage: vi.fn(async (message: { type?: string }) => {
-        if (message.type === 'GET_MCP_SERVERS') return [multimodalServer];
+        if (message.type === 'GET_MCP_SERVERS') return serversResponse;
         if (message.type === 'GET_PLATFORM_CAPABILITIES') return platformEnvironment;
         if (message.type === 'GET_MCP_TOOL_CACHE') return multimodalCache;
         if (message.type === 'GET_TOOL_CALL_HISTORY') return historyResponse;
@@ -89,6 +91,56 @@ describe('McpPage server row collapse', () => {
     expect(container.textContent).toContain('history_tool');
   });
 });
+
+describe('McpPage discovered tool switch states', () => {
+  it('labels an auto-mode selected tool as automatic', async () => {
+    await renderMcpPage();
+
+    const row = findToolRow('Multimodal Status');
+    expect(row.textContent).toContain('自动');
+    expect(toolSwitch(row).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('labels a manual-mode selected tool as selected, not auto or enabled', async () => {
+    serversResponse = [{
+      ...multimodalServer,
+      execution: { enabled: true, mode: 'manual' },
+    }];
+    await renderMcpPage();
+
+    const row = findToolRow('Multimodal Status');
+    expect(row.textContent).toContain('已选择');
+    expect(row.textContent).not.toContain('自动');
+    expect(toolSwitch(row).getAttribute('aria-pressed')).toBe('true');
+    expect(container.textContent).toContain('当前注入 0 个工具');
+  });
+
+  it('labels an unselected tool as disabled with the switch off', async () => {
+    serversResponse = [{
+      ...multimodalServer,
+      execution: { enabled: true, mode: 'manual' },
+      allowlist: { mode: 'allow', toolNames: [] },
+    }];
+    await renderMcpPage();
+
+    const row = findToolRow('Multimodal Status');
+    expect(row.textContent).toContain('禁用');
+    expect(toolSwitch(row).getAttribute('aria-pressed')).toBe('false');
+  });
+});
+
+function findToolRow(title: string): HTMLElement {
+  const titleElement = findExactText(title);
+  const row = titleElement.closest<HTMLElement>('.ds-card');
+  expect(row).toBeTruthy();
+  return row!;
+}
+
+function toolSwitch(row: HTMLElement): HTMLElement {
+  const toggle = row.querySelector<HTMLElement>('button.ds-switch');
+  expect(toggle).toBeTruthy();
+  return toggle!;
+}
 
 async function renderMcpPage() {
   await act(async () => {

--- a/tests/mcp-persistence-contract.test.ts
+++ b/tests/mcp-persistence-contract.test.ts
@@ -189,6 +189,33 @@ describe('MCP persisted-config contract', () => {
     expect(await getMcpToolCache(MCP_SERVER_IDS.shell)).toEqual(MCP_CACHE_ENTRY);
   });
 
+  it('preserves the discovery cache when only the execution policy changes', async () => {
+    storage[MCP_STORAGE_KEY] = structuredClone(MCP_STORAGE_V2);
+
+    await updateMcpServer(MCP_SERVER_IDS.shell, {
+      execution: { enabled: true, mode: 'manual' },
+    });
+
+    expect(await getMcpToolCache(MCP_SERVER_IDS.shell)).toEqual(MCP_CACHE_ENTRY);
+    expect(await getMcpServerById(MCP_SERVER_IDS.shell)).toMatchObject({
+      execution: { enabled: true, mode: 'manual' },
+    });
+  });
+
+  it('keeps the discovered list after a manual-mode allowlist selection change', async () => {
+    storage[MCP_STORAGE_KEY] = structuredClone(MCP_STORAGE_V2);
+
+    await updateMcpServer(MCP_SERVER_IDS.shell, {
+      execution: { enabled: true, mode: 'manual' },
+      allowlist: { mode: 'deny', toolNames: ['shell_status'] },
+    });
+
+    expect(await getMcpToolCache(MCP_SERVER_IDS.shell)).toEqual(MCP_CACHE_ENTRY);
+    expect(await getMcpServerById(MCP_SERVER_IDS.shell)).toMatchObject({
+      allowlist: { mode: 'deny', toolNames: ['shell_status'] },
+    });
+  });
+
   it('accepts current v2 cache collisions so the user can clear or refresh them', () => {
     const raw = structuredClone(MCP_STORAGE_V2_COLLIDING_CACHE);
 

--- a/tests/sidepanel-mcp-tools-controller.test.ts
+++ b/tests/sidepanel-mcp-tools-controller.test.ts
@@ -7,6 +7,7 @@ import {
   getAllowedMcpTransportKinds,
   isMcpNativeMessagingSupported,
   isMcpToolEnabled,
+  isMcpToolSelected,
   nextMcpToolAllowlist,
   normalizeHostPermissionOrigin,
 } from '../entrypoints/sidepanel/controllers/mcp-tools-controller';
@@ -163,6 +164,55 @@ describe('sidepanel MCP and Tools controller', () => {
       .toBe('https://example.test/*');
     expect(() => normalizeHostPermissionOrigin('file:///tmp/data'))
       .toThrow('only supports http/https');
+  });
+
+  it('keeps allowlist selection independent of execution policy for manual-mode toggles', () => {
+    const manualServer: McpServerConfig = {
+      ...server,
+      execution: { enabled: true, mode: 'manual' },
+    };
+    const disabledServer: McpServerConfig = {
+      ...server,
+      enabled: false,
+      execution: { enabled: true, mode: 'manual' },
+    };
+
+    expect(isMcpToolEnabled(manualServer, pythonTool)).toBe(false);
+    expect(isMcpToolSelected(manualServer, pythonTool)).toBe(true);
+    expect(isMcpToolSelected(disabledServer, pythonTool)).toBe(true);
+
+    const off = nextMcpToolAllowlist(
+      manualServer.allowlist,
+      pythonTool,
+      !isMcpToolSelected(manualServer, pythonTool),
+    );
+    expect(off).toEqual({ mode: 'deny', toolNames: ['python_exec'] });
+    expect(isMcpToolSelected({ ...manualServer, allowlist: off }, pythonTool)).toBe(false);
+
+    const backOn = nextMcpToolAllowlist(off, pythonTool, !isMcpToolSelected(
+      { ...manualServer, allowlist: off },
+      pythonTool,
+    ));
+    expect(backOn).toEqual({ mode: 'all', toolNames: [] });
+    expect(isMcpToolSelected({ ...manualServer, allowlist: backOn }, pythonTool)).toBe(true);
+  });
+
+  it('deselects an allow-listed tool in manual mode instead of only ever enabling', () => {
+    const manualServer: McpServerConfig = {
+      ...server,
+      execution: { enabled: true, mode: 'manual' },
+      allowlist: { mode: 'allow', toolNames: ['python_exec'] },
+    };
+
+    expect(isMcpToolEnabled(manualServer, pythonTool)).toBe(false);
+    expect(isMcpToolSelected(manualServer, pythonTool)).toBe(true);
+
+    const next = nextMcpToolAllowlist(
+      manualServer.allowlist,
+      pythonTool,
+      !isMcpToolSelected(manualServer, pythonTool),
+    );
+    expect(next).toEqual({ mode: 'allow', toolNames: [] });
   });
 
   it('keeps native controls disabled until the platform snapshot loads', () => {


### PR DESCRIPTION
## Summary

Fixes the remaining reproducible branch of #451 by separating MCP allowlist selection from effective automatic execution.

Discovered-tool switches now remain configurable in manual mode without silently changing the execution policy. Allowlist/execution-only updates preserve the raw discovery cache, so the discovered list no longer requires a manual refresh. The UI distinguishes automatic, selected-but-manual, and unselected states.

Fixes #451

## PR Type

- [ ] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

```bash
git fetch --prune origin
git worktree add -b codex/fix-issue-451-mcp-tool-toggles <isolated-worktree> origin/main
# base: 6af9a76ffdd0019f8694bb50b104d3b94990edf5
```

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

GPT-5.6, DeepSeek V4 Flash, Kimi K3

Coding Agent tool(s) used:

Codex, DeepSeekCoder, KimiFrontend

## Local Validation

Commands run:

```bash
npx vitest run tests/mcp-page-collapse.test.ts tests/sidepanel-mcp-tools-controller.test.ts tests/mcp-persistence-contract.test.ts
npx vitest run
npm run compile
npm run verify:i18n
npm run build:chrome
git diff --check
```

Result summary:

- Parent acceptance set: 3 files / 40 tests passed.
- Coder full suite: 176 files / 1297 tests passed.
- TypeScript compile passed.
- i18n locale and coverage checks passed.
- Chrome MV3 build passed.
- Diff whitespace check passed.
- No cache race was patched speculatively: targeted storage/controller tests confirmed that policy-only mutations preserve the existing discovery cache.

## Local Feature Evidence

Evidence:

N/A — this restores the released MCP switch/cache behavior and adds no new feature surface. DOM regression tests cover automatic, manual-selected, and manual-unselected states; a real Shell Native Host browser click smoke remains outside the local automated evidence.