### PR TITLE
fix: prefer DeepSeek native search in agent runs

### DIFF
--- a/core/interceptor/request-augmentation.ts
+++ b/core/interceptor/request-augmentation.ts
@@ -7,6 +7,7 @@ import {
   type PromptInjectionSettings,
 } from '../prompt/settings';
 import { parseSkillCommand } from '../skill/parser';
+import { projectToolDescriptorsForNativeSearch } from '../tool';
 import type { Memory, ModelType, Skill, SystemPromptPreset, ToolDescriptor } from '../types';
 import { filterMemoriesByProjectScope } from '../memory/scope';
 
@@ -104,6 +105,11 @@ export function augmentDecodedRequestBody(
     body.model_type = state.modelType;
   }
 
+  const modelFacingToolDescriptors = projectToolDescriptorsForNativeSearch(
+    state.toolDescriptors,
+    body.search_enabled === true,
+  );
+
   const invocation = parseSkillCommand(originalPrompt);
   if (invocation) {
     const resolved = resolveSkills(state.skills, invocation.skillName, invocation.args, locale);
@@ -116,7 +122,7 @@ export function augmentDecodedRequestBody(
         visibleUserPrompt: originalPrompt,
         presetContent,
         projectContext: state.projectContext,
-        toolDescriptors: state.toolDescriptors,
+        toolDescriptors: modelFacingToolDescriptors,
         locale,
         memoryEnabled: promptSettings.memoryEnabled,
         systemPromptEnabled: promptSettings.systemPromptEnabled,
@@ -138,7 +144,7 @@ export function augmentDecodedRequestBody(
     thinkingEnabled,
     presetContent,
     projectContext: state.projectContext,
-    toolDescriptors: state.toolDescriptors,
+    toolDescriptors: modelFacingToolDescriptors,
     locale,
     memoryEnabled: promptSettings.memoryEnabled,
     systemPromptEnabled: promptSettings.systemPromptEnabled,

--- a/core/tool/index.ts
+++ b/core/tool/index.ts
@@ -72,6 +72,11 @@ export {
 } from './web-search';
 
 export {
+  isExtensionOwnedWebSearchDescriptor,
+  projectToolDescriptorsForNativeSearch,
+} from './native-search-projection';
+
+export {
   WEB_FETCH_DESCRIPTOR_ID,
   WEB_FETCH_PERMISSION_ERROR_CODE,
   isRetryableWebFetchPermissionPrecondition,

--- a/core/tool/native-search-projection.ts
+++ b/core/tool/native-search-projection.ts
@@ -1,0 +1,33 @@
+import type { ToolDescriptor } from './types';
+import { WEB_SEARCH_TOOL_PROVIDER } from './web-search';
+
+/**
+ * Stable identity of the extension-owned local web_search descriptor. This is
+ * the local provider contract (kind 'local', id 'web') plus the exact tool
+ * name; an MCP tool that merely happens to be named web_search is not covered.
+ */
+export function isExtensionOwnedWebSearchDescriptor(
+  descriptor: ToolDescriptor,
+): boolean {
+  return (
+    descriptor.name === 'web_search' &&
+    descriptor.provider?.kind === WEB_SEARCH_TOOL_PROVIDER.kind &&
+    descriptor.provider?.id === WEB_SEARCH_TOOL_PROVIDER.id
+  );
+}
+
+/**
+ * Model-facing projection: when DeepSeek page-native search is enabled for a
+ * turn, remove only the extension-owned local web_search descriptor so the
+ * schema and mandatory web-search guidance disappear together. All other
+ * descriptors (web_fetch, browser, MCP, memory, capability helpers) keep their
+ * order. When native search is disabled the input array is returned by the
+ * same reference, unchanged.
+ */
+export function projectToolDescriptorsForNativeSearch(
+  descriptors: readonly ToolDescriptor[],
+  nativeSearchEnabled: boolean,
+): readonly ToolDescriptor[] {
+  if (!nativeSearchEnabled) return descriptors;
+  return descriptors.filter((descriptor) => !isExtensionOwnedWebSearchDescriptor(descriptor));
+}

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -19,6 +19,7 @@ import type {
 import { normalizePetConfig } from '../core/pet/config';
 import { pickPetLine, type PetState } from '../core/pet/lines';
 import { createToolInvocationCatalog } from '../core/tool/invocation';
+import { projectToolDescriptorsForNativeSearch } from '../core/tool/native-search-projection';
 import { createLatestSyncGate, type LatestSyncLease } from '../core/tool/latest-sync';
 import { DEFAULT_PROMPT_INJECTION_SETTINGS, normalizePromptInjectionSettings } from '../core/prompt/settings';
 import { normalizeBackgroundConfig } from '../core/background/config';
@@ -3685,7 +3686,12 @@ async function startInlineAgentLoop(payload: InlineAgentStartPayload): Promise<v
   try {
     await runInlineAgentLoop({
       ...payload,
-      toolDescriptors: authorization.descriptors,
+      toolDescriptors: [
+        ...projectToolDescriptorsForNativeSearch(
+          authorization.descriptors,
+          payload.promptOptions.searchEnabled,
+        ),
+      ],
     }, { post, executeTool, signal: abort.signal });
   } finally {
     await closeContentToolAuthorization(authorizationRequestKey);

--- a/tests/inline-agent-loop.test.ts
+++ b/tests/inline-agent-loop.test.ts
@@ -53,6 +53,38 @@ describe('runInlineAgentLoop', () => {
     }));
   });
 
+  it('keeps sending searchEnabled: true on continuation requests', async () => {
+    adapterMocks.submitPromptStreaming.mockImplementationOnce(async (_input, handlers) => {
+      handlers.onTextChunk('Done after tool result.');
+      return {
+        assistantText: '',
+        responseMessageId: 102,
+        requestMessageId: 101,
+        finished: true,
+      };
+    });
+
+    const post = vi.fn();
+    const executeTool = vi.fn();
+
+    await runInlineAgentLoop({
+      ...createPayload(),
+      promptOptions: {
+        ...createPayload().promptOptions,
+        searchEnabled: true,
+      },
+    }, {
+      post,
+      executeTool,
+      signal: new AbortController().signal,
+    });
+
+    expect(adapterMocks.submitPromptStreaming).toHaveBeenCalledTimes(1);
+    expect(adapterMocks.submitPromptStreaming.mock.calls[0]?.[0]).toMatchObject({
+      searchEnabled: true,
+    });
+  });
+
   it('does not replay the same step when planning text is followed by a complete answer', async () => {
     const answer = [
       '要求查看贵金属走势，之前的搜索已经提供了一些结果。我需要基于这些结果给出一个全面的回答。',

--- a/tests/native-search-projection.test.ts
+++ b/tests/native-search-projection.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDefaultToolDescriptors,
+  isExtensionOwnedWebSearchDescriptor,
+  projectToolDescriptorsForNativeSearch,
+} from '../core/tool';
+import type { ToolDescriptor } from '../core/types';
+
+describe('projectToolDescriptorsForNativeSearch', () => {
+  it('returns the descriptors unchanged when native search is disabled', () => {
+    const descriptors = createDefaultToolDescriptors('en');
+
+    const projected = projectToolDescriptorsForNativeSearch(descriptors, false);
+
+    expect(projected).toBe(descriptors);
+    expect(projected).toEqual([...descriptors]);
+    expect(projected.map((descriptor) => descriptor.id)).toEqual(
+      descriptors.map((descriptor) => descriptor.id),
+    );
+  });
+
+  it('removes only the extension-owned local web_search descriptor when native search is enabled', () => {
+    const descriptors = createDefaultToolDescriptors('en');
+    expect(descriptors.map((descriptor) => descriptor.name))
+      .toEqual(['memory_save', 'memory_update', 'memory_delete', 'web_search', 'web_fetch']);
+
+    const projected = projectToolDescriptorsForNativeSearch(descriptors, true);
+
+    expect(projected.map((descriptor) => descriptor.name))
+      .toEqual(['memory_save', 'memory_update', 'memory_delete', 'web_fetch']);
+  });
+
+  it('preserves descriptor order for the remaining descriptors', () => {
+    const descriptors = createDefaultToolDescriptors('en');
+    const projected = projectToolDescriptorsForNativeSearch(descriptors, true);
+
+    expect(projected.map((descriptor) => descriptor.id)).toEqual([
+      'local:memory:memory_save',
+      'local:memory:memory_update',
+      'local:memory:memory_delete',
+      'local:web:web_fetch',
+    ]);
+  });
+
+  it('does not mutate the input descriptor array', () => {
+    const descriptors = [...createDefaultToolDescriptors('en')];
+    const snapshot = [...descriptors];
+
+    projectToolDescriptorsForNativeSearch(descriptors, true);
+
+    expect(descriptors).toEqual(snapshot);
+  });
+
+  it('does not remove an MCP descriptor that merely shares the web_search name', () => {
+    const descriptors = [
+      createDefaultToolDescriptors('en')[0],
+      mcpWebSearchDescriptor(),
+      createDefaultToolDescriptors('en').find((descriptor) => descriptor.name === 'web_fetch')!,
+    ];
+
+    const projected = projectToolDescriptorsForNativeSearch(descriptors, true);
+
+    expect(projected.map((descriptor) => descriptor.id)).toEqual([
+      'local:memory:memory_save',
+      'mcp:browser-tools:web_search',
+      'local:web:web_fetch',
+    ]);
+  });
+
+  it('identifies the local extension web_search by provider contract rather than name alone', () => {
+    expect(isExtensionOwnedWebSearchDescriptor(createDefaultToolDescriptors('en')
+      .find((descriptor) => descriptor.name === 'web_search')!)).toBe(true);
+    expect(isExtensionOwnedWebSearchDescriptor(mcpWebSearchDescriptor())).toBe(false);
+    expect(isExtensionOwnedWebSearchDescriptor(createDefaultToolDescriptors('en')
+      .find((descriptor) => descriptor.name === 'web_fetch')!)).toBe(false);
+  });
+});
+
+function mcpWebSearchDescriptor(): ToolDescriptor {
+  return {
+    id: 'mcp:browser-tools:web_search',
+    provider: {
+      kind: 'mcp',
+      id: 'browser-tools',
+      displayName: 'Browser Tools',
+      transport: 'streamable_http',
+    },
+    name: 'web_search',
+    invocationName: 'browser_tools_web_search',
+    title: 'Search (MCP)',
+    description: 'A hypothetical MCP tool named web_search.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Query' },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
+    execution: { mode: 'auto', enabled: true, risk: 'low' },
+  };
+}

--- a/tests/request-augmentation.test.ts
+++ b/tests/request-augmentation.test.ts
@@ -324,3 +324,112 @@ function memory(
     lastAccessedAt: 1,
   };
 }
+
+describe('page-native search projection', () => {
+  it('keeps web_search schema and guidance when native search is disabled', () => {
+    const result = augmentRequestBody(JSON.stringify({
+      prompt: 'search latest DeepSeek news',
+      parent_message_id: null,
+      thinking_enabled: false,
+      search_enabled: false,
+    }), {
+      memories: [],
+      skills: [],
+      activePreset: null,
+      modelType: null,
+      toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+      messageCount: 0,
+      locale: 'en',
+    });
+
+    const prompt = JSON.parse(result?.body ?? '{}').prompt as string;
+    expect(prompt).toContain('### Tool web_search');
+    expect(prompt).toContain('## Web Search Rules');
+    expect(prompt).toContain('### Tool memory_save');
+    expect(JSON.parse(result?.body ?? '{}').search_enabled).toBe(false);
+  });
+
+  it('drops the local web_search schema and guidance when native search is enabled', () => {
+    const result = augmentRequestBody(JSON.stringify({
+      prompt: 'search latest DeepSeek news',
+      parent_message_id: null,
+      thinking_enabled: false,
+      search_enabled: true,
+    }), {
+      memories: [],
+      skills: [],
+      activePreset: null,
+      modelType: null,
+      toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+      messageCount: 0,
+      locale: 'en',
+    });
+
+    const prompt = JSON.parse(result?.body ?? '{}').prompt as string;
+    expect(prompt).not.toContain('### Tool web_search');
+    expect(prompt).not.toContain('## Web Search Rules');
+    expect(prompt).toContain('### Tool web_fetch');
+    expect(prompt).toContain('### Tool memory_save');
+    expect(JSON.parse(result?.body ?? '{}').search_enabled).toBe(true);
+  });
+
+  it('applies the same projection to Skill-command requests', () => {
+    const result = augmentRequestBody(JSON.stringify({
+      prompt: '/writer Search this topic',
+      parent_message_id: null,
+      thinking_enabled: false,
+      search_enabled: true,
+    }), {
+      memories: [],
+      skills: [{
+        name: 'writer',
+        instructions: 'Write a report using web evidence.',
+        memoryEnabled: false,
+      }],
+      activePreset: null,
+      modelType: null,
+      toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+      messageCount: 0,
+      locale: 'en',
+    });
+
+    const prompt = JSON.parse(result?.body ?? '{}').prompt as string;
+    expect(prompt).not.toContain('### Tool web_search');
+    expect(prompt).not.toContain('## Web Search Rules');
+    expect(prompt).toContain('### Tool web_fetch');
+    expect(prompt).toContain('### Tool memory_save');
+  });
+
+  it('keeps a hypothetical MCP web_search descriptor under native search', () => {
+    const mcpDescriptor = {
+      ...DEFAULT_TOOL_DESCRIPTORS.find((descriptor) => descriptor.name === 'web_search')!,
+      id: 'mcp:browser-tools:web_search',
+      invocationName: 'browser_tools_web_search',
+      provider: {
+        kind: 'mcp' as const,
+        id: 'browser-tools',
+        displayName: 'Browser Tools',
+        transport: 'streamable_http' as const,
+      },
+    };
+    const result = augmentRequestBody(JSON.stringify({
+      prompt: 'search latest DeepSeek news',
+      parent_message_id: null,
+      thinking_enabled: false,
+      search_enabled: true,
+    }), {
+      memories: [],
+      skills: [],
+      activePreset: null,
+      modelType: null,
+      toolDescriptors: [mcpDescriptor],
+      messageCount: 0,
+      locale: 'en',
+    });
+
+    const prompt = JSON.parse(result?.body ?? '{}').prompt as string;
+    expect(prompt).toContain('### Tool web_search');
+    expect(prompt).toContain('Accepted tag names: browser_tools_web_search, web_search');
+    expect(prompt).toContain('## Web Search Rules');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the conflict between DeepSeek page-native intelligent search and the extension-owned `web_search` XML tool.

When a request already has `search_enabled: true`, one shared model-facing projection removes only DeepSeek++'s local `web_search` descriptor from the initial augmented prompt and inline-agent continuation descriptors. Native search remains enabled on continuation requests; `web_fetch`, browser, MCP, memory, and other tools are unchanged. Native-search-disabled prompt bytes remain frozen.

Fixes #480

## PR Type

- [ ] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

```bash
git fetch --prune origin
git worktree add -b codex/fix-issue-480-native-search-routing <isolated-worktree> origin/main
# base: 6af9a76ffdd0019f8694bb50b104d3b94990edf5
```

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

GPT-5.6, DeepSeek V4 Flash

Coding Agent tool(s) used:

Codex, DeepSeekCoder

## Local Validation

Commands run:

```bash
npx vitest run tests/native-search-projection.test.ts tests/request-augmentation.test.ts tests/inline-agent-loop.test.ts tests/prompt-output-contract.test.ts
npm run compile
npm run prompt:freeze
git diff --check
```

Result summary:

- Parent acceptance set: 4 files / 34 tests passed.
- Coder focused set: 7 files / 54 tests passed under a 60-second process-group timeout.
- TypeScript compile passed.
- Prompt freeze passed (7/7); no native-search-disabled golden drift.
- Diff whitespace check passed.
- Review corrected a readonly-to-mutable cast before commit; the disabled projection branch now preserves the same readonly array reference and materializes a mutable copy only at the content loop boundary.

## Local Feature Evidence

Evidence:

N/A — this restores routing between two already released search paths and adds no new UI surface. Automated coverage includes ordinary and Skill prompts, same-name MCP preservation, native-search-disabled byte compatibility, and continuation `searchEnabled: true`. A real DeepSeek browser turn with native search enabled remains the post-build runtime evidence boundary.