### PR TITLE
fix: advertise valid MCP client capabilities

### DIFF
--- a/core/mcp/client.ts
+++ b/core/mcp/client.ts
@@ -66,12 +66,14 @@ export async function initializeMcpServer(
   transport: McpProtocolTransport,
   options?: { signal?: AbortSignal },
 ): Promise<McpInitializeResult> {
-    const response = await transport.request<Record<string, unknown>, McpInitializeResult>(
+  const response = await transport.request<Record<string, unknown>, McpInitializeResult>(
     createMcpRequest('initialize', {
       protocolVersion: MCP_PROTOCOL_VERSION,
-      capabilities: {
-        tools: {},
-      },
+      // Client capabilities are not the server's advertised tool capabilities.
+      // Keep this empty until DeepSeek++ implements a client-side MCP capability
+      // such as roots, sampling, or elicitation. Strict servers reject unknown
+      // client capability keys during initialize.
+      capabilities: {},
       clientInfo: {
         name: CLIENT_NAME,
         version: getExtensionVersion(),

--- a/tests/fixtures/external-runtime/mcp.ts
+++ b/tests/fixtures/external-runtime/mcp.ts
@@ -1,6 +1,7 @@
 export const MCP_PROTOCOL_CONTRACT = {
   requestVersion: '2025-06-18',
   supportedVersions: ['2024-11-05', '2025-03-26', '2025-06-18'],
+  clientCapabilities: {},
   nativeEnvelopeProtocol: 'deepseek-pp-mcp-native',
   nativeEnvelopeVersion: 1,
   transportKinds: ['http', 'sse', 'streamable_http', 'stdio_bridge', 'native_messaging'],

--- a/tests/mcp-external-contract.test.ts
+++ b/tests/mcp-external-contract.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../core/mcp';
 import { parseJsonRpcSseMessage } from '../core/mcp/transports/common';
 import type {
+  McpJsonRpcRequest,
   McpJsonRpcResponse,
   McpProtocolTransport,
   McpServerConfig,
@@ -47,6 +48,46 @@ describe('MCP and Native external contract', () => {
       'stdio_bridge',
       'native_messaging',
     ]);
+  });
+
+  it('advertises only implemented client capabilities during initialize', async () => {
+    vi.stubGlobal('chrome', {
+      runtime: { getManifest: () => ({ version: '1.11.9' }) },
+    });
+
+    const initializeRequests: Array<McpJsonRpcRequest<Record<string, unknown>>> = [];
+    const transport: McpProtocolTransport = {
+      async request(request) {
+        initializeRequests.push(
+          request as McpJsonRpcRequest<Record<string, unknown>>,
+        );
+        return {
+          jsonrpc: '2.0',
+          id: request.id,
+          result: {
+            protocolVersion: MCP_PROTOCOL_VERSION,
+            capabilities: { tools: {} },
+            serverInfo: { name: 'strict-server', version: '1.0.0' },
+          },
+        } as McpJsonRpcResponse<any>;
+      },
+      async notify() {},
+    };
+
+    await initializeMcpServer(mcpServer(), transport);
+
+    expect(initializeRequests[0]).toMatchObject({
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'DeepSeek++', version: '1.11.9' },
+      },
+    });
+    expect(
+      (initializeRequests[0]?.params as { capabilities?: Record<string, unknown> } | undefined)
+        ?.capabilities,
+    ).not.toHaveProperty('tools');
   });
 
   it('preserves known/missing negotiation and rejects unsupported versions before notification', async () => {

--- a/tests/mcp-external-contract.test.ts
+++ b/tests/mcp-external-contract.test.ts
@@ -80,7 +80,7 @@ describe('MCP and Native external contract', () => {
       method: 'initialize',
       params: {
         protocolVersion: MCP_PROTOCOL_VERSION,
-        capabilities: {},
+        capabilities: MCP_PROTOCOL_CONTRACT.clientCapabilities,
         clientInfo: { name: 'DeepSeek++', version: '1.11.9' },
       },
     });


### PR DESCRIPTION
## Summary

Corrects the MCP `initialize` request so DeepSeek++ advertises only client capabilities it actually implements. The request previously sent `capabilities.tools`, which is a server capability and can be rejected by strict MCP servers as invalid initialize parameters.

This is a focused interoperability fix for the new v1.11.9 retest feedback in #469. The Issue remains open until the reporter verifies the protected server over legacy SSE and Streamable HTTP.

Refs #469

## PR Type

- [ ] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

```bash
git fetch origin --prune
# base: 9c6690118fb3177fd2042aaa41d5f27b9219f3dc
```

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

GPT-5.6

Coding Agent tool(s) used:

Codex

## Local Validation

Commands run:

```bash
npx vitest run tests/mcp-external-contract.test.ts tests/mcp-transport-common.test.ts tests/mcp-execution-policy.test.ts --reporter=dot
npm run compile
npm run verify:mcp:mock
npm run smoke:mcp
npm run prompt:freeze
npm run build:all
npm run verify:manifest-policy
npm run verify:extension-utf8
npm run ci:quality
```

Result summary:

- MCP focused set: 3 files / 36 tests passed.
- Full quality gate: 177 files / 1312 tests passed.
- Compile, prompt freeze, MCP live mock/smoke, Chrome/Edge/Firefox builds, manifest policy, UTF-8 verification, packaging, release-asset verification, and Pyodide offline smoke all passed.
- Added an external-contract regression that freezes `initialize.params.capabilities` as an empty object and rejects accidental client-side `tools` advertisement.

## Local Feature Evidence

Evidence:

N/A — this is a protocol interoperability correction with no new UI surface. The repository does not have access to the reporter's protected MCP endpoint, so real-provider verification remains required before closing #469.