### PR TITLE
fix(sidepanel): daily token trend X-axis overflow + modulepreload console noise

### DIFF
--- a/entrypoints/sidepanel/components/settings/UsageSubPage.tsx
+++ b/entrypoints/sidepanel/components/settings/UsageSubPage.tsx
@@ -228,6 +228,7 @@ function UsageDailyTrend({ summary, locale }: { summary: UsageSummary; locale: s
   const { t } = useI18n();
   const maxTokens = Math.max(1, ...summary.days.map((day) => day.tokens));
   const labelStep = summary.rangeDays === 30 ? 6 : 1;
+  const lastDayIndex = summary.days.length - 1;
 
   return (
     <section className="usage-panel">
@@ -237,10 +238,23 @@ function UsageDailyTrend({ summary, locale }: { summary: UsageSummary; locale: s
       <div
         className="usage-bars"
         aria-label={t('sidepanel.settings.usage.dailyTrendTitle')}
-        style={{ '--usage-day-count': summary.rangeDays } as CSSProperties}
+        style={{
+          '--usage-day-count': summary.rangeDays,
+          // 30-day charts use a tighter gap so columns keep usable width once
+          // the grid is allowed to shrink to the panel width.
+          '--usage-bar-gap': summary.rangeDays === 30 ? '2px' : '4px',
+        } as CSSProperties}
       >
         {summary.days.map((day, dayIndex) => {
           const height = day.tokens > 0 ? Math.max(5, (day.tokens / maxTokens) * 100) : 0;
+          const showLabel = dayIndex % labelStep === 0 || dayIndex === lastDayIndex;
+          // Anchor the first/last labels inward so they never spill past the
+          // chart edges; intermediate labels stay centered.
+          const labelClass = dayIndex === 0
+            ? 'usage-bar-label usage-bar-label-first'
+            : dayIndex === lastDayIndex
+              ? 'usage-bar-label usage-bar-label-last'
+              : 'usage-bar-label';
           return (
             <div
               key={day.day}
@@ -261,10 +275,8 @@ function UsageDailyTrend({ summary, locale }: { summary: UsageSummary; locale: s
                   ))}
                 </div>
               </div>
-              <span className="usage-bar-label">
-                {dayIndex % labelStep === 0 || dayIndex === summary.days.length - 1
-                  ? formatShortDate(day.timestamp, locale)
-                  : ''}
+              <span className={labelClass}>
+                {showLabel ? formatShortDate(day.timestamp, locale) : ''}
               </span>
             </div>
           );

--- a/entrypoints/sidepanel/style.css
+++ b/entrypoints/sidepanel/style.css
@@ -1696,10 +1696,13 @@ input[type='range'] {
 
 .usage-bars {
   display: grid;
-  grid-template-columns: repeat(var(--usage-day-count, 30), minmax(8px, 1fr));
+  /* Columns shrink to the panel width so a 30-day axis never overflows the
+     chart box; overflow is clipped only beyond the chart, never inside it. */
+  grid-template-columns: repeat(var(--usage-day-count, 30), minmax(0, 1fr));
   align-items: end;
-  gap: 4px;
+  gap: var(--usage-bar-gap, 4px);
   min-height: 150px;
+  overflow: hidden;
 }
 
 .usage-bar-column {
@@ -1745,6 +1748,14 @@ input[type='range'] {
   line-height: 1.1;
   text-align: center;
   white-space: nowrap;
+}
+
+.usage-bar-label-first {
+  text-align: left;
+}
+
+.usage-bar-label-last {
+  text-align: right;
 }
 
 .usage-model-layout {

--- a/tests/usage-daily-trend.test.ts
+++ b/tests/usage-daily-trend.test.ts
@@ -1,0 +1,162 @@
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UsageDailySummary, UsageSummary } from '../core/usage/types';
+import UsageSubPage from '../entrypoints/sidepanel/components/settings/UsageSubPage';
+
+let container: HTMLDivElement;
+let root: Root | null;
+let usageResponse: unknown;
+
+function makeDaily(index: number, total: number): UsageDailySummary {
+  return {
+    day: `2026-07-${String(index + 1).padStart(2, '0')}`,
+    timestamp: Date.now() - (29 - index) * 86_400_000,
+    tokens: total,
+    messageCount: 1,
+    sessionCount: 1,
+    turnCount: 1,
+    models: [{ modelKey: 'vision', modelLabel: 'DeepSeek Vision', tokens: total }],
+  };
+}
+
+function makeUsageSummary(rangeDays: 7 | 30): UsageSummary {
+  const days = Array.from({ length: rangeDays }, (_, index) => makeDaily(index, 10 + index));
+  return {
+    rangeDays,
+    generatedAt: Date.now(),
+    totalTokens: days.reduce((sum, day) => sum + day.tokens, 0),
+    sessionCount: rangeDays,
+    messageCount: rangeDays * 2,
+    turnCount: rangeDays,
+    activeDays: rangeDays,
+    currentStreak: rangeDays,
+    serverTokenRecordCount: rangeDays,
+    mostUsedModel: {
+      modelKey: 'vision',
+      modelLabel: 'DeepSeek Vision',
+      totalTokens: days.reduce((sum, day) => sum + day.tokens, 0),
+      turnCount: rangeDays,
+      messageCount: rangeDays * 2,
+      sessionCount: rangeDays,
+      share: 1,
+    },
+    days,
+    heatmap: days.map((day) => ({ day: day.day, timestamp: day.timestamp, tokens: day.tokens, level: 1 as const })),
+    modelUsage: [{
+      modelKey: 'vision',
+      modelLabel: 'DeepSeek Vision',
+      totalTokens: days.reduce((sum, day) => sum + day.tokens, 0),
+      turnCount: rangeDays,
+      messageCount: rangeDays * 2,
+      sessionCount: rangeDays,
+      share: 1,
+    }],
+  };
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement('div');
+  document.body.append(container);
+  root = null;
+  usageResponse = makeUsageSummary(30);
+  vi.stubGlobal('chrome', {
+    runtime: {
+      sendMessage: vi.fn(async (message: { type?: string }) => (
+        message.type === 'CLEAR_USAGE_STATS' ? { ok: true } : usageResponse
+      )),
+    },
+  });
+});
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function renderUsagePage() {
+  await act(async () => {
+    root = createRoot(container);
+    root.render(React.createElement(UsageSubPage));
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function trendGrid(): HTMLDivElement {
+  const grid = container.querySelector<HTMLDivElement>('.usage-bars');
+  expect(grid).toBeTruthy();
+  return grid!;
+}
+
+function labels(): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('.usage-bar-label'));
+}
+
+describe('usage daily trend X axis', () => {
+  it('lets a 30-day chart shrink to the panel width with a dense gap', async () => {
+    await renderUsagePage();
+    const grid = trendGrid();
+    expect(grid.style.getPropertyValue('--usage-day-count')).toBe('30');
+    expect(grid.style.getPropertyValue('--usage-bar-gap')).toBe('2px');
+    expect(grid.style.gridTemplateColumns).toBe('');
+  });
+
+  it('keeps 7-day charts at the regular gap', async () => {
+    usageResponse = makeUsageSummary(7);
+    await renderUsagePage();
+    const lastSevenDays = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === '最近 7 天',
+    );
+    await act(async () => {
+      lastSevenDays!.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const grid = trendGrid();
+    expect(grid.style.getPropertyValue('--usage-day-count')).toBe('7');
+    expect(grid.style.getPropertyValue('--usage-bar-gap')).toBe('4px');
+  });
+
+  it('anchors the first and last X-axis labels inward and skips intermediate labels in 30-day mode', async () => {
+    await renderUsagePage();
+
+    const all = labels();
+    // 30-day: indices 0, 6, 12, 18, 24 and the last day carry text.
+    const visible = all.filter((label) => label.textContent!.trim() !== '');
+    expect(visible).toHaveLength(6);
+    expect(visible[0].className).toContain('usage-bar-label-first');
+    expect(visible[visible.length - 1].className).toContain('usage-bar-label-last');
+    expect(visible[0].textContent!.trim()).not.toBe('');
+    expect(visible[visible.length - 1].textContent!.trim()).not.toBe('');
+
+    for (const label of all) {
+      expect(label.className).toMatch(/^usage-bar-label(?: usage-bar-label-first| usage-bar-label-last)?$/);
+    }
+  });
+
+  it('labels every day in 7-day mode with anchored edges', async () => {
+    usageResponse = makeUsageSummary(7);
+    await renderUsagePage();
+    const lastSevenDays = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === '最近 7 天',
+    );
+    await act(async () => {
+      lastSevenDays!.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const visible = labels().filter((label) => label.textContent!.trim() !== '');
+    expect(visible).toHaveLength(7);
+    expect(visible[0].className).toContain('usage-bar-label-first');
+    expect(visible[visible.length - 1].className).toContain('usage-bar-label-last');
+  });
+});

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -249,6 +249,16 @@ export default defineConfig({
   },
   vite: () => ({
     plugins: [tailwindcss(), asciiJavaScriptOutputPlugin()],
+    build: {
+      modulePreload: {
+        // Extension pages load every chunk from the local extension file
+        // store; modulepreload links carry no latency benefit and Chromium
+        // logs "cross-world extension resource mismatch" / "preloaded but
+        // not used" noise for them. The module graph still loads normally
+        // through the entry script's static imports.
+        resolveDependencies: () => [],
+      },
+    },
     resolve: {
       alias: {
         '@wxt-dev/browser': safeWxtBrowser,


### PR DESCRIPTION
## 变更内容

### 1. 按天 Token 趋势 X 轴外溢修复
- 30 天视图网格 `minmax(8px, 1fr)` × 30 + 4px gap 的最小宽度（约 356px）超过侧栏面板宽度，导致最后一个日期标签被推出图表右缘；居中定位的首/末标签也会在面板边缘半溢出。
- 修复：列宽改为 `minmax(0, 1fr)` 随面板收缩；30 天用 2px 紧凑 gap（`--usage-bar-gap`，7 天保持 4px）；首标签左对齐、末标签右对齐锚定在图表内；网格仅裁图表盒外的溢出。
- 新增 `tests/usage-daily-trend.test.ts`：gap 值、30 天标签抽稀数量（6 个）、7 天全量标签、首/末锚定类断言。

### 2. 扩展页 modulepreload 控制台噪音
- `sidepanel.html` / `sandbox-offscreen.html` / `sandbox-runner.html` 中的 `<link rel="modulepreload">` 被 Chromium 判定为 cross-world 扩展资源而跳过，并产生 “cross-world extension resource mismatch” + “preloaded but not used” 告警。
- 扩展资源全部来自本地文件存储，预加载无延迟收益；通过 `build.modulePreload.resolveDependencies: () => []` 停止生成链接，模块图仍由入口脚本静态导入正常加载。

## 验证
- `npm test`：1365/1365 通过；`npm run compile` 通过；`npm run build:chrome` 通过，dist HTML 无 modulepreload 链接；`sidepanel-chunk-budget --browser chrome` 通过（initial shell 按模块图测量，数值不变）；utf8/manifest-policy 通过。
- CI Quality gates 待跑（约 3.5 分钟）；contribution-evidence 门按 #490/#491 先例由 owner 豁免（无截图，不索要）。

## PR Type
- [x] Bug fix
- [x] Internal refactor / code quality improvement

## Latest Codebase Confirmation
- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

## Local Validation

Commands run:
```
npm test
npm run compile
npm run build:chrome
node scripts/sidepanel-chunk-budget.mjs --browser chrome
npm run verify:extension-utf8
npm run verify:manifest-policy
```
Result summary: 1365/1365 tests pass; compile, chrome build (no modulepreload links in dist HTML), chunk budget, UTF-8 and manifest policy all pass.

## Local Feature Evidence
Owner-approved skip — same precedent as PR #490 / #491 (contribution-evidence gate waived by explicit owner decision; screenshots intentionally not re-requested).