### PR TITLE
fix(firefox): provide toolbar action to open the sidebar

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -639,6 +639,16 @@ type SidePanelApi = {
   setPanelBehavior?: (options: { openPanelOnActionClick: boolean }) => Promise<void>;
 };
 
+type SidebarActionApi = {
+  open: () => Promise<void>;
+};
+
+type FirefoxActionApi = {
+  onClicked?: {
+    addListener: (listener: () => void) => void;
+  };
+};
+
 type ActionApi = {
   setBadgeText?: (details: { text: string }) => Promise<void> | void;
   setBadgeBackgroundColor?: (details: { color: string }) => Promise<void> | void;
@@ -741,13 +751,38 @@ async function ensureAutomationWakeAlarm() {
 }
 
 function enableSidePanelActionClick() {
-  if (import.meta.env.FIREFOX) return;
+  if (import.meta.env.FIREFOX) {
+    registerFirefoxActionClickOpen();
+    return;
+  }
 
   const sidePanel = readOptionalChromeApi(
     () => (chrome as typeof chrome & { sidePanel?: SidePanelApi }).sidePanel,
   );
   sidePanel?.setPanelBehavior?.({ openPanelOnActionClick: true })
     .catch((error) => reportBackgroundStartupError('sidepanel_behavior_failed', error));
+}
+
+/**
+ * Firefox entry point for the sidebar: there is no chrome.sidePanel, so the
+ * manifest declares an `action` (wxt.config.ts) and clicking it opens the
+ * sidebar. The click is the user gesture `sidebarAction.open()` requires;
+ * calling it directly from the onClicked listener keeps the gesture valid.
+ * The action badge path (refreshWhatsNewBadge) already runs on every
+ * browser through the shared chrome.action API.
+ */
+function registerFirefoxActionClickOpen() {
+  const action = readOptionalChromeApi(
+    () => (chrome as typeof chrome & { action?: FirefoxActionApi }).action,
+  );
+  const sidebarAction = readOptionalChromeApi(
+    () => (chrome as typeof chrome & { sidebarAction?: SidebarActionApi }).sidebarAction,
+  );
+  if (!action?.onClicked?.addListener || !sidebarAction?.open) return;
+  action.onClicked.addListener(() => {
+    sidebarAction.open()
+      .catch((error) => reportBackgroundStartupError('firefox_sidebar_open_failed', error));
+  });
 }
 
 function registerWhatsNewInstallListener() {

--- a/scripts/manifest-policy-check.mjs
+++ b/scripts/manifest-policy-check.mjs
@@ -79,7 +79,13 @@ for (const target of targets) {
     assert(!manifest.browser_specific_settings, `${target.browser}: browser_specific_settings must be omitted`);
   } else {
     assert(!manifest.side_panel, `${target.browser}: side_panel must be omitted`);
-    assert(!manifest.action, `${target.browser}: action must be omitted`);
+    // Firefox: the toolbar action is the explicit sidebar entry point
+    // (background action-click opens the sidebar; no extra permission).
+    assertEqual(
+      manifest.action?.default_title,
+      expectedLocalizedManifest.actionTitle,
+      `${target.browser}: action.default_title`,
+    );
     assertEqual(
       manifest.browser_specific_settings?.gecko?.id,
       expectedFirefoxId,
@@ -152,6 +158,8 @@ assertIncludes(wxtConfig, "default_locale: 'en'", 'manifest config must declare 
 assertIncludes(wxtConfig, '__MSG_extension_name__', 'manifest config must use localized name');
 assertIncludes(wxtConfig, '__MSG_extension_description__', 'manifest config must use localized description');
 assertIncludes(wxtConfig, '__MSG_extension_action_title__', 'manifest config must use localized action title');
+assertIncludes(background, 'action.onClicked.addListener', 'Firefox action click must open the sidebar');
+assertIncludes(background, 'sidebarAction.open', 'Firefox action click must call sidebarAction.open');
 assertIncludes(wxtConfig, 'copyPyodideAssets', 'manifest build must bundle Pyodide assets for browser Python sandbox');
 assertIncludes(wxtConfig, 'copyBundledSkillAssets', 'manifest build must bundle on-demand Skill resources');
 assertIncludes(wxtConfig, "'build:done'", 'large extension assets must be copied once after WXT entrypoint builds finish');

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -109,6 +109,14 @@ export function createManifest(env: ConfigEnv): UserManifest {
       },
     } : {}),
     ...(isFirefox ? {
+      // Firefox has no chrome.sidePanel: the toolbar action button is the
+      // explicit sidebar entry point. It stays visible in the toolbar and
+      // opens the sidebar from the background action-click handler
+      // (entrypoints/background.ts enableSidePanelActionClick). No new
+      // permission is required: `action` needs none in Firefox MV3.
+      action: {
+        default_title: MANIFEST_ACTION_TITLE,
+      },
       browser_specific_settings: {
         gecko: {
           id: 'deepseek-pp@zhu1090093659.github',


### PR DESCRIPTION
## Summary

Firefox 没有 `chrome.sidePanel`，此前 Release 构建只有 `sidebar_action`，工具栏缺少与 Chrome/Edge 一致的显式入口。本 PR 在 Firefox manifest 中声明 `action`（与 Chromium 共用本地化标题），并由 background 的 action-click 处理器调用 `sidebarAction.open()`——点击本身即为该 API 所需的用户手势。Chrome/Edge 继续走 `sidePanel.setPanelBehavior` 路径，行为不变。

## PR Type

- [x] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

```bash
git fetch origin && git rebase origin/main
# base: e6d2ee7 (Release DeepSeek++ 1.12.0)
```

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

DeepSeek（辅助）

Coding Agent tool(s) used:

Codex

## Local Validation

Commands run:

```bash
npm run compile
npm run build:all
npm run verify:manifest-policy
npm run verify:extension-utf8
```

Result summary:

- `npm run compile`（tsc --noEmit）通过
- Chrome / Edge / Firefox 三浏览器构建通过；生成的 Firefox manifest 包含 `action.default_title`（保留 `sidebar_action` 与稳定 gecko id，无 `side_panel`）；Chrome/Edge 不受影响
- `verify:manifest-policy` 通过（Firefox 分支已更新为断言 action 存在，并新增 background handler 源码断言：`action.onClicked.addListener` + `sidebarAction.open`）
- `verify:extension-utf8` 通过

## Local Feature Evidence

Evidence:

N/A — 仓库 owner 自查 PR，按贡献规则豁免截图证据（pr-contribution-rules.yml）。Firefox 行为已由 manifest-policy 静态回归 + 三浏览器构建产物断言覆盖。

