### PR TITLE
feat(sidepanel): add overflow chevrons to the shared SubTabs strip

### DIFF
--- a/core/i18n/resources/en.ts
+++ b/core/i18n/resources/en.ts
@@ -61,6 +61,10 @@ export const en = {
     en: 'English',
   },
   sidepanel: {
+    subTabs: {
+      scrollLeft: 'Scroll tabs left',
+      scrollRight: 'Scroll tabs right',
+    },
     libraryPage: {
       navLabel: 'Library navigation',
       tabs: {

--- a/core/i18n/resources/zh-CN.ts
+++ b/core/i18n/resources/zh-CN.ts
@@ -61,6 +61,10 @@ export const zhCN = {
     en: 'English',
   },
   sidepanel: {
+    subTabs: {
+      scrollLeft: '向左滚动标签',
+      scrollRight: '向右滚动标签',
+    },
     libraryPage: {
       navLabel: '资料子导航',
       tabs: {

--- a/entrypoints/sidepanel/components/settings/primitives.tsx
+++ b/entrypoints/sidepanel/components/settings/primitives.tsx
@@ -1,4 +1,5 @@
-import { useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useI18n } from '../../i18n';
 import { StatusMessage } from './feedback-primitives';
 
 export { StatusMessage, useConfirm } from './feedback-primitives';
@@ -220,6 +221,13 @@ export function StatusBadge({
  * LibraryPage / CapabilitiesPage / SettingsPage. Adds the ARIA tab semantics
  * (`role="tablist"`/`role="tab"`/`aria-selected`) and left/right keyboard
  * navigation that the duplicated markup was missing.
+ *
+ * When the strip overflows its container, chevron buttons appear at the
+ * edges (hidden while there is nothing to scroll in that direction):
+ * clicking scrolls by roughly the visible width, the active tab is kept in
+ * view on selection/keyboard change, and arrow visibility is recomputed on
+ * resize and when the tab set or its labels change. Reduced-motion users
+ * get instant scrolling instead of smooth animation.
  */
 export function SubTabs<T extends string>({
   tabs,
@@ -232,6 +240,54 @@ export function SubTabs<T extends string>({
   onChange: (key: T) => void;
   ariaLabel: string;
 }) {
+  const { t } = useI18n();
+  const listRef = useRef<HTMLElement | null>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+  // Stable key for the tab set: label changes (e.g. locale switch) or a
+  // different tab count re-run the layout effects without depending on the
+  // identity of the caller-provided array.
+  const tabsKey = tabs.map((tab) => tab.label).join('\u0000');
+
+  const updateArrows = useCallback(() => {
+    const el = listRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 4);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 4);
+  }, []);
+
+  useEffect(() => {
+    updateArrows();
+    const el = listRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(updateArrows);
+    observer.observe(el);
+    el.addEventListener('scroll', updateArrows, { passive: true });
+    return () => {
+      observer.disconnect();
+      el.removeEventListener('scroll', updateArrows);
+    };
+  }, [updateArrows, tabsKey]);
+
+  // Keep the selected tab fully visible when the selection changes or the
+  // tab set is rebuilt (labels/locale), scrolling the strip the minimum
+  // amount needed.
+  useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const active = el.querySelector<HTMLElement>('[aria-selected="true"]');
+    if (!active) return;
+    const left = active.offsetLeft;
+    const right = left + active.offsetWidth;
+    const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
+    if (left < el.scrollLeft) {
+      el.scrollTo({ left, behavior });
+    } else if (right > el.scrollLeft + el.clientWidth) {
+      el.scrollTo({ left: right - el.clientWidth, behavior });
+    }
+    updateArrows();
+  }, [value, tabsKey, updateArrows]);
+
   const onKeyDown = (e: React.KeyboardEvent, index: number) => {
     if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
     e.preventDefault();
@@ -240,27 +296,66 @@ export function SubTabs<T extends string>({
       : (index - 1 + tabs.length) % tabs.length;
     onChange(tabs[next].key);
   };
+
+  const scrollByPage = (direction: 1 | -1) => {
+    const el = listRef.current;
+    if (!el) return;
+    const amount = Math.max(el.clientWidth * 0.7, 120);
+    el.scrollBy({ left: direction * amount, behavior: prefersReducedMotion() ? 'auto' : 'smooth' });
+  };
+
   return (
-    <nav className="sub-tabs" aria-label={ariaLabel} role="tablist">
-      {tabs.map((tab, index) => {
-        const active = tab.key === value;
-        return (
-          <button
-            key={tab.key}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            tabIndex={active ? 0 : -1}
-            onClick={() => onChange(tab.key)}
-            onKeyDown={(e) => onKeyDown(e, index)}
-            className={`sub-tab${active ? ' sub-tab-active' : ''}`}
-          >
-            {tab.label}
-          </button>
-        );
-      })}
-    </nav>
+    <div className="sub-tabs-shell">
+      <button
+        type="button"
+        className="sub-tabs-arrow sub-tabs-arrow-left"
+        aria-label={t('sidepanel.subTabs.scrollLeft')}
+        disabled={!canScrollLeft}
+        tabIndex={-1}
+        onClick={() => scrollByPage(-1)}
+      >
+        <svg className="sub-tabs-arrow-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2} aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+      </button>
+      <nav ref={listRef} className="sub-tabs" aria-label={ariaLabel} role="tablist">
+        {tabs.map((tab, index) => {
+          const active = tab.key === value;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              tabIndex={active ? 0 : -1}
+              onClick={() => onChange(tab.key)}
+              onKeyDown={(e) => onKeyDown(e, index)}
+              className={`sub-tab${active ? ' sub-tab-active' : ''}`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </nav>
+      <button
+        type="button"
+        className="sub-tabs-arrow sub-tabs-arrow-right"
+        aria-label={t('sidepanel.subTabs.scrollRight')}
+        disabled={!canScrollRight}
+        tabIndex={-1}
+        onClick={() => scrollByPage(1)}
+      >
+        <svg className="sub-tabs-arrow-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2} aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+    </div>
   );
+}
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
 }
 
 /**

--- a/entrypoints/sidepanel/style.css
+++ b/entrypoints/sidepanel/style.css
@@ -1500,6 +1500,53 @@ input[type='range'] {
   background: var(--ds-blue);
 }
 
+/* Sub-tabs overflow chevrons: absolute overlays at the strip edges. A
+   button is shown only while that direction actually has hidden content
+   (disabled = display:none), fades the covered tabs with a card-colored
+   gradient, and uses the existing tab strip colors — no extra assets. */
+.sub-tabs-shell {
+  position: relative;
+}
+
+.sub-tabs-arrow {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  padding: 0;
+  border: 0;
+  color: var(--ds-text-secondary);
+  cursor: pointer;
+  font: inherit;
+}
+
+.sub-tabs-arrow:disabled {
+  display: none;
+}
+
+.sub-tabs-arrow-left {
+  left: 0;
+  background: linear-gradient(to right, var(--ds-card) 55%, transparent);
+}
+
+.sub-tabs-arrow-right {
+  right: 0;
+  background: linear-gradient(to left, var(--ds-card) 55%, transparent);
+}
+
+.sub-tabs-arrow:hover .sub-tabs-arrow-icon {
+  color: var(--ds-text);
+}
+
+.sub-tabs-arrow-icon {
+  width: 14px;
+  height: 14px;
+}
+
 .ds-switch-thumb {
   background: var(--ds-switch-thumb);
   box-shadow: var(--ds-shadow-sm);

--- a/tests/sidepanel-navigation.test.ts
+++ b/tests/sidepanel-navigation.test.ts
@@ -16,6 +16,13 @@ beforeEach(() => {
   container = document.createElement('div');
   document.body.append(container);
   root = null;
+  // jsdom has no ResizeObserver; SubTabs uses it to recompute overflow
+  // chevrons. Browsers always provide it.
+  vi.stubGlobal('ResizeObserver', class {
+    observe(): void {}
+    disconnect(): void {}
+    unobserve(): void {}
+  });
 
   vi.stubGlobal('chrome', {
     runtime: {

--- a/tests/subtabs-overflow.test.ts
+++ b/tests/subtabs-overflow.test.ts
@@ -1,0 +1,251 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SubTabs } from '../entrypoints/sidepanel/components/settings/primitives';
+
+let container: HTMLDivElement;
+let root: Root | null;
+let resizeCallback: (() => void) | null = null;
+
+const TABS = [
+  { key: 'general', label: 'General' },
+  { key: 'api', label: 'API' },
+  { key: 'prompt', label: 'Prompt' },
+  { key: 'voice', label: 'Voice' },
+  { key: 'appearance', label: 'Appearance' },
+  { key: 'usage', label: 'Usage' },
+  { key: 'data', label: 'Data' },
+  { key: 'projectFiles', label: 'Project Files' },
+  { key: 'about', label: 'About' },
+];
+
+function defineLayout(
+  element: HTMLElement,
+  layout: { clientWidth?: number; scrollWidth?: number; scrollLeft?: number },
+): void {
+  if (layout.clientWidth !== undefined) {
+    Object.defineProperty(element, 'clientWidth', { configurable: true, value: layout.clientWidth });
+  }
+  if (layout.scrollWidth !== undefined) {
+    Object.defineProperty(element, 'scrollWidth', { configurable: true, value: layout.scrollWidth });
+  }
+  if (layout.scrollLeft !== undefined) {
+    Object.defineProperty(element, 'scrollLeft', { configurable: true, value: layout.scrollLeft, writable: true });
+  }
+}
+
+/** Simulate the container resizing: re-runs the component's ResizeObserver. */
+async function resize() {
+  await act(async () => {
+    resizeCallback?.();
+  });
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement('div');
+  document.body.append(container);
+  root = null;
+  resizeCallback = null;
+
+  vi.stubGlobal('ResizeObserver', class {
+    constructor(callback: () => void) {
+      resizeCallback = callback;
+    }
+    observe(): void {}
+    disconnect(): void {
+      resizeCallback = null;
+    }
+    unobserve(): void {}
+  });
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn(() => ({ matches: false })),
+  });
+});
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount());
+  }
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function renderSubTabs(props: {
+  tabs?: { key: string; label: string }[];
+  value?: string;
+  onChange?: (key: string) => void;
+}) {
+  await act(async () => {
+    root = createRoot(container);
+    root.render(React.createElement(SubTabs, {
+      tabs: props.tabs ?? TABS,
+      value: props.value ?? 'general',
+      onChange: props.onChange ?? (() => {}),
+      ariaLabel: 'test sub navigation',
+    }));
+  });
+}
+
+async function rerender(value: string) {
+  await act(async () => {
+    root?.render(React.createElement(SubTabs, {
+      tabs: TABS,
+      value,
+      onChange: () => {},
+      ariaLabel: 'test sub navigation',
+    }));
+  });
+}
+
+function nav(): HTMLElement {
+  const element = container.querySelector('nav[role="tablist"]');
+  expect(element).toBeTruthy();
+  return element as HTMLElement;
+}
+
+function arrow(direction: 'left' | 'right'): HTMLButtonElement {
+  const element = container.querySelector(`.sub-tabs-arrow-${direction}`) as HTMLButtonElement | null;
+  expect(element).toBeTruthy();
+  return element!;
+}
+
+function tabByLabel(label: string): HTMLButtonElement {
+  const element = Array.from(container.querySelectorAll('button[role="tab"]')).find(
+    (button) => button.textContent === label,
+  ) as HTMLButtonElement | undefined;
+  expect(element).toBeTruthy();
+  return element!;
+}
+
+function stubScrollBy(list: HTMLElement) {
+  const scrollBy = vi.fn((options: { left: number }) => {
+    const next = Math.max(0, (list.scrollLeft ?? 0) + options.left);
+    Object.defineProperty(list, 'scrollLeft', { configurable: true, value: next, writable: true });
+    list.dispatchEvent(new Event('scroll'));
+  });
+  list.scrollBy = scrollBy as unknown as typeof list.scrollBy;
+  return scrollBy;
+}
+
+describe('SubTabs overflow chevrons', () => {
+  it('hides both arrows while the strip fits its container', async () => {
+    await renderSubTabs({});
+    defineLayout(nav(), { clientWidth: 800, scrollWidth: 800, scrollLeft: 0 });
+    await resize();
+
+    expect(arrow('left').disabled).toBe(true);
+    expect(arrow('right').disabled).toBe(true);
+  });
+
+  it('shows the right arrow on overflow and scrolls by the visible width on click', async () => {
+    await renderSubTabs({});
+    const list = nav();
+    defineLayout(list, { clientWidth: 200, scrollWidth: 800, scrollLeft: 0 });
+    const scrollBy = stubScrollBy(list);
+    await resize();
+
+    expect(arrow('left').disabled).toBe(true);
+    expect(arrow('right').disabled).toBe(false);
+
+    await act(async () => {
+      arrow('right').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(scrollBy).toHaveBeenCalledTimes(1);
+    const amount = (scrollBy.mock.calls[0] as unknown as [{ left: number }])[0].left;
+    // ~70% of the visible width, at least 120px.
+    expect(amount).toBeGreaterThanOrEqual(120);
+  });
+
+  it('reveals the left arrow after scrolling and hides it again at the start', async () => {
+    await renderSubTabs({});
+    const list = nav();
+    defineLayout(list, { clientWidth: 200, scrollWidth: 800, scrollLeft: 0 });
+    stubScrollBy(list);
+    await resize();
+
+    await act(async () => {
+      arrow('right').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(arrow('left').disabled).toBe(false);
+
+    await act(async () => {
+      arrow('left').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(arrow('left').disabled).toBe(true);
+    expect(arrow('right').disabled).toBe(false);
+  });
+
+  it('keeps the selected tab in view when selection moves off-screen', async () => {
+    await renderSubTabs({ value: 'general' });
+    const list = nav();
+    defineLayout(list, { clientWidth: 200, scrollWidth: 800, scrollLeft: 0 });
+    const scrollTo = vi.fn((options: { left: number }) => {
+      Object.defineProperty(list, 'scrollLeft', { configurable: true, value: options.left, writable: true });
+    });
+    list.scrollTo = scrollTo as unknown as typeof list.scrollTo;
+    const aboutTab = tabByLabel('About');
+    Object.defineProperty(aboutTab, 'offsetLeft', { configurable: true, value: 780 });
+    Object.defineProperty(aboutTab, 'offsetWidth', { configurable: true, value: 60 });
+
+    await rerender('about');
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    const target = (scrollTo.mock.calls[0] as unknown as [{ left: number }])[0].left;
+    expect(target).toBe(780 + 60 - 200);
+  });
+
+  it('keeps the left/right arrow keyboard navigation working', async () => {
+    const onChange = vi.fn();
+    await renderSubTabs({ value: 'general', onChange });
+
+    await act(async () => {
+      tabByLabel('General').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    });
+    expect(onChange).toHaveBeenCalledWith('api');
+  });
+
+  it('has distinct localized aria labels for the arrow buttons', async () => {
+    await renderSubTabs({});
+    const left = arrow('left').getAttribute('aria-label');
+    const right = arrow('right').getAttribute('aria-label');
+    expect(left).toBeTruthy();
+    expect(right).toBeTruthy();
+    expect(left).not.toBe(right);
+  });
+});
+
+describe('SubTabs reduced motion and CSS contract', () => {
+  it('uses auto scrolling when the user prefers reduced motion', async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+      })),
+    });
+    await renderSubTabs({ value: 'general' });
+    const list = nav();
+    defineLayout(list, { clientWidth: 200, scrollWidth: 800, scrollLeft: 0 });
+    const scrollTo = vi.fn();
+    list.scrollTo = scrollTo as unknown as typeof list.scrollTo;
+    const aboutTab = tabByLabel('About');
+    Object.defineProperty(aboutTab, 'offsetLeft', { configurable: true, value: 780 });
+    Object.defineProperty(aboutTab, 'offsetWidth', { configurable: true, value: 60 });
+
+    await rerender('about');
+    expect((scrollTo.mock.calls[0] as unknown as [{ behavior: string }])[0].behavior).toBe('auto');
+  });
+
+  it('keeps the sub-tabs CSS shell and arrow rules in the stylesheet', () => {
+    const css = readFileSync(
+      resolve(__dirname, '../entrypoints/sidepanel/style.css'),
+      'utf8',
+    );
+    for (const selector of ['.sub-tabs-shell', '.sub-tabs-arrow', '.sub-tabs-arrow-left', '.sub-tabs-arrow-right']) {
+      expect(css).toContain(selector);
+    }
+  });
+});

--- a/tests/sync-settings-target.test.ts
+++ b/tests/sync-settings-target.test.ts
@@ -31,6 +31,13 @@ beforeEach(() => {
   root = null;
   runtimeMessageListener = null;
   sendMessage = vi.fn(defaultRuntimeResponse);
+  // jsdom has no ResizeObserver; SubTabs uses it to recompute overflow
+  // chevrons. Browsers always provide it.
+  vi.stubGlobal('ResizeObserver', class {
+    observe(): void {}
+    disconnect(): void {}
+    unobserve(): void {}
+  });
 
   vi.stubGlobal('chrome', {
     runtime: {


### PR DESCRIPTION
## Summary

共享 `SubTabs` 组件（设置/能力/资料库三处导航）在窄侧边栏下会隐藏溢出 Tab 且无可视提示（滚动条被隐藏）。本 PR 在条带两端叠加滚动按钮：

- 仅当该方向确有隐藏内容时显示对应按钮（`display:none` 隐藏，不占布局）；
- 点击按可视宽度约 70% 平滑滚动（≥120px）；
- 选中项变化/键盘切换时，激活 Tab 自动滚入视区（最小滚动量）；
- 容器尺寸（ResizeObserver）、标签语言变化、Tab 数量变化时重新计算箭头可见性；
- 保留 `tablist/tab`、左右方向键与 reduced-motion 语义（reduced-motion 用户为瞬时滚动）；
- 纯 CSS + 内联 SVG 箭头（currentColor），无第三方资产。

## PR Type

- [x] User-facing feature or behavior change
- [ ] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

```bash
git fetch origin && git rebase origin/main
# base: e6d2ee7 (Release DeepSeek++ 1.12.0)
```

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

DeepSeek（辅助）

Coding Agent tool(s) used:

Codex

## Local Validation

Commands run:

```bash
npx vitest run tests/subtabs-overflow.test.ts tests/sidepanel-navigation.test.ts tests/sidepanel-lazy-routes.test.ts
npm run compile
npm run verify:i18n
npm run build:all
npm run verify:manifest-policy
npm run verify:sidepanel-chunks
npm run verify:extension-utf8
```

Result summary:

- 新增 `tests/subtabs-overflow.test.ts` **8/8 通过**：溢出时右箭头出现、点击按可视宽度滚动、回滚后左箭头隐藏、选中项滚入视区、键盘方向键回归、reduced-motion 瞬时滚动、箭头 aria-label 与 CSS 契约
- `sidepanel-navigation` / `sidepanel-lazy-routes` 回归 **18/18 通过**（jsdom 补 ResizeObserver stub）
- `npm run compile`、`verify:i18n`（399 files）、三浏览器构建、`verify:manifest-policy`、`verify:sidepanel-chunks`、`verify:extension-utf8` 全部通过

## Local Feature Evidence

Evidence:

N/A — 仓库 owner 自查 PR，按贡献规则豁免截图证据（pr-contribution-rules.yml）。溢出/滚动/键盘/reduced-motion 行为由 tests/subtabs-overflow.test.ts 的 DOM 断言覆盖。

