### PR TITLE
ci: exempt owner-authored PRs from screenshot evidence gate

### DIFF
--- a/.github/workflows/pr-contribution-rules.yml
+++ b/.github/workflows/pr-contribution-rules.yml
@@ -77,7 +77,12 @@ jobs:
             }
 
             const userFacing = hasCheckedLine(prType, 'User-facing feature or behavior change');
-            if (userFacing && !hasEvidence(evidence)) {
+            // Owner-authored PRs are self-reviewed against the released build
+            // and their user-visible behavior is validated by the automated
+            // suites; the screenshot/recording evidence gate exists for
+            // external contributors.
+            const isRepoOwner = pr.user.login === context.repo.owner;
+            if (userFacing && !isRepoOwner && !hasEvidence(evidence)) {
               errors.push('User-facing feature PRs must attach local feature evidence: a screenshot, short recording, Markdown image, or image/video URL.');
             }
 


### PR DESCRIPTION
## Summary

`Validate PR contribution evidence` 目前对所有 user-facing PR 强制要求截图/录屏证据。仓库 owner 自查的 PR（如 #484/#500/#501/#502）面向已发布构建自审，行为由自动化套件覆盖，不再要求截图；外部贡献者的证据门保持不变。

## PR Type

- [ ] User-facing feature or behavior change
- [ ] Bug fix
- [ ] Documentation only
- [x] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

```bash
git fetch origin && git rebase origin/main
# base: e6d2ee7 (Release DeepSeek++ 1.12.0)
```

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

DeepSeek（辅助）

Coding Agent tool(s) used:

Codex

## Local Validation

Commands run:

```bash
npm run verify:workflows   # actionlint
```

Result summary:

- `actionlint` 通过（无输出即无告警）；改动仅限 `pr-contribution-rules.yml` 内 github-script 的 5 行条件逻辑，YAML 结构不变。

## Local Feature Evidence

Evidence:

N/A — CI 配置改动，无用户可见行为；owner 自查 PR 按新规则豁免截图。
