### PR TITLE
[P2-B1] StreamFn 模型后端适配：DS 网页薄适配器

### DIFF
--- a/core/inline-agent/loop.ts
+++ b/core/inline-agent/loop.ts
@@ -22,9 +22,6 @@ import {
 import {
   INLINE_AGENT_MAX_NUDGES,
   INLINE_AGENT_MAX_STEPS,
-  INLINE_AGENT_REQUEST_DELAY_MAX_MS,
-  INLINE_AGENT_REQUEST_DELAY_MIN_MS,
-  INLINE_AGENT_STEP_TIMEOUT_MS,
   type InlineAgentLoopCompleteMsg,
   type InlineAgentLoopErrorMsg,
   type InlineAgentStartPayload,
@@ -32,6 +29,7 @@ import {
   type InlineAgentStreamChunkMsg,
   type InlineAgentToolDetectedMsg,
 } from './types';
+import { createStepSignal, waitBetweenDeepSeekRequests } from './step-control';
 
 type PostFn = (type: string, data: unknown) => void;
 type ExecuteToolFn = (call: ToolCall) => Promise<ToolExecutionRecord>;
@@ -442,51 +440,6 @@ function clampStreamEventText(value: string): string {
   return value.length > INLINE_AGENT_STREAM_EVENT_MAX_CHARS
     ? `${value.slice(0, INLINE_AGENT_STREAM_EVENT_MAX_CHARS)}${TRUNCATION_SUFFIX}`
     : value;
-}
-
-function waitBetweenDeepSeekRequests(signal: AbortSignal): Promise<void> {
-  if (signal.aborted) return Promise.resolve();
-  const delay = randomInt(INLINE_AGENT_REQUEST_DELAY_MIN_MS, INLINE_AGENT_REQUEST_DELAY_MAX_MS);
-  return new Promise((resolve) => {
-    const timeout = setTimeout(cleanup, delay);
-    const onAbort = () => cleanup();
-
-    function cleanup() {
-      clearTimeout(timeout);
-      signal.removeEventListener('abort', onAbort);
-      resolve();
-    }
-
-    signal.addEventListener('abort', onAbort, { once: true });
-  });
-}
-
-function randomInt(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
-}
-
-function createStepSignal(parentSignal: AbortSignal): {
-  signal: AbortSignal;
-  clear: () => void;
-  timedOut: () => boolean;
-} {
-  const controller = new AbortController();
-  let timedOut = false;
-  const timeout = setTimeout(() => {
-    timedOut = true;
-    controller.abort(new DOMException('Agent step timed out.', 'TimeoutError'));
-  }, INLINE_AGENT_STEP_TIMEOUT_MS);
-  const onParentAbort = () => controller.abort();
-  if (parentSignal.aborted) {
-    onParentAbort();
-  } else {
-    parentSignal.addEventListener('abort', onParentAbort, { once: true });
-  }
-  const clear = () => {
-    clearTimeout(timeout);
-    parentSignal.removeEventListener('abort', onParentAbort);
-  };
-  return { signal: controller.signal, clear, timedOut: () => timedOut };
 }
 
 /**

--- a/core/inline-agent/pi/deepseek-stream-fn.ts
+++ b/core/inline-agent/pi/deepseek-stream-fn.ts
@@ -1,0 +1,270 @@
+/**
+ * DeepSeek-web StreamFn adapter (Issue A1-T2).
+ *
+ * Wraps the DeepSeek web session as a pi `StreamFn` model backend:
+ *
+ *  - `createDeepSeekTurnSubmitter` — thin adapter over `submitPromptStreaming`
+ *    that mirrors the original loop's turn semantics exactly: client headers +
+ *    PoW headers created once per turn, a bounded single retry that is only
+ *    allowed when no text chunk was received (retrying after streamed content
+ *    could fork the conversation chain), and the 120s step timeout. The
+ *    original loop's implementation is replaced by this module in Issue A3;
+ *    until then the two copies share the extracted `step-control` helpers.
+ *
+ *  - `createDeepSeekStreamFn` — maps the DS-web text/tool-call stream into pi
+ *    `AssistantMessageEventStream` protocol events. Never throws: request,
+ *    model and runtime failures are encoded as protocol `error` events with a
+ *    final AssistantMessage carrying stopReason "error"/"aborted"
+ *    (StreamFn contract).
+ *
+ * The DS-web conversation chain stays the authority: `parentMessageId` is
+ * read from and written back to the injected session state (never derived
+ * from the pi context) — fail-closed against chain forks (risk (g)).
+ */
+import { createAssistantMessageEventStream } from '@earendil-works/pi-ai';
+import type {
+  Api,
+  AssistantMessage,
+  AssistantMessageEvent,
+  Model,
+  ToolCall,
+  Usage,
+} from '@earendil-works/pi-ai';
+import type { StreamFn } from '@earendil-works/pi-agent-core';
+import {
+  createClientHeaders,
+  createPowHeaders,
+  submitPromptStreaming,
+  type ModelTurn,
+  type SubmitPromptInput,
+} from '../../deepseek/adapter';
+import { createStreamingToolCallParser } from '../../interceptor/streaming-tool-call-parser';
+import { createStreamingToolTextAccumulator } from '../../interceptor/streaming-tool-text';
+import type { ToolCall as CoreToolCall } from '../../types';
+import { createStepSignal, waitBetweenDeepSeekRequests } from '../step-control';
+import type {
+  DeepSeekStreamFnDeps,
+  DeepSeekTurnCallbacks,
+  DeepSeekTurnRequest,
+  DeepSeekTurnResult,
+  DeepSeekTurnSubmitter,
+  ParsedXmlToolCall,
+} from './stream-fn-port';
+
+const INLINE_AGENT_MAX_STEP_ATTEMPTS = 2;
+
+export interface DeepSeekTurnSubmitterOptions {
+  powWasmUrl?: string;
+}
+
+/**
+ * Builds the turn submitter: one turn = one PoW solve + bounded no-chunk
+ * retry + 120s step timeout, mirroring the original `submitAgentTurn`.
+ */
+export function createDeepSeekTurnSubmitter(
+  options: DeepSeekTurnSubmitterOptions = {},
+): DeepSeekTurnSubmitter {
+  const { powWasmUrl } = options;
+
+  return async (request, callbacks, signal) => {
+    const clientHeaders = createClientHeaders();
+    const powHeaders = await createPowHeaders(clientHeaders, powWasmUrl);
+    const input: SubmitPromptInput = {
+      chatSessionId: request.chatSessionId,
+      parentMessageId: request.parentMessageId,
+      modelType: request.modelType,
+      prompt: request.prompt,
+      refFileIds: request.refFileIds,
+      thinkingEnabled: request.thinkingEnabled,
+      searchEnabled: request.searchEnabled,
+      clientHeaders,
+      powHeaders,
+    };
+    return submitWithRetry(input, callbacks, signal);
+  };
+}
+
+/**
+ * Builds the pi StreamFn over the DS-web backend. The returned function never
+ * rejects; failures are encoded as protocol events.
+ */
+export function createDeepSeekStreamFn(deps: DeepSeekStreamFnDeps): StreamFn {
+  const { submitTurn, session, serializePrompt, mapToolCall, toolDescriptors, turnDefaults } = deps;
+
+  return (model, context, options) => {
+    const stream = createAssistantMessageEventStream();
+    const signal = options?.signal;
+
+    const partial = createEmptyAssistantMessage(model);
+    const emit = (event: AssistantMessageEvent) => stream.push(event);
+    const snapshot = () => ({ ...partial, content: [...partial.content] });
+
+    emit({ type: 'start', partial: snapshot() });
+
+    void (async () => {
+      try {
+        const request: DeepSeekTurnRequest = {
+          chatSessionId: session.chatSessionId,
+          parentMessageId: session.parentMessageId,
+          modelType: turnDefaults.modelType ?? model.id ?? null,
+          prompt: serializePrompt(context),
+          refFileIds: turnDefaults.refFileIds,
+          thinkingEnabled: turnDefaults.thinkingEnabled,
+          searchEnabled: turnDefaults.searchEnabled,
+        };
+
+        const textAccumulator = createStreamingToolTextAccumulator(toolDescriptors);
+        const toolCallParser = createStreamingToolCallParser(toolDescriptors);
+        let lastVisibleText = '';
+        let textContentIndex: number | null = null;
+        let toolCallCount = 0;
+
+        const emitText = (fullText: string) => {
+          const delta = fullText.slice(lastVisibleText.length);
+          lastVisibleText = fullText;
+          if (!delta) return;
+          if (textContentIndex === null) {
+            textContentIndex = partial.content.length;
+            partial.content.push({ type: 'text', text: fullText });
+            emit({ type: 'text_start', contentIndex: textContentIndex, partial: snapshot() });
+          } else {
+            partial.content[textContentIndex] = { type: 'text', text: fullText };
+          }
+          emit({ type: 'text_delta', contentIndex: textContentIndex, delta, partial: snapshot() });
+        };
+
+        const emitToolCall = (parsed: ParsedXmlToolCall) => {
+          const toolCall = mapToolCall(parsed, toolCallCount);
+          toolCallCount += 1;
+          const contentIndex = partial.content.length;
+          partial.content.push({ type: 'toolCall', id: toolCall.id, name: toolCall.name, arguments: {} });
+          emit({ type: 'toolcall_start', contentIndex, partial: snapshot() });
+          partial.content[contentIndex] = toolCall;
+          emit({ type: 'toolcall_end', contentIndex, toolCall, partial: snapshot() });
+        };
+
+        const onParsed = (parsed: { completed: CoreToolCall[]; failed: CoreToolCall[] }) => {
+          for (const call of parsed.completed) {
+            emitToolCall({ name: call.name, invocationName: call.invocationName ?? call.name, payload: call.payload });
+          }
+          for (const call of parsed.failed) {
+            emitToolCall({ name: call.name, invocationName: call.invocationName ?? call.name, payload: call.payload });
+          }
+        };
+
+        const callbacks: DeepSeekTurnCallbacks = {
+          onTextChunk(text) {
+            emitText(textAccumulator.append(text));
+            onParsed(toolCallParser.append(text));
+          },
+          onTokenSpeed(progress) {
+            deps.onTokenSpeed?.(progress);
+          },
+        };
+
+        const result = await submitTurn(request, callbacks, signal);
+
+        // The conversation chain authority: the page session, not this turn's
+        // transcript, owns the next parent message id.
+        session.setParentMessageId(result.responseMessageId);
+
+        onParsed(toolCallParser.flush());
+        emitText(textAccumulator.flush());
+        if (textContentIndex !== null) {
+          emit({
+            type: 'text_end',
+            contentIndex: textContentIndex,
+            content: lastVisibleText,
+            partial: snapshot(),
+          });
+        }
+
+        partial.stopReason = partial.content.some((block) => block.type === 'toolCall') ? 'toolUse' : 'stop';
+        emit({ type: 'done', reason: partial.stopReason, message: snapshot() });
+      } catch (err) {
+        const aborted = signal?.aborted ?? false;
+        partial.stopReason = aborted ? 'aborted' : 'error';
+        partial.errorMessage = aborted ? 'Aborted' : (err instanceof Error ? err.message : String(err));
+        emit({ type: 'error', reason: partial.stopReason, error: snapshot() });
+      }
+    })();
+
+    return stream;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Submits one turn with a bounded single retry. A retry is only allowed when
+ * the request failed before any text chunk was received: once the server has
+ * streamed content the turn is likely committed server-side, and replaying it
+ * with the same parent message could fork the conversation chain. User abort
+ * is never retried. Mirrors the original loop's `submitAgentTurn`.
+ */
+async function submitWithRetry(
+  input: SubmitPromptInput,
+  callbacks: DeepSeekTurnCallbacks,
+  parentSignal: AbortSignal | undefined,
+): Promise<DeepSeekTurnResult> {
+  const signal = parentSignal ?? new AbortController().signal;
+  let receivedAnyChunk = false;
+
+  for (let attempt = 1; attempt <= INLINE_AGENT_MAX_STEP_ATTEMPTS; attempt++) {
+    const stepTimeout = createStepSignal(signal);
+    try {
+      const turn: ModelTurn = await submitPromptStreaming(input, {
+        retainAssistantText: false,
+        onTextChunk(text, fullText) {
+          receivedAnyChunk = true;
+          callbacks.onTextChunk(text, fullText);
+        },
+        onTokenSpeed: callbacks.onTokenSpeed,
+      }, stepTimeout.signal);
+      return {
+        assistantText: turn.assistantText,
+        responseMessageId: turn.responseMessageId,
+        requestMessageId: turn.requestMessageId,
+        finished: turn.finished,
+      };
+    } catch (err) {
+      if (signal.aborted) throw err;
+      const timeoutFired = stepTimeout.timedOut();
+      if (timeoutFired && receivedAnyChunk) {
+        throw new Error('DeepSeek agent step timed out while streaming; the response was interrupted.');
+      }
+      if (attempt >= INLINE_AGENT_MAX_STEP_ATTEMPTS) {
+        if (timeoutFired) throw new Error('DeepSeek agent step timed out after retry.');
+        throw err;
+      }
+      await waitBetweenDeepSeekRequests(signal);
+      if (signal.aborted) throw err;
+    } finally {
+      stepTimeout.clear();
+    }
+  }
+  throw new Error('DeepSeek agent step failed without a completed attempt.');
+}
+
+function createEmptyAssistantMessage(model: Model<Api>): AssistantMessage {
+  const emptyUsage: Usage = {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+  return {
+    role: 'assistant',
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: emptyUsage,
+    stopReason: 'stop',
+    timestamp: Date.now(),
+  };
+}

--- a/core/inline-agent/pi/stream-fn-port.ts
+++ b/core/inline-agent/pi/stream-fn-port.ts
@@ -1,0 +1,110 @@
+/**
+ * StreamFn port for the pi-agent-core integration (Issue A1).
+ *
+ * Contract module: declares the serializable seam between the pi agent loop
+ * and the DeepSeek web backend. It MUST NOT import concrete browser, DOM,
+ * provider, or entrypoint implementations (AGENTS.md contract rule); only
+ * pure types from pi packages and core type modules are allowed.
+ *
+ * The port has four parts:
+ *  1. `DeepSeekTurnRequest/Callbacks/Result` — one DS-web turn, serializable.
+ *  2. `DeepSeekTurnSubmitter` — the injection point satisfied by a thin
+ *     wrapper around `submitPromptStreaming` (A1-T2).
+ *  3. `DeepSeekSessionState` — the DS conversation-chain authority owned by
+ *     the loop adapter (A3). The page session, never the pi context, is the
+ *     source of truth for `parentMessageId` (fail-closed against chain forks).
+ *  4. `DeepSeekStreamFnFactory` — the pi `StreamFn` factory (A1-T2).
+ *
+ * Version-drift guard: `tests/stream-fn-port.test.ts` asserts assignability
+ * against the exact pi export shapes, so an upstream API break fails
+ * compilation instead of surfacing at runtime.
+ */
+import type { AgentContext, StreamFn } from '@earendil-works/pi-agent-core';
+import type { ToolCall } from '@earendil-works/pi-ai';
+import type { ResponseTokenSpeedPayload } from '../../deepseek/stream-metrics';
+
+/** One DS-web turn request — the serializable wire contract. */
+export interface DeepSeekTurnRequest {
+  chatSessionId: string;
+  parentMessageId: number | null;
+  modelType: string | null;
+  prompt: string;
+  refFileIds: string[];
+  thinkingEnabled: boolean;
+  searchEnabled: boolean;
+}
+
+/** Callbacks invoked while the DS-web turn streams. */
+export interface DeepSeekTurnCallbacks {
+  onTextChunk: (text: string, fullText: string) => void;
+  onTokenSpeed: (progress: ResponseTokenSpeedPayload) => void;
+}
+
+/** Result of one completed DS-web turn. */
+export interface DeepSeekTurnResult {
+  assistantText: string;
+  responseMessageId: number | null;
+  requestMessageId: number | null;
+  finished: boolean;
+}
+
+/**
+ * The model-backend seam: submits one DS-web turn and resolves with its
+ * result. Satisfied by a thin wrapper around `submitPromptStreaming`
+ * (same callbacks, same no-chunk-retry / abort semantics).
+ */
+export type DeepSeekTurnSubmitter = (
+  request: DeepSeekTurnRequest,
+  callbacks: DeepSeekTurnCallbacks,
+  signal?: AbortSignal,
+) => Promise<DeepSeekTurnResult>;
+
+/**
+ * DS conversation-chain state owned by the loop adapter (A3).
+ *
+ * The page session is the authority: the pi context is only the current-turn
+ * working memory (risk (g) mitigation). `setParentMessageId` is called with
+ * every successful turn result; a `null` response id fails closed (tool calls
+ * are refused without a continuable chain link).
+ */
+export interface DeepSeekSessionState {
+  chatSessionId: string;
+  parentMessageId: number | null;
+  setParentMessageId: (id: number | null) => void;
+}
+
+/**
+ * Serializes the pi agent context (system prompt + message transcript) into
+ * the DS-web wire prompt. Pure function; must not throw.
+ *
+ * The inline-agent wire contract (`<original_task>`/`<tool_results>`/
+ * `<task_complete>` markers, truncation suffixes, invisible placeholders) is
+ * preserved by this serializer — pi's own prompt templates are never used
+ * (prompt-bytes invariant, AGENTS.md).
+ */
+export type DeepSeekPromptSerializer = (context: AgentContext) => string;
+
+/** Parsed XML tool call shape produced by the DS stream parser. */
+export interface ParsedXmlToolCall {
+  name: string;
+  invocationName: string;
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Maps one parsed XML tool call (from the DS text stream) to the pi ToolCall
+ * shape. `index` is the zero-based position within the turn, used to
+ * synthesize the required stable `id` when the XML block carries none.
+ */
+export type DeepSeekToolCallMapper = (call: ParsedXmlToolCall, index: number) => ToolCall;
+
+/** Dependencies required to build the DS-web StreamFn (A1-T2). */
+export interface DeepSeekStreamFnDeps {
+  submitTurn: DeepSeekTurnSubmitter;
+  session: DeepSeekSessionState;
+  serializePrompt: DeepSeekPromptSerializer;
+  mapToolCall: DeepSeekToolCallMapper;
+}
+
+/** The pi StreamFn factory implemented by the DS-web adapter. */
+export type DeepSeekStreamFnFactory = (deps: DeepSeekStreamFnDeps) => StreamFn;

--- a/core/inline-agent/pi/stream-fn-port.ts
+++ b/core/inline-agent/pi/stream-fn-port.ts
@@ -19,8 +19,9 @@
  * against the exact pi export shapes, so an upstream API break fails
  * compilation instead of surfacing at runtime.
  */
-import type { AgentContext, StreamFn } from '@earendil-works/pi-agent-core';
-import type { ToolCall } from '@earendil-works/pi-ai';
+import type { StreamFn } from '@earendil-works/pi-agent-core';
+import type { Context, ToolCall } from '@earendil-works/pi-ai';
+import type { ToolDescriptor } from '../../types';
 import type { ResponseTokenSpeedPayload } from '../../deepseek/stream-metrics';
 
 /** One DS-web turn request — the serializable wire contract. */
@@ -74,7 +75,7 @@ export interface DeepSeekSessionState {
 }
 
 /**
- * Serializes the pi agent context (system prompt + message transcript) into
+ * Serializes the pi request context (system prompt + message transcript) into
  * the DS-web wire prompt. Pure function; must not throw.
  *
  * The inline-agent wire contract (`<original_task>`/`<tool_results>`/
@@ -82,7 +83,7 @@ export interface DeepSeekSessionState {
  * preserved by this serializer — pi's own prompt templates are never used
  * (prompt-bytes invariant, AGENTS.md).
  */
-export type DeepSeekPromptSerializer = (context: AgentContext) => string;
+export type DeepSeekPromptSerializer = (context: Context) => string;
 
 /** Parsed XML tool call shape produced by the DS stream parser. */
 export interface ParsedXmlToolCall {
@@ -98,12 +99,29 @@ export interface ParsedXmlToolCall {
  */
 export type DeepSeekToolCallMapper = (call: ParsedXmlToolCall, index: number) => ToolCall;
 
+/** Per-run DS-web turn defaults (from the loop adapter's prompt options). */
+export interface DeepSeekTurnDefaults {
+  modelType: string | null;
+  refFileIds: string[];
+  thinkingEnabled: boolean;
+  searchEnabled: boolean;
+}
+
 /** Dependencies required to build the DS-web StreamFn (A1-T2). */
 export interface DeepSeekStreamFnDeps {
   submitTurn: DeepSeekTurnSubmitter;
   session: DeepSeekSessionState;
   serializePrompt: DeepSeekPromptSerializer;
   mapToolCall: DeepSeekToolCallMapper;
+  /** Tool descriptors used to parse XML tool calls out of the DS text stream. */
+  toolDescriptors: readonly ToolDescriptor[];
+  /** Per-run defaults merged into every turn request. */
+  turnDefaults: DeepSeekTurnDefaults;
+  /**
+   * Optional forwarder for DS-web token-speed progress. The loop adapter
+   * (A3) wires this to the `AGENT_TOKEN_SPEED` page event.
+   */
+  onTokenSpeed?: (progress: ResponseTokenSpeedPayload) => void;
 }
 
 /** The pi StreamFn factory implemented by the DS-web adapter. */

--- a/core/inline-agent/step-control.ts
+++ b/core/inline-agent/step-control.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared step-level control helpers for the inline agent.
+ *
+ * Extracted from the original self-built loop (loop.ts) so the DS-web
+ * StreamFn adapter (Issue A1) can reuse the exact same timeout/abort and
+ * request-throttling semantics without duplicating them. Behavior is
+ * byte-identical to the previous private implementations; the original
+ * loop is replaced by the pi engine in Issue A3, which consumes this
+ * module as well.
+ */
+import {
+  INLINE_AGENT_REQUEST_DELAY_MAX_MS,
+  INLINE_AGENT_REQUEST_DELAY_MIN_MS,
+  INLINE_AGENT_STEP_TIMEOUT_MS,
+} from './types';
+
+export interface StepSignal {
+  signal: AbortSignal;
+  clear: () => void;
+  timedOut: () => boolean;
+}
+
+/**
+ * Creates an abort signal that fires either when the parent signal aborts or
+ * when the step timeout (120s) elapses. Mirrors the original loop semantics:
+ * the timeout reason is a `TimeoutError` DOMException and `timedOut()` reports
+ * whether the timeout (not a parent abort) fired.
+ */
+export function createStepSignal(parentSignal: AbortSignal): StepSignal {
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort(new DOMException('Agent step timed out.', 'TimeoutError'));
+  }, INLINE_AGENT_STEP_TIMEOUT_MS);
+  const onParentAbort = () => controller.abort();
+  if (parentSignal.aborted) {
+    onParentAbort();
+  } else {
+    parentSignal.addEventListener('abort', onParentAbort, { once: true });
+  }
+  const clear = () => {
+    clearTimeout(timeout);
+    parentSignal.removeEventListener('abort', onParentAbort);
+  };
+  return { signal: controller.signal, clear, timedOut: () => timedOut };
+}
+
+/** Resolves after a random 2.5–6.5s delay, or immediately when aborted. */
+export function waitBetweenDeepSeekRequests(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  const delay = randomInt(INLINE_AGENT_REQUEST_DELAY_MIN_MS, INLINE_AGENT_REQUEST_DELAY_MAX_MS);
+  return new Promise((resolve) => {
+    const timeout = setTimeout(cleanup, delay);
+    const onAbort = () => cleanup();
+
+    function cleanup() {
+      clearTimeout(timeout);
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }
+
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function randomInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -27,7 +27,7 @@
 
 | Task | Issue | Delivery Batch | PR | Status |
 |:-----|:------|:---------------|:---|:-------|
-| A0（A0-T1 + A0-T2） | [#511](https://github.com/zhu1090093659/deepseek-pp/issues/511) | P1-B1 | — | Open |
+| A0（A0-T1 + A0-T2） | [#511](https://github.com/zhu1090093659/deepseek-pp/issues/511) | P1-B1 | [#516](https://github.com/zhu1090093659/deepseek-pp/pull/516) | In review |
 | A1（A1-T1..3） | [#512](https://github.com/zhu1090093659/deepseek-pp/issues/512) | P2-B1 | — | Open |
 | A2（A2-T1..3） | [#513](https://github.com/zhu1090093659/deepseek-pp/issues/513) | P3-B1 | — | Open |
 | A3（A3-T1..3） | [#514](https://github.com/zhu1090093659/deepseek-pp/issues/514) | P4-B1 | — | Open |
@@ -37,7 +37,7 @@
 
 | Batch | Issue | Integration Branch | Validation | Depends On | Status |
 |:------|:------|:--------------------|:-----------|:-----------|:-------|
-| P1-B1 | #511 | `batch/p1-b1-contract-foundation` | golden + compile + build:chrome + pi-bundle-budget | — | Planned |
+| P1-B1 | #511 | `batch/p1-b1-contract-foundation` | golden + compile + build:chrome + pi-bundle-budget | — | **PR #516 in review** |
 | P2-B1 | #512 | `batch/p2-b1-deepseek-stream-fn` | 定向测试 + compile + build:chrome + shake 断言 | P1-B1 | Planned |
 | P3-B1 | #513 | `batch/p3-b1-tool-bridge-auth` | 定向测试 + compile + prompt:freeze + build | P1-B1 | Planned |
 | P4-B1 | #514 | `batch/p4-b1-loop-swap` | 完整验证链（prompt:freeze 零 diff → build:all → verify → 窄冒烟） | P2-B1, P3-B1 | Planned |
@@ -54,8 +54,8 @@ gh api repos/zhu1090093659/deepseek-pp/milestones --jq '.[] | select(.number==51
 
 ## Current Status
 
-**Active Phase**: Phase 1（P1-B1）执行中
-**Active Task**: A0-T1 完成（`da0ad1a`，golden 9/9 + compile + 回归 25/25）；A0-T2 进行中（lane worktree `a0-t2-dep-probe`）
+**Active Phase**: Phase 1（P1-B1）批次集成完成，PR #516 待评审
+**Active Task**: A0-T1（`da0ad1a`）+ A0-T2（lane `3de8ff1`）已合入批次分支；合并 main 时解决依赖冲突（dexie 移除 + pi 锁版）与 docs rename 碰撞（已恢复 run 文档）
 **Blockers**: 无
 
 ## Governance Status

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -27,8 +27,8 @@
 
 | Task | Issue | Delivery Batch | PR | Status |
 |:-----|:------|:---------------|:---|:-------|
-| A0（A0-T1 + A0-T2） | [#511](https://github.com/zhu1090093659/deepseek-pp/issues/511) | P1-B1 | [#516](https://github.com/zhu1090093659/deepseek-pp/pull/516) | In review |
-| A1（A1-T1..3） | [#512](https://github.com/zhu1090093659/deepseek-pp/issues/512) | P2-B1 | — | Open |
+| A0（A0-T1 + A0-T2） | [#511](https://github.com/zhu1090093659/deepseek-pp/issues/511) | P1-B1 | [#516](https://github.com/zhu1090093659/deepseek-pp/pull/516) | **Merged（#511 closed）** |
+| A1（A1-T1..3） | [#512](https://github.com/zhu1090093659/deepseek-pp/issues/512) | P2-B1 | — | 完成待 PR |
 | A2（A2-T1..3） | [#513](https://github.com/zhu1090093659/deepseek-pp/issues/513) | P3-B1 | — | Open |
 | A3（A3-T1..3） | [#514](https://github.com/zhu1090093659/deepseek-pp/issues/514) | P4-B1 | — | Open |
 | A4（A4-T1..2） | [#515](https://github.com/zhu1090093659/deepseek-pp/issues/515) | P5-B1 | — | Open |

--- a/scripts/pi-bundle-budget.mjs
+++ b/scripts/pi-bundle-budget.mjs
@@ -14,27 +14,34 @@
 //     "./node" entry). The "." entry graph is therefore browser-clean by
 //     construction.
 //
-//  3. Pi narrow-entry probe: a probe bundle importing the A3 usage surface
-//     ({ agentLoop, setDefaultStreamFn } from the "." entry) is built with
-//     the same pipeline as the extension (vite build, i.e. rolldown + esbuild
-//     minify, WXT 0.20.26 / vite 8.0.10) and must stay under the calibrated
-//     pi increment budget and contain no `node:` builtin imports and no
-//     provider-SDK markers (AWS/Anthropic/Google/Mistral/OpenAI clients must
-//     not enter the bundle).
+//  3. Narrow-entry probes: probe bundles importing the A3 usage surface are
+//     built with the same pipeline as the extension (vite build, i.e.
+//     rolldown + esbuild minify, WXT 0.20.26 / vite 8.0.10) and must stay
+//     under their calibrated budgets and contain no `node:` builtin imports
+//     and no provider-SDK markers (AWS/Anthropic/Google/Mistral/OpenAI
+//     clients must not enter the bundle). Two probes (Issue A1-T3):
+//       - pi-only: { agentLoop, setDefaultStreamFn } from the "." entry.
+//       - adapter: additionally imports the real DS-web adapter
+//         (createDeepSeekStreamFn + createDeepSeekTurnSubmitter), whose graph
+//         includes the DS++ core modules (stream codec, streaming tool
+//         parsers) that the extension content bundle already ships.
 //
 // Budget calibration (measured on 2026-08-05, Node v25.8.1, this lockfile):
-//   - rolldown probe (minified):  173,657 raw / 52,525 gzip
-//   - esbuild probe (minified):   213,749 raw / 59,616 gzip (more
+//   - rolldown pi-only probe (minified): 173,657 raw / 52,525 gzip
+//   - rolldown adapter probe (minified): 305,638 raw / 96,539 gzip (includes
+//     DS++ core modules already present in the content bundle; the probe
+//     double-counts them and is therefore conservative)
+//   - esbuild pi-only probe (minified): 213,749 raw / 59,616 gzip (more
 //     conservative retention; kept for reference)
-//   - The budgets below allow ~32% raw / ~37% gzip headroom over the rolldown
-//     measurement for bundler/engine drift and the small extra runtime surface
-//     A3 is expected to import (runAgentLoopContinue etc.). A wide-entry
-//     regression (index.js `export *` pulling pi-ai's provider catalog and the
-//     heavy SDK tree) measures ~950,000 raw / ~260,000+ gzip and blows these
-//     budgets by a wide margin.
+//   - Budgets allow ~32-40% raw / ~37-45% gzip headroom for bundler/engine
+//     drift and the extra runtime surface A3 is expected to import
+//     (runAgentLoopContinue etc.). A wide-entry regression (index.js
+//     `export *` pulling pi-ai's provider catalog and the heavy SDK tree)
+//     measures ~950,000 raw / ~260,000+ gzip and blows these budgets by a
+//     wide margin.
 //
-// The real background today (720,903 raw / 208,719 gzip) plus the pi probe
-// increment (173,657 / 52,525) would exceed the red lines (~894,560 /
+// The real background today (720,903 raw / 208,719 gzip) plus the pi-only
+// probe increment (173,657 / 52,525) would exceed the red lines (~894,560 /
 // ~261,244), so the A3 integration must plan bundle mitigation (dynamic chunk
 // for the loop engine or background slimming); this script is the guardrail
 // that keeps both sides honest meanwhile.
@@ -57,9 +64,11 @@ const policy = JSON.parse(readFileSync(
 const RED_LINE_RAW = policy.budget.backgroundRawBytesMax;
 const RED_LINE_GZIP = policy.budget.backgroundGzipBytesMax;
 
-// Calibrated pi increment budget (see header comment).
+// Calibrated probe budgets (see header comment).
 const PI_PROBE_RAW_MAX = 230_000;
 const PI_PROBE_GZIP_MAX = 72_000;
+const ADAPTER_PROBE_RAW_MAX = 340_000;
+const ADAPTER_PROBE_GZIP_MAX = 110_000;
 
 const PI_CORE_DIR = resolve(rootDir, 'node_modules/@earendil-works/pi-agent-core');
 
@@ -80,9 +89,11 @@ const report = {
   browser: requestedBrowser,
   redLine: { raw: RED_LINE_RAW, gzip: RED_LINE_GZIP },
   piProbeBudget: { raw: PI_PROBE_RAW_MAX, gzip: PI_PROBE_GZIP_MAX },
+  adapterProbeBudget: { raw: ADAPTER_PROBE_RAW_MAX, gzip: ADAPTER_PROBE_GZIP_MAX },
   bundles: {},
   piDistNodeGate: null,
   piProbe: null,
+  adapterProbe: null,
 };
 
 // ---------------------------------------------------------------------------
@@ -153,31 +164,61 @@ if (!existsSync(PI_CORE_DIR)) {
 }
 
 // ---------------------------------------------------------------------------
-// Gate 3: pi narrow-entry probe (same pipeline as the extension build).
+// Gate 3: narrow-entry probes (same pipeline as the extension build).
 // ---------------------------------------------------------------------------
 if (failures.length === 0) {
-  try {
-    const probe = await runPiProbe();
-    report.piProbe = {
-      raw: probe.raw,
-      gzip: probe.gzip,
-      nodeImports: probe.nodeImports,
-      sdkMarkers: probe.sdkMarkers,
-    };
-    if (probe.raw > PI_PROBE_RAW_MAX || probe.gzip > PI_PROBE_GZIP_MAX) {
-      failures.push(
-        `pi probe exceeds budget: raw ${probe.raw}/${PI_PROBE_RAW_MAX}, `
-        + `gzip ${probe.gzip}/${PI_PROBE_GZIP_MAX}`,
-      );
+  const probes = [
+    {
+      key: 'piProbe',
+      label: 'pi probe',
+      rawMax: PI_PROBE_RAW_MAX,
+      gzipMax: PI_PROBE_GZIP_MAX,
+      entry: [
+        "import { agentLoop, setDefaultStreamFn } from '@earendil-works/pi-agent-core';",
+        "console.log('pi-budget-probe', typeof agentLoop, typeof setDefaultStreamFn);",
+        '',
+      ].join('\n'),
+    },
+    {
+      key: 'adapterProbe',
+      label: 'adapter probe',
+      rawMax: ADAPTER_PROBE_RAW_MAX,
+      gzipMax: ADAPTER_PROBE_GZIP_MAX,
+      entry: [
+        "import { agentLoop, setDefaultStreamFn } from '@earendil-works/pi-agent-core';",
+        "import { createDeepSeekStreamFn, createDeepSeekTurnSubmitter } from '../../core/inline-agent/pi/deepseek-stream-fn';",
+        "console.log('pi-budget-probe', typeof agentLoop, typeof setDefaultStreamFn, typeof createDeepSeekStreamFn, typeof createDeepSeekTurnSubmitter);",
+        '',
+      ].join('\n'),
+    },
+  ];
+
+  for (const probeSpec of probes) {
+    try {
+      const probe = await runPiProbe(probeSpec.entry);
+      report[probeSpec.key] = {
+        raw: probe.raw,
+        gzip: probe.gzip,
+        nodeImports: probe.nodeImports,
+        sdkMarkers: probe.sdkMarkers,
+      };
+      if (probe.raw > probeSpec.rawMax || probe.gzip > probeSpec.gzipMax) {
+        failures.push(
+          `${probeSpec.label} exceeds budget: raw ${probe.raw}/${probeSpec.rawMax}, `
+          + `gzip ${probe.gzip}/${probeSpec.gzipMax}`,
+        );
+      }
+      if (probe.nodeImports > 0) {
+        failures.push(`${probeSpec.label} output contains ${probe.nodeImports} node: builtin import(s)`);
+      }
+      if (probe.sdkMarkers > 0) {
+        failures.push(
+          `${probeSpec.label} output contains ${probe.sdkMarkers} provider-SDK marker(s); heavy SDK tree leaked in`,
+        );
+      }
+    } catch (error) {
+      failures.push(`${probeSpec.label} build failed: ${error.message}`);
     }
-    if (probe.nodeImports > 0) {
-      failures.push(`pi probe output contains ${probe.nodeImports} node: builtin import(s)`);
-    }
-    if (probe.sdkMarkers > 0) {
-      failures.push(`pi probe output contains ${probe.sdkMarkers} provider-SDK marker(s); heavy SDK tree leaked in`);
-    }
-  } catch (error) {
-    failures.push(`pi probe build failed: ${error.message}`);
   }
 }
 
@@ -209,18 +250,14 @@ function relativeTo(baseDir, file) {
   return file.slice(baseDir.length + 1).replaceAll('\\', '/');
 }
 
-async function runPiProbe() {
+async function runPiProbe(entrySource) {
   // The probe entry lives under dist/ (gitignored). It uses a side-effect
   // form (console.log) because rolldown tree-shakes a pure function export
   // out of the entry chunk, which would otherwise under-report the graph.
   const probeDir = join(rootDir, 'dist', '.pi-budget-probe');
   mkdirSync(probeDir, { recursive: true });
   const entryPath = join(probeDir, 'entry.mjs');
-  writeFileSync(entryPath, [
-    "import { agentLoop, setDefaultStreamFn } from '@earendil-works/pi-agent-core';",
-    "console.log('pi-budget-probe', typeof agentLoop, typeof setDefaultStreamFn);",
-    '',
-  ].join('\n'));
+  writeFileSync(entryPath, entrySource);
 
   const { build } = await import('vite');
   const result = await build({

--- a/tests/stream-fn-adapter.test.ts
+++ b/tests/stream-fn-adapter.test.ts
@@ -1,0 +1,346 @@
+/**
+ * DeepSeek-web StreamFn adapter tests (Issue A1-T2).
+ *
+ * Uses the same adapter mock seam as the inline-agent tests
+ * (`vi.mock('../core/deepseek/adapter')`), so the turn submitter exercises
+ * the real no-chunk-retry / step-timeout semantics against mocked
+ * `submitPromptStreaming`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AssistantMessageEvent, Api, Context, Message, Model } from '@earendil-works/pi-ai';
+import { createArtifactToolDescriptors } from '../core/artifact';
+import type { ToolDescriptor } from '../core/types';
+import type {
+  DeepSeekSessionState,
+  DeepSeekStreamFnDeps,
+  DeepSeekTurnRequest,
+} from '../core/inline-agent/pi/stream-fn-port';
+
+const adapterMocks = vi.hoisted(() => ({
+  createPowHeaders: vi.fn(),
+  submitPromptStreaming: vi.fn(),
+}));
+
+vi.mock('../core/deepseek/adapter', () => ({
+  createClientHeaders: () => ({ Authorization: 'Bearer test-token' }),
+  createPowHeaders: adapterMocks.createPowHeaders,
+  submitPromptStreaming: adapterMocks.submitPromptStreaming,
+}));
+
+const { createDeepSeekStreamFn, createDeepSeekTurnSubmitter } = await import(
+  '../core/inline-agent/pi/deepseek-stream-fn'
+);
+
+const TOOL_CALL_TEXT = '<artifact_create>{"filename":"a.txt","content":"ok"}</artifact_create>';
+
+const TEST_MODEL: Model<Api> = {
+  id: 'deepseek-chat',
+  name: 'DeepSeek Chat',
+  api: 'openai-completions',
+  provider: 'deepseek',
+  baseUrl: 'https://api.deepseek.com',
+  reasoning: false,
+  input: [],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 0,
+  maxTokens: 0,
+};
+
+const TOOL_DESCRIPTORS: readonly ToolDescriptor[] = createArtifactToolDescriptors('en');
+
+function createSession(initialParent: number | null = 100): DeepSeekSessionState & { updates: Array<number | null> } {
+  const updates: Array<number | null> = [];
+  return {
+    chatSessionId: 'chat-1',
+    parentMessageId: initialParent,
+    setParentMessageId(id) {
+      updates.push(id);
+    },
+    updates,
+  };
+}
+
+function createDeps(
+  overrides: Partial<DeepSeekStreamFnDeps> = {},
+): DeepSeekStreamFnDeps & { session: ReturnType<typeof createSession> } {
+  const session = createSession();
+  return {
+    submitTurn: createDeepSeekTurnSubmitter({}),
+    session,
+    serializePrompt: (context: Context) => `serialized(${context.messages.length})`,
+    mapToolCall: (call, index) => ({
+      type: 'toolCall',
+      id: `xml:${index}`,
+      name: call.invocationName,
+      arguments: call.payload,
+    }),
+    toolDescriptors: TOOL_DESCRIPTORS,
+    turnDefaults: {
+      modelType: null,
+      refFileIds: [],
+      thinkingEnabled: false,
+      searchEnabled: false,
+    },
+    ...overrides,
+  } as DeepSeekStreamFnDeps & { session: ReturnType<typeof createSession> };
+}
+
+const EMPTY_CONTEXT: Context = { messages: [] };
+
+function turnResult(overrides: Partial<{ responseMessageId: number | null; requestMessageId: number | null; finished: boolean }> = {}) {
+  return {
+    assistantText: '',
+    responseMessageId: 102,
+    requestMessageId: 101,
+    finished: true,
+    ...overrides,
+  };
+}
+
+async function collectEvents(
+  deps: DeepSeekStreamFnDeps,
+  context: Context = EMPTY_CONTEXT,
+  signal?: AbortSignal,
+): Promise<AssistantMessageEvent[]> {
+  const streamFn = createDeepSeekStreamFn(deps);
+  const stream = await streamFn(TEST_MODEL, context, { signal });
+  const events: AssistantMessageEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+describe('createDeepSeekStreamFn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapterMocks.createPowHeaders.mockResolvedValue({ 'X-DS-PoW-Response': 'pow-1' });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('maps a text-only turn to text events and a done event', async () => {
+    adapterMocks.submitPromptStreaming.mockImplementationOnce(async (_input, handlers) => {
+      handlers.onTextChunk('Hello ');
+      handlers.onTextChunk('world.');
+      return turnResult();
+    });
+
+    const deps = createDeps();
+    const events = await collectEvents(deps);
+
+    const types = events.map((e) => e.type);
+    expect(types).toEqual(['start', 'text_start', 'text_delta', 'text_delta', 'text_end', 'done']);
+
+    const done = events.at(-1);
+    expect(done?.type).toBe('done');
+    if (done?.type === 'done') {
+      expect(done.reason).toBe('stop');
+      expect(done.message.content).toEqual([{ type: 'text', text: 'Hello world.' }]);
+      expect(done.message.stopReason).toBe('stop');
+    }
+    expect(deps.session.updates).toEqual([102]);
+  });
+
+  it('maps a streamed XML tool call to toolcall events and stopReason toolUse', async () => {
+    adapterMocks.submitPromptStreaming.mockImplementationOnce(async (_input, handlers) => {
+      handlers.onTextChunk(TOOL_CALL_TEXT);
+      return turnResult();
+    });
+
+    const deps = createDeps();
+    const events = await collectEvents(deps);
+
+    const types = events.map((e) => e.type);
+    expect(types).toEqual(['start', 'toolcall_start', 'toolcall_end', 'done']);
+
+    const done = events.at(-1);
+    expect(done?.type).toBe('done');
+    if (done?.type === 'done') {
+      expect(done.reason).toBe('toolUse');
+      expect(done.message.content).toEqual([
+        {
+          type: 'toolCall',
+          id: 'xml:0',
+          name: 'artifact_create',
+          arguments: { filename: 'a.txt', content: 'ok' },
+        },
+      ]);
+    }
+    expect(deps.session.updates).toEqual([102]);
+  });
+
+  it('maps interleaved text and tool calls into ordered content blocks', async () => {
+    adapterMocks.submitPromptStreaming.mockImplementationOnce(async (_input, handlers) => {
+      handlers.onTextChunk('Let me check.');
+      handlers.onTextChunk(TOOL_CALL_TEXT);
+      handlers.onTextChunk(' Found it.');
+      return turnResult();
+    });
+
+    const deps = createDeps();
+    const events = await collectEvents(deps);
+
+    const done = events.at(-1);
+    expect(done?.type).toBe('done');
+    if (done?.type === 'done') {
+      expect(done.reason).toBe('toolUse');
+      const blocks = done.message.content;
+      expect(blocks[0]).toEqual({ type: 'text', text: 'Let me check. Found it.' });
+      expect(blocks[1]).toMatchObject({ type: 'toolCall', name: 'artifact_create' });
+    }
+  });
+
+  it('builds the turn request from session, serializer and turn defaults', async () => {
+    adapterMocks.submitPromptStreaming.mockImplementationOnce(async (_input, handlers) => {
+      handlers.onTextChunk('ok');
+      return turnResult();
+    });
+
+    const deps = createDeps({
+      turnDefaults: {
+        modelType: 'expert',
+        refFileIds: ['f1'],
+        thinkingEnabled: true,
+        searchEnabled: true,
+      },
+    });
+    await collectEvents(deps);
+
+    const request = adapterMocks.submitPromptStreaming.mock.calls[0]?.[0] as DeepSeekTurnRequest;
+    expect(request).toMatchObject({
+      chatSessionId: 'chat-1',
+      parentMessageId: 100,
+      modelType: 'expert',
+      prompt: 'serialized(0)',
+      refFileIds: ['f1'],
+      thinkingEnabled: true,
+      searchEnabled: true,
+    });
+    // The submitter enriches the port request with session auth headers.
+    expect(request).toHaveProperty('clientHeaders', { Authorization: 'Bearer test-token' });
+    expect(request).toHaveProperty('powHeaders', { 'X-DS-PoW-Response': 'pow-1' });
+  });
+
+  it('encodes submitter failures as an error event without throwing', async () => {
+    vi.useFakeTimers();
+    adapterMocks.submitPromptStreaming.mockRejectedValue(new Error('network down'));
+
+    const deps = createDeps();
+    const streamFn = createDeepSeekStreamFn(deps);
+    const stream = await streamFn(TEST_MODEL, EMPTY_CONTEXT, {});
+    const events: AssistantMessageEvent[] = [];
+    const drain = (async () => {
+      for await (const event of stream) events.push(event);
+    })();
+    await vi.advanceTimersByTimeAsync(7_000);
+    await drain;
+
+    // Both attempts fail with the same error; the second attempt surfaces it.
+    expect(adapterMocks.submitPromptStreaming).toHaveBeenCalledTimes(2);
+    const last = events.at(-1);
+    expect(last?.type).toBe('error');
+    if (last?.type === 'error') {
+      expect(last.reason).toBe('error');
+      expect(last.error.stopReason).toBe('error');
+      expect(last.error.errorMessage).toBe('network down');
+    }
+    expect(deps.session.updates).toEqual([]);
+  });
+
+  it('encodes user abort as an aborted error event', async () => {
+    const controller = new AbortController();
+    adapterMocks.submitPromptStreaming.mockImplementation((_input, _handlers, signal) =>
+      new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+      }),
+    );
+
+    const deps = createDeps();
+    const streamFn = createDeepSeekStreamFn(deps);
+    const stream = await streamFn(TEST_MODEL, EMPTY_CONTEXT, { signal: controller.signal });
+    const events: AssistantMessageEvent[] = [];
+    const drain = (async () => {
+      for await (const event of stream) events.push(event);
+    })();
+    controller.abort();
+    await drain;
+
+    const last = events.at(-1);
+    expect(last?.type).toBe('error');
+    if (last?.type === 'error') {
+      expect(last.reason).toBe('aborted');
+      expect(last.error.stopReason).toBe('aborted');
+    }
+  });
+
+  it('retries once when the turn failed before any chunk was received', async () => {
+    vi.useFakeTimers();
+    adapterMocks.submitPromptStreaming
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockImplementationOnce(async (_input, handlers) => {
+        handlers.onTextChunk('recovered');
+        return turnResult();
+      });
+
+    const deps = createDeps();
+    const streamFn = createDeepSeekStreamFn(deps);
+    const stream = await streamFn(TEST_MODEL, EMPTY_CONTEXT, {});
+    const events: AssistantMessageEvent[] = [];
+    const drain = (async () => {
+      for await (const event of stream) events.push(event);
+    })();
+    await vi.advanceTimersByTimeAsync(7_000);
+    await drain;
+
+    expect(adapterMocks.submitPromptStreaming).toHaveBeenCalledTimes(2);
+    expect(events.some((e) => e.type === 'error')).toBe(false);
+    expect(events.at(-1)?.type).toBe('done');
+  });
+
+  it('does not retry a timed-out step after text was already received', async () => {
+    vi.useFakeTimers();
+    adapterMocks.submitPromptStreaming.mockImplementation((_input, handlers, signal) => {
+      handlers.onTextChunk('partial...');
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    });
+
+    const deps = createDeps();
+    const streamFn = createDeepSeekStreamFn(deps);
+    const stream = await streamFn(TEST_MODEL, EMPTY_CONTEXT, {});
+    const events: AssistantMessageEvent[] = [];
+    const drain = (async () => {
+      for await (const event of stream) events.push(event);
+    })();
+    await vi.advanceTimersByTimeAsync(120_000);
+    await drain;
+
+    expect(adapterMocks.submitPromptStreaming).toHaveBeenCalledTimes(1);
+    const last = events.at(-1);
+    expect(last?.type).toBe('error');
+    if (last?.type === 'error') {
+      expect(last.error.errorMessage).toBe(
+        'DeepSeek agent step timed out while streaming; the response was interrupted.',
+      );
+      expect(last.error.content).toEqual([{ type: 'text', text: 'partial...' }]);
+    }
+  });
+
+  it('forwards token speed progress through the optional dep callback', async () => {
+    const progress = { modelType: 'default', tokenSpeed: 42 };
+    adapterMocks.submitPromptStreaming.mockImplementationOnce(async (_input, handlers) => {
+      handlers.onTokenSpeed?.(progress);
+      handlers.onTextChunk('ok');
+      return turnResult();
+    });
+
+    const onTokenSpeed = vi.fn();
+    const deps = createDeps({ onTokenSpeed });
+    await collectEvents(deps);
+
+    expect(onTokenSpeed).toHaveBeenCalledWith(progress);
+  });
+});

--- a/tests/stream-fn-event-mapping.test.ts
+++ b/tests/stream-fn-event-mapping.test.ts
@@ -1,0 +1,216 @@
+/**
+ * DS-web stream → pi AssistantMessageEventStream mapping contract (A1-T3).
+ *
+ * Documented mapping table (the adapter's behavior is exercised in
+ * tests/stream-fn-adapter.test.ts; this file locks the protocol-level
+ * invariants the pi loop relies on):
+ *
+ * | DS-web stream state                          | pi event emitted                          |
+ * |----------------------------------------------|-------------------------------------------|
+ * | turn begins                                  | `start` (empty partial)                   |
+ * | first visible text chunk                     | `text_start` (text block appended)        |
+ * | subsequent visible text chunk                | `text_delta` (delta = new - old)          |
+ * | turn ends with visible text                  | `text_end`                                |
+ * | completed XML tool call in stream            | `toolcall_start` + `toolcall_end`         |
+ * | turn succeeded, tool calls present           | `done` reason `toolUse`                   |
+ * | turn succeeded, no tool calls                | `done` reason `stop`                      |
+ * | submitter failure (non-abort)                | `error` reason `error`, errorMessage set  |
+ * | abort during turn                            | `error` reason `aborted`, stopReason abort |
+ *
+ * Protocol invariants asserted here:
+ *  1. Every stream starts with `start` and terminates with `done` or `error`.
+ *  2. `partial` snapshots are self-consistent: text blocks are cumulative,
+ *     tool-call blocks are append-only, content order is stable.
+ *  3. `done` carries the complete final message; `error` carries errorMessage
+ *     and the partial content streamed before the failure.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AssistantMessageEvent, Context } from '@earendil-works/pi-ai';
+import { createArtifactToolDescriptors } from '../core/artifact';
+import type { ToolDescriptor } from '../core/types';
+import type { DeepSeekStreamFnDeps } from '../core/inline-agent/pi/stream-fn-port';
+
+const adapterMocks = vi.hoisted(() => ({
+  createPowHeaders: vi.fn(),
+  submitPromptStreaming: vi.fn(),
+}));
+
+vi.mock('../core/deepseek/adapter', () => ({
+  createClientHeaders: () => ({ Authorization: 'Bearer test-token' }),
+  createPowHeaders: adapterMocks.createPowHeaders,
+  submitPromptStreaming: adapterMocks.submitPromptStreaming,
+}));
+
+const { createDeepSeekStreamFn, createDeepSeekTurnSubmitter } = await import(
+  '../core/inline-agent/pi/deepseek-stream-fn'
+);
+
+const TOOL_CALL_TEXT = '<artifact_create>{"filename":"a.txt","content":"ok"}</artifact_create>';
+
+const TEST_MODEL = {
+  id: 'deepseek-chat',
+  name: 'DeepSeek Chat',
+  api: 'openai-completions',
+  provider: 'deepseek',
+  baseUrl: 'https://api.deepseek.com',
+  reasoning: false,
+  input: [],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 0,
+  maxTokens: 0,
+};
+
+const TOOL_DESCRIPTORS: readonly ToolDescriptor[] = createArtifactToolDescriptors('en');
+
+function createDeps(): DeepSeekStreamFnDeps {
+  return {
+    submitTurn: createDeepSeekTurnSubmitter({}),
+    session: {
+      chatSessionId: 'chat-1',
+      parentMessageId: 100,
+      setParentMessageId: vi.fn(),
+    },
+    serializePrompt: (context: Context) => `serialized(${context.messages.length})`,
+    mapToolCall: (call, index) => ({
+      type: 'toolCall',
+      id: `xml:${index}`,
+      name: call.invocationName,
+      arguments: call.payload,
+    }),
+    toolDescriptors: TOOL_DESCRIPTORS,
+    turnDefaults: {
+      modelType: null,
+      refFileIds: [],
+      thinkingEnabled: false,
+      searchEnabled: false,
+    },
+  };
+}
+
+async function runScenario(): Promise<AssistantMessageEvent[]> {
+  const deps = createDeps();
+  const streamFn = createDeepSeekStreamFn(deps);
+  const stream = await streamFn(TEST_MODEL, { messages: [] }, {});
+  const events: AssistantMessageEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+describe('DS-web → pi event mapping protocol', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapterMocks.createPowHeaders.mockResolvedValue({ 'X-DS-PoW-Response': 'pow-1' });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('text-only turn: start → text events → done(stop), partial cumulative', async () => {
+    adapterMocks.submitPromptStreaming.mockImplementationOnce(async (_input, handlers) => {
+      handlers.onTextChunk('Hello ');
+      handlers.onTextChunk('world.');
+      return { assistantText: '', responseMessageId: 102, requestMessageId: 101, finished: true };
+    });
+
+    const events = await runScenario();
+    expect(events[0]?.type).toBe('start');
+    expect(events.at(-1)?.type).toBe('done');
+
+    const deltas = events.filter((e) => e.type === 'text_delta');
+    expect(deltas.map((e) => (e.type === 'text_delta' ? e.delta : ''))).toEqual(['Hello ', 'world.']);
+
+    // Partial snapshots are cumulative.
+    const textBlocks = events
+      .filter((e) => e.type === 'text_delta' && e.type === 'text_delta')
+      .map((e) => (e as { partial: { content: Array<{ text?: string }> } }).partial.content[0]?.text);
+    expect(textBlocks).toEqual(['Hello ', 'Hello world.']);
+
+    const done = events.at(-1);
+    if (done?.type === 'done') {
+      expect(done.reason).toBe('stop');
+      expect(done.message.content).toEqual([{ type: 'text', text: 'Hello world.' }]);
+    }
+  });
+
+  it('tool turn: start → toolcall events → done(toolUse), tool blocks append-only', async () => {
+    adapterMocks.submitPromptStreaming.mockImplementationOnce(async (_input, handlers) => {
+      handlers.onTextChunk(TOOL_CALL_TEXT);
+      handlers.onTextChunk(TOOL_CALL_TEXT.replace('a.txt', 'b.txt'));
+      return { assistantText: '', responseMessageId: 102, requestMessageId: 101, finished: true };
+    });
+
+    const events = await runScenario();
+    expect(events[0]?.type).toBe('start');
+    expect(events.at(-1)?.type).toBe('done');
+
+    const toolCallEnds = events.filter((e) => e.type === 'toolcall_end');
+    expect(toolCallEnds).toHaveLength(2);
+    if (toolCallEnds[0]?.type === 'toolcall_end') {
+      expect(toolCallEnds[0].toolCall.arguments).toEqual({ filename: 'a.txt', content: 'ok' });
+    }
+    if (toolCallEnds[1]?.type === 'toolcall_end') {
+      expect(toolCallEnds[1].toolCall.arguments).toEqual({ filename: 'b.txt', content: 'ok' });
+    }
+
+    const done = events.at(-1);
+    if (done?.type === 'done') {
+      expect(done.reason).toBe('toolUse');
+      expect(done.message.content.filter((b) => b.type === 'toolCall')).toHaveLength(2);
+    }
+  });
+
+  it('failure turn: start → error, errorMessage set, no done event', async () => {
+    vi.useFakeTimers();
+    adapterMocks.submitPromptStreaming.mockRejectedValue(new Error('boom'));
+
+    const deps = createDeps();
+    const streamFn = createDeepSeekStreamFn(deps);
+    const stream = await streamFn(TEST_MODEL, { messages: [] }, {});
+    const events: AssistantMessageEvent[] = [];
+    const drain = (async () => {
+      for await (const event of stream) events.push(event);
+    })();
+    await vi.advanceTimersByTimeAsync(7_000);
+    await drain;
+
+    expect(events[0]?.type).toBe('start');
+    expect(events.some((e) => e.type === 'done')).toBe(false);
+    const last = events.at(-1);
+    expect(last?.type).toBe('error');
+    if (last?.type === 'error') {
+      expect(last.reason).toBe('error');
+      expect(last.error.errorMessage).toBe('boom');
+      expect(last.error.stopReason).toBe('error');
+    }
+  });
+
+  it('aborted turn: start → error(aborted) with streamed content preserved', async () => {
+    const controller = new AbortController();
+    adapterMocks.submitPromptStreaming.mockImplementation((_input, handlers, signal) => {
+      handlers.onTextChunk('partial answer');
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    });
+
+    const deps = createDeps();
+    const streamFn = createDeepSeekStreamFn(deps);
+    const stream = await streamFn(TEST_MODEL, { messages: [] }, { signal: controller.signal });
+    const events: AssistantMessageEvent[] = [];
+    const drain = (async () => {
+      for await (const event of stream) events.push(event);
+    })();
+    controller.abort();
+    await drain;
+
+    const last = events.at(-1);
+    expect(last?.type).toBe('error');
+    if (last?.type === 'error') {
+      expect(last.reason).toBe('aborted');
+      expect(last.error.stopReason).toBe('aborted');
+      expect(last.error.content).toEqual([{ type: 'text', text: 'partial answer' }]);
+    }
+  });
+});

--- a/tests/stream-fn-port.test.ts
+++ b/tests/stream-fn-port.test.ts
@@ -1,0 +1,93 @@
+/**
+ * StreamFn port contract tests (Issue A1-T1).
+ *
+ * 1. Compile-time assignability: the port factory return must remain a valid
+ *    pi `StreamFn` and the parsed XML tool call must remain mappable to a pi
+ *    `ToolCall`. If upstream pi changes shape, this file fails to compile
+ *    (version-drift guard, risk (a)).
+ * 2. Serializability: `DeepSeekTurnRequest` must round-trip through JSON.
+ * 3. Contract hygiene: the port module may only import pi packages and
+ *    type-only relative imports — no concrete implementation modules.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { StreamFn } from '@earendil-works/pi-agent-core';
+import type { ToolCall } from '@earendil-works/pi-ai';
+import type {
+  DeepSeekStreamFnDeps,
+  DeepSeekStreamFnFactory,
+  DeepSeekTurnRequest,
+  ParsedXmlToolCall,
+} from '../core/inline-agent/pi/stream-fn-port';
+
+// --- Compile-time assignability (drift guard) -------------------------------
+
+// The factory return type must remain assignable to pi's StreamFn.
+type FactoryReturn = ReturnType<DeepSeekStreamFnFactory>;
+const _streamFnAssignable: StreamFn = null as unknown as FactoryReturn;
+void _streamFnAssignable;
+
+// The deps object must remain constructible from the port's own types.
+type DepsShape = DeepSeekStreamFnDeps;
+const _depsAssignable: DepsShape = null as unknown as DepsShape;
+void _depsAssignable;
+
+// A parsed XML call must remain mappable to pi's ToolCall shape.
+const _toolCallMapper = (call: ParsedXmlToolCall, index: number): ToolCall => ({
+  type: 'toolCall',
+  id: call.name ? `xml:${index}` : `xml:${index}`,
+  name: call.invocationName,
+  arguments: call.payload,
+});
+void _toolCallMapper;
+
+describe('stream-fn port contract', () => {
+  it('serializes DeepSeekTurnRequest through JSON round-trip', () => {
+    const request: DeepSeekTurnRequest = {
+      chatSessionId: 'chat-1',
+      parentMessageId: 100,
+      modelType: null,
+      prompt: 'Continue the task.',
+      refFileIds: [],
+      thinkingEnabled: false,
+      searchEnabled: true,
+    };
+    const restored = JSON.parse(JSON.stringify(request)) as DeepSeekTurnRequest;
+    expect(restored).toEqual(request);
+  });
+
+  it('maps a parsed XML tool call to the pi ToolCall shape with a synthesized id', () => {
+    const call: ParsedXmlToolCall = {
+      name: 'artifact_create',
+      invocationName: 'artifact_create',
+      payload: { filename: 'a.txt', content: 'ok' },
+    };
+    const mapped = _toolCallMapper(call, 0);
+    expect(mapped).toEqual({
+      type: 'toolCall',
+      id: 'xml:0',
+      name: 'artifact_create',
+      arguments: { filename: 'a.txt', content: 'ok' },
+    });
+  });
+
+  it('keeps the port module free of implementation imports', () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, '../core/inline-agent/pi/stream-fn-port.ts'),
+      'utf8',
+    );
+    const importLines = source
+      .split('\n')
+      .filter((line) => /^\s*import\b/.test(line))
+      .map((line) => line.trim());
+
+    expect(importLines.length).toBeGreaterThan(0);
+    for (const line of importLines) {
+      if (line.includes('@earendil-works/')) continue;
+      // Relative imports must be type-only (contract rule).
+      expect(line).toMatch(/^import\s+type\b/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Spec-driven run「pi-agent-core 集成 Step A」批次 2（Issue #512）：StreamFn 模型后端适配——把 DS 网页接口封装为 pi 的模型后端（薄适配器，纯新增 + 行为零变化重构，**不接线到 loop**）。

## PR Type

- [ ] User-facing feature or behavior change
- [ ] Bug fix
- [ ] Documentation only
- [x] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

`git fetch origin && git merge origin/main`（batch 分支基于已合入的 P1-B1）

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

deepseek-v4-flash

Coding Agent tool(s) used:

DSH (DeepSeek Harness) + spec-driven-develop workflow

## Local Validation

Commands run:

```bash
npm test                                  # 全量 vitest（197 文件）
npm run compile                           # tsc --noEmit
npm run build:chrome                      # WXT chrome-mv3 构建
node scripts/pi-bundle-budget.mjs         # 双 probe + node:/SDK 泄漏门
```

Result summary:

全部通过。A1 定向测试 16 个（port 3 / adapter 9 / mapping 4）+ inline-agent 回归 50 个全绿；compile 0 错误；build:chrome 成功；预算护栏双 probe 全绿（pi 173K/52K、adapter 305K/96K，均无 node:/SDK 泄漏）。

## Local Feature Evidence

N/A — 无用户可见行为变化（纯新增适配层 + 行为零变化重构，未接线到 loop）。

---

### 变更内容（spec-driven 详情）

1. **`core/inline-agent/pi/stream-fn-port.ts`**（A1-T1，契约模块）：串行化的回合请求/回调/结果、会话链状态端口、prompt 序列化器与工具调用映射类型、StreamFn 工厂签名；编译期漂移防线测试（pi 升级破坏形状即编译失败）。
2. **`core/inline-agent/step-control.ts`**：从 loop.ts 抽取的步超时/节流辅助（行为零变化；golden + 既有 loop 测试 50/50 验证）。
3. **`core/inline-agent/pi/deepseek-stream-fn.ts`**（A1-T2）：`createDeepSeekTurnSubmitter`（原 loop 精确语义：每回合一次 PoW、无 chunk 才重试、120s 步超时）+ `createDeepSeekStreamFn`（DS 文本/XML 工具流 → pi 事件流；永不 throw，失败编码为协议 error/aborted 事件）。
4. **映射契约测试**（A1-T3）：DS 流状态 ↔ pi 事件映射表（文档化于 Issue #512）+ 协议不变量测试。
5. **`scripts/pi-bundle-budget.mjs`**（A1-T3）：Gate 3 升级为双 probe——pi 裸面（预算 230K/72K）与真实适配器图（预算 340K/110K），node:/SDK 泄漏门全 0。

### 关键设计点

- **会话链权威**：`parentMessageId` 由 session state 读写（A3 适配器持有），pi context 仅作回合工作内存（风险 g 缓解）
- **prompt 字节零变化**：序列化器走现有 wire 契约（`<original_task>`/`<tool_results>`/`<task_complete>`），禁用 pi 模板
- **回滚安全**：本批次未接线到 loop，生产行为零变化（loop.ts 仅有行为零变化的重构）

### 遥测

- A1-T1：est S / actual S / S.U.P.E.R P,U / drift 0
- A1-T2：est L / actual L / S.U.P.E.R P,E,S / drift 0
- A1-T3：est M / actual M / S.U.P.E.R R / drift 0

Closes #512
