### PR TITLE
B1-P1: deepseek-web provider port contract (契约先行，生产零改动)

### DIFF
--- a/core/inline-agent/pi/provider-port.ts
+++ b/core/inline-agent/pi/provider-port.ts
@@ -1,0 +1,70 @@
+/**
+ * deepseek-web pi-ai provider port (Issue B1-T1).
+ *
+ * Contract module: declares the serializable seam between the pi-ai provider
+ * registry and the DeepSeek web backend. It MUST NOT import concrete browser,
+ * DOM, provider, or entrypoint implementations (AGENTS.md contract rule);
+ * only pure types from pi packages and the existing StreamFn port are
+ * allowed.
+ *
+ * The port has three parts:
+ *  1. `DEEPSEEK_WEB_API` — the custom `Api` id (`Api = KnownApi | (string &
+ *     {})` extension point) that labels every deepseek-web model. It is a
+ *     distinct api shape from the OpenAI-compatible ones because the DS-web
+ *     wire format is not OpenAI-compatible (SSE `{p,o,v}` patches, XML tool
+ *     calls, PoW, no native function calling); the translation layer lives
+ *     in the existing StreamFn adapter, never in pi-ai's own api modules.
+ *  2. `DeepSeekWebProviderDeps` — the injection surface satisfied by the
+ *     loop adapter: the existing `DeepSeekStreamFnDeps` plus an auth-header
+ *     resolver. The provider never owns page/session state; it is a pure
+ *     registration + delegation object.
+ *  3. `DeepSeekWebProviderFactory` — `(deps) => Provider<'deepseek-web'>`,
+ *     implemented in B1-T3 via pi-ai's `createProvider`.
+ *
+ * Version-drift guard: `tests/deepseek-web-provider.test.ts` asserts
+ * assignability against the exact pi export shapes (`Provider`,
+ * `createProvider`), so an upstream API break fails compilation instead of
+ * surfacing at runtime.
+ */
+import type { Provider } from '@earendil-works/pi-ai';
+import type { DeepSeekStreamFnDeps } from './stream-fn-port';
+
+/**
+ * Custom pi-ai `Api` id for the DeepSeek web backend. Models with this api
+ * are streamed by the deepseek-web provider's own `ProviderStreams`; pi-ai's
+ * `ApiOptionsMap` has no entry for it, so stream options fall back to the
+ * generic `StreamOptions` shape (compatible: only `signal` is consumed).
+ */
+export const DEEPSEEK_WEB_API = 'deepseek-web' as const;
+
+/**
+ * pi-ai provider id registered for the DeepSeek web backend. Distinct from
+ * the official-API provider id (`deepseek`, B2) so the two backends can
+ * coexist in one registry.
+ */
+export const DEEPSEEK_WEB_PROVIDER = 'deepseek-web' as const;
+
+/** Model ids exposed by the deepseek-web provider catalog. */
+export const DEEPSEEK_WEB_MODEL_IDS = ['deepseek-chat', 'deepseek-reasoner'] as const;
+export type DeepSeekWebModelId = (typeof DEEPSEEK_WEB_MODEL_IDS)[number];
+
+/**
+ * Resolves the DS-web session auth headers (Bearer token + x-client-*).
+ * Returns undefined when the page session is not configured — the provider
+ * reports "not configured" (pi-ai ambient-credential semantics). The loop
+ * adapter satisfies this from the existing `createClientHeaders` path; the
+ * provider must not read page storage itself.
+ */
+export type DeepSeekWebAuthHeaderResolver = () =>
+  | Record<string, string>
+  | undefined
+  | Promise<Record<string, string> | undefined>;
+
+/** Dependencies required to build the deepseek-web provider (B1-T3). */
+export interface DeepSeekWebProviderDeps extends DeepSeekStreamFnDeps {
+  /** DS-web session auth headers for pi-ai auth resolution. */
+  resolveAuthHeaders: DeepSeekWebAuthHeaderResolver;
+}
+
+/** The pi-ai provider factory implemented by the deepseek-web adapter. */
+export type DeepSeekWebProviderFactory = (deps: DeepSeekWebProviderDeps) => Provider<typeof DEEPSEEK_WEB_API>;

--- a/docs/analysis/project-overview.md
+++ b/docs/analysis/project-overview.md
@@ -1,0 +1,65 @@
+# Project Overview — pi-agent-core Step B1: deepseek-web 正式 provider 注册
+
+> **Run**: spec:pi-agent-core-provider ｜ **Mode**: GITHUB_STANDARD ｜ **Base**: origin/main (c283e49, Step A 归档合入)
+> **日期**: 2026-08-05 ｜ **交接**: step-b-handoff.md（Step A 已合入 main v1.12.2，浏览器实测无问题）
+
+## 目标
+
+把当前"自定义 StreamFn 独有路径"（`core/inline-agent/pi/deepseek-stream-fn.ts` 的 `createDeepSeekStreamFn` 直接构造 pi StreamFn）升级为 **pi-ai 正式 provider 注册**：利用 `Api = KnownApi | (string & {})` 扩展点，将 DS 网页后端注册为 pi-ai 的 `Provider`（`createProvider` + `ProviderStreams`），使 deepseek-web 成为 pi-ai 模型注册表中的一等公民，为 B2（多后端切换）与 B3（skills/agents 生态）铺路。
+
+**非目标**：不改变任何生产行为（golden 10/10 保持）；不引入新持久化；不触碰主工作区；不升级 pi 版本（仍锁 0.83.0）；不引入 OpenAI SDK 依赖树。
+
+## 现状（Step A 交付，2026-08-05 合入）
+
+- `core/inline-agent/pi/deepseek-stream-fn.ts`：
+  - `createDeepSeekTurnSubmitter(options)` → `DeepSeekTurnSubmitter`（薄封装 `submitPromptStreaming`，PoW 一次/回合、无-chunk-才重试、120s 步超时）。
+  - `createDeepSeekStreamFn(deps)` → `StreamFn`（`(model, context, options) => AssistantMessageEventStream`），内部复用 `createClientHeaders`/`createPowHeaders`/`submitPromptStreaming` + interceptor 的 tool-parser/streaming-tool-call-parser/streaming-tool-text。
+- `core/inline-agent/pi/stream-fn-port.ts`：纯类型契约模块（`DeepSeekStreamFnDeps` 等），无具体实现导入。
+- `core/inline-agent/pi/loop-adapter.ts`：`runPiInlineAgentLoop` 手工构造 `Model<Api>`（`{ id: 'deepseek-chat', api: 'openai-completions', provider: 'deepseek' }`）+ `pacedStreamFn` 包装后传给 `runAgentLoop`。
+- 体积护栏：`scripts/pi-bundle-budget.mjs`（双 probe：pi 裸面 230K/72K、full-A3 430K/145K；node:/SDK 泄漏门；background 红线 raw≤820K/gzip≤240K）。
+
+## pi-ai 0.83.0 provider 体系（事实核查，node_modules 实测）
+
+- `Api = KnownApi | (string & {})`：`KnownApi` 为 10 个已知 api 字符串；自定义字符串（如 `'deepseek-web'`）合法，`ApiOptionsMap` 无条目时回退 `StreamOptions & Record<string, unknown>`。
+- `createProvider<TApi>(input: CreateProviderOptions<TApi>)`（`dist/models.js`）：
+  - `{ id, name?, baseUrl?, headers?, auth, models, fetchModels?, filterModels?, api }`；
+  - `api` 可以是单 `ProviderStreams`（`{ stream, streamSimple }`）或 `Partial<Record<TApi, ProviderStreams>>` 按 `model.api` 分发；无条目时报 stream error；
+  - `Provider<TApi>` 接口：`getModels()`、`stream(model, context, options)`、`streamSimple(...)`；`auth` 必填（`ProviderAuth`，`apiKey`/`oauth` 至少其一）。
+- `ProviderStreams`（`dist/types.d.ts`）：`{ stream(model, context, options?) => AssistantMessageEventStream; streamSimple(...) }`。
+- `AssistantMessageEventStream`：`EventStream<AssistantMessageEvent, AssistantMessage>`，`createAssistantMessageEventStream()` 工厂（已有导入）。
+- 参考实现：`providers/deepseek.js` = `createProvider({ id: 'deepseek', baseUrl: 'https://api.deepseek.com', auth: { apiKey: envApiKeyAuth(...) }, models: Object.values(DEEPSEEK_MODELS), api: openAICompletionsApi() })`。注意 `openAICompletionsApi` 是 `lazyApi(() => import('./openai-completions.js'))` —— 重型 SDK 在动态 import 后，静态图不进入 bundle。
+
+## B1 设计决策
+
+1. **自定义 api 形状 `'deepseek-web'`**：DS 网页私有格式（SSE `{p,o,v}` patch、XML 工具调用、PoW、无原生 function-calling）不是 OpenAI 兼容消息格式；pi-ai 现有 `openai-completions` api 的 `convertMessages`/`buildParams` 假设 OpenAI 消息形状，直接复用会违反"不得复制协议逻辑"。因此定义新 api 字符串，`ApiOptionsMap` 之外（回退 `StreamOptions`），由我们自己的 `ProviderStreams` 实现承载。
+2. **薄封装复用**：`createDeepSeekWebProvider(deps)` 内部直接复用 `createDeepSeekStreamFn` 与 `createDeepSeekTurnSubmitter`（同一个 body，注册面 = `{ stream: streamFn, streamSimple: streamFn }`）。**不复制** stream-codec/active-client 协议逻辑（AGENTS.md 规则 3）。
+3. **auth 形状**：`ProviderAuth` 必填。deepseek-web 的"认证"是页面会话 headers（`createClientHeaders` 从 localStorage 读取 userToken + x-client-*），不是 API key。用 `apiKey.resolve()` 形式表达"已配置"（返回 `{ auth: { headers } }`，source 标记 `'DeepSeek Web session'`）；无 token 时 resolve undefined（未配置）——语义与 pi-ai 的 "ambient credentials" 一致。
+4. **模型目录**：静态 `Model<'deepseek-web'>` 列表（`deepseek-chat` / `deepseek-reasoner` 两个 id，api='deepseek-web'），`getModels()` 同步返回。B1 不接 `createModels` 集合，loop-adapter 直接持 provider 对象（最小改动面）。
+5. **loop-adapter 接线**：`runPiInlineAgentLoop` 改为 `createDeepSeekWebProvider(deps)` 取 `model` + `stream`，替换手工 `Model` 构造 + `pacedStreamFn`；`pacedStreamFn` 包装保留（行为不变）。`model.api` 由 `'openai-completions'` 变为 `'deepseek-web'`、`provider` 由 `'deepseek'` 变为 `'deepseek-web'`——golden 只断言 AGENT_* 事件载荷，不含 model 元数据，预期全绿。
+6. **streamSimple**：与 stream 同一实现（pi loop 只用 stream；streamSimple 是接口要求，映射同一函数）。
+7. **体积**：`createProvider` 依赖 `dist/models.js`（auth/context、credential-store、resolve、models-store、api/lazy、event-stream）。这些模块远小于 OpenAI SDK 树；需实测 pi-bundle-budget 增量并校准。禁止把 `openai-completions.js`（OpenAI SDK）引入静态图。
+
+## 风险承接（承自 Step A risk-assessment，B1 新增标注）
+
+| # | 风险 | 概率 | 影响 | 缓解 |
+|:--|:-----|:----:|:----:|:-----|
+| (b2) | 引入 createProvider 依赖面拉大 bundle | 中 | 高 | 窄入口只导入 `createProvider`/`createModels`（如需）；实测 probe 增量；护栏脚本校准；禁止动态 import 重型 API 模块进静态图 |
+| (d2) | prompt 字节契约 | 低 | 高 | provider 不消费 pi 模板；prompt 序列化仍走 loop-adapter 注入的 `serializePrompt`（现有 `buildContinuationPrompt`/`buildNudgePrompt`）；prompt:freeze 零 diff 必跑 |
+| (g2) | 会话链 authority 漂移 | 低 | 高 | `DeepSeekSessionState` 仍由 loop-adapter 持有并注入；provider 不持有页面状态 |
+| (a2) | pi-ai 版本漂移 | 中 | 中 | 精确锁 0.83.0 不动；契约测试编译期断言 `Provider<'deepseek-web'>` 可赋值 |
+| (f2) | 授权路径 | 低 | 高 | provider 不接触工具执行；tool-bridge 不变 |
+| (e2) | DS 网页协议变更 | 中 | 中 | stream 仍复用 active-client/stream-codec 唯一权威 |
+
+## 验收方向（承交接文档）
+
+- `pi-bundle-budget` 全绿（含新增 provider probe 或扩展 adapter probe）；
+- golden 10/10（`tests/inline-agent-event-protocol-golden.test.ts`）；
+- 既有 StreamFn 路径行为不变（`tests/stream-fn-adapter.test.ts`、`stream-fn-event-mapping.test.ts` 全绿）；
+- provider 注册契约测试（编译期赋值断言 + 注册形状 + stream 委托一致性）；
+- `prompt:freeze` 零 diff；`npm run compile` 干净；浏览器构建通过。
+
+## References
+
+- `docs/archives/pi-agent-core-integration/`（Step A 归档：MASTER.md / milestones.md / risk-assessment.md / task-breakdown.md）
+- `AGENTS.md`（pi-agent-core 集成 5 条稳定规则）
+- `step-b-handoff.md`（交接文档）

--- a/docs/analysis/risk-assessment.md
+++ b/docs/analysis/risk-assessment.md
@@ -1,0 +1,40 @@
+# Risk Assessment — pi-agent-core Step B1: deepseek-web provider 注册
+
+## S.U.P.E.R Architecture Health（B1 视角）
+
+| Principle | Status | Findings（B1 变更面） | Priority |
+|:----------|:-------|:---------------------|:---------|
+| **S** Single Purpose | 🟢 | 新增 provider 模块单一职责：注册面 + 委托，不复刻协议 | 低 |
+| **U** Unidirectional Flow | 🟢 | provider 只向下调 stream/active-client；不反向持有授权/页面状态（会话链仍在 loop-adapter） | 低 |
+| **P** Ports over Implementation | 🟢 | 复用 `stream-fn-port.ts` 契约模块；provider 端口类型可序列化 | 低 |
+| **E** Environment-Agnostic | 🟡 | `createProvider` 依赖面（models.js → auth/models-store/event-stream）需 bundle 实测（风险 b2） | 高 |
+| **R** Replaceable Parts | 🟢 | golden 契约测试守护；provider 注册可替换为任何 pi-ai provider | 低 |
+
+## Risk Matrix（B1 增量）
+
+| # | 风险项 | 概率 | 影响 | 缓解方向 |
+|:--|:-------|:----:|:----:|:---------|
+| (b2) | `createProvider`/`models.js` 依赖面拉大 content bundle | 中 | 高 | 只导入 `createProvider` 一个符号；probe 实测增量并校准护栏；保持 `openai-completions`/`openai-responses` 等重型 API 模块不进静态图（lazy 门） |
+| (d2) | provider 层误用 pi prompt 模板或改变序列化 | 低 | 高 | 序列化仍由 loop-adapter 注入；provider 无模板引用（grep 断言）；prompt:freeze 零 diff |
+| (g2) | provider 持有会话链状态导致 fork | 低 | 高 | `DeepSeekSessionState` 保持 loop-adapter 所有；provider 构造时注入，不新建状态 |
+| (a2) | pi-ai 上游类型漂移 | 中 | 中 | 精确锁 0.83.0；`tests/deepseek-web-provider.test.ts` 编译期赋值断言 |
+| (f2) | 授权路径被绕 | 低 | 高 | provider 不触碰工具；tool-bridge 不变；golden 全量工具记录载荷回归 |
+| (m2) | model.api 标识变更（'openai-completions'→'deepseek-web'）影响 pi 内部逻辑 | 低 | 中 | 核查 agent-loop.js：`model.api` 仅透传给 AssistantMessage/streamFn，无 api 分支；golden 不测 model 元数据；回归全绿即证 |
+
+## 不可违反清单（B1 映射）
+
+- **A（inline-agent 语义）**：AGENT_* 事件协议逐字节不变（golden 10/10）；abort/预算/截断语义不动。
+- **B（工具授权红线）**：provider 层零工具逻辑；执行路径不变。
+- **C（prompt 字节契约）**：prompt:freeze 零 diff；序列化函数不变。
+- **D（SSE/route 契约）**：stream 仍复用 active-client/stream-codec；不复制协议。
+- **E（fixtures 同步）**：无跨 runtime 契约变更（AGENT_* 载荷不变）→ 无 fixtures diff；如有意外 diff 立即停查。
+- **F（验证顺序）**：定向测试 → compile → prompt:freeze → build:all → verify:* → 窄冒烟 → ci:quality。
+
+## 测试面挂载
+
+| 测试面 | 代表文件 | B1 用途 |
+|:-------|:---------|:--------|
+| provider 注册契约（新增） | `tests/deepseek-web-provider.test.ts` | 编译期赋值断言 + 注册形状 + stream/streamSimple 委托一致性 + auth resolve |
+| 事件协议 golden | `tests/inline-agent-event-protocol-golden.test.ts` | 10 场景逐字节回归（接线后必跑） |
+| StreamFn 适配 | `tests/stream-fn-adapter.test.ts`、`stream-fn-event-mapping.test.ts` | 既有路径行为不变 |
+| 体积护栏 | `scripts/pi-bundle-budget.mjs` | provider probe 增量校准 |

--- a/docs/plan/milestones.md
+++ b/docs/plan/milestones.md
@@ -1,0 +1,12 @@
+# Milestones — pi-agent-core Step B1
+
+| # | Milestone | Target | Criteria | Status |
+|:--|:----------|:-------|:---------|:-------|
+| 1 | **M-B1 · deepseek-web 正式 provider 注册完成** | After P3-B1 合入 | ① `pi-bundle-budget` 全绿（含 provider probe） ② golden 10/10 ③ 既有 StreamFn 路径测试全绿 ④ provider 注册契约测试绿 ⑤ prompt:freeze 零 diff ⑥ B2 启动条件记录 | Pending |
+
+## Step B 后续（记录，不建 Milestone/Issue，逐项独立 run）
+
+| # | Roadmap Item | 启动条件 | 备注（风险承接） |
+|:--|:-------------|:---------|:-----------------|
+| B2 | 多后端支持（官方 API 等第二模型后端） | B1 完成 | 复用 `DeepSeekAutomationClient` 端口；每条新后端需独立 Issue 授权（不可违反 D）；消息格式差异（reasoning_content/thinking）、授权 provider 身份扩展、prompt 字节契约评估 |
+| B3 | pi skills/agents 生态导入 | B2 完成 | 记忆双轨（pi 自身记忆 vs IndexedDB——必须保持单一权威）、prompt 字节契约（pi 模板不得进入 wire）；每项变更独立 Issue 授权 |

--- a/docs/plan/task-breakdown.md
+++ b/docs/plan/task-breakdown.md
@@ -1,0 +1,68 @@
+# Task Breakdown — pi-agent-core Step B1: deepseek-web provider 注册
+
+## Overview
+
+- **Total Phases**: 4 ｜ **Total Tasks**: 7（归入 1 个 Issue）｜ **Delivery Batches / PRs**: 3（每批一个 PR，每 PR 一行 `Closes #N`）
+- **Estimated Total Effort**: M+（4×S + 2×M + 1×L）
+- **工作区**: worktree `/Users/zcl/code/deepseek-pp-worktrees/pi-agent-core-step-b`（分支 `spec/pi-agent-core-provider`）；主工作区只读参照，一律不碰。
+- **前置**: Step A 已合入（c283e49）；pi 锁 0.83.0 不动。
+
+## 设计约束（S.U.P.E.R + AGENTS.md）
+
+- **P** 契约先行：provider 端口（deps 形状、注册形状、stream 委托契约）先于实现。
+- **S** provider 模块单一职责：只做"注册面 + 委托"，不复制 stream-codec/active-client 协议逻辑。
+- **E** 新依赖面（models.js/createProvider）必须 probe 实测体积；禁止重型 API 模块进静态图。
+- **R** golden 契约守护：接线批次必须 golden 10/10 + 既有 StreamFn 测试全绿。
+- 验证顺序（F）：定向测试 → compile → prompt:freeze → build:all → verify:* → 窄冒烟 → ci:quality。
+
+## Phase 1: provider 端口定义与契约测试（Issue B1）
+
+**Goal**: 零生产行为变化下，把"deepseek-web 注册为 pi-ai provider"的形状固化为契约测试。
+**S.U.P.E.R Focus**: P + R。
+
+| # | Task | Priority | Effort | Depends On | Delivery Batch | S.U.P.E.R | Test Expectation | Acceptance Criteria |
+|:--|:-----|:---------|:-------|:-----------|:---------------|:----------|:-----------------|:--------------------|
+| B1-T1 | provider 端口定义（`core/inline-agent/pi/provider-port.ts` 或扩展 stream-fn-port）：`DeepSeekWebProviderDeps`、`DeepSeekWebProviderFactory`（`(deps) => Provider<'deepseek-web'>`）纯类型 | P0 | S | — | P1-B1 | P, U | 编译期导出类型断言测试（`Provider<'deepseek-web'>` 可赋值、deps 可构造） | 契约模块 import 面仅 pi 包 + 纯类型相对导入（grep 断言）；compile 绿；生产代码 0 行改动 |
+| B1-T2 | provider 注册形状契约测试（`tests/deepseek-web-provider.test.ts`）：createProvider 产物形状（id/api/models/auth/stream 委托）、streamSimple 与 stream 一致性、auth resolve 语义（有 token→headers；无 token→undefined） | P0 | M | B1-T1 | P1-B1 | R, P | 注册形状 + auth 语义单测（mock deps） | 测试绿；测试不 import 生产 provider 实现（先定义后实现）|
+
+**本 phase 验证链**：定向测试 → compile（生产零改动，无 build/prompt 需求，理由记录）。
+
+## Phase 2: provider 注册实现（Issue B1）
+
+**Goal**: `createDeepSeekWebProvider(deps)` 实现——复用 `createDeepSeekStreamFn`/`createDeepSeekTurnSubmitter`，`createProvider` 注册。
+**S.U.P.E.R Focus**: S + E。
+
+| # | Task | Priority | Effort | Depends On | Delivery Batch | S.U.P.E.R | Test Expectation | Acceptance Criteria |
+|:--|:-----|:---------|:-------|:-----------|:---------------|:----------|:-----------------|:--------------------|
+| B1-T3 | `core/inline-agent/pi/deepseek-web-provider.ts`：`createDeepSeekWebProvider(deps)` → `Provider<'deepseek-web'>`（`createProvider({ id: 'deepseek-web', auth, models, api: { stream, streamSimple } })`）；auth.resolve 读注入 token 提供者；模型目录静态 2 条目 | P0 | M | B1-T1 | P2-B1 | S, E | `tests/deepseek-web-provider.test.ts` 全部改跑真实实现；grep 断言无 openai-completions/pi 模板引用 | 定向测试 + compile 绿；provider 产物形状与 Phase 1 契约一致；未接线 loop（生产行为零变化） |
+| B1-T4 | 体积探针扩展：`pi-bundle-budget.mjs` 增加 provider probe（或扩展 adapter probe 导入 `createDeepSeekWebProvider`）并校准预算 | P1 | S | B1-T3 | P2-B1 | E | probe 实测增量报告；护栏绿 | 护栏脚本绿；增量实测记录入 Issue；无 node:/SDK 泄漏 |
+
+**本 phase 验证链**：定向测试 → compile → build:chrome → pi-bundle-budget。
+
+## Phase 3: loop-adapter 接线 + golden 回归（Issue B1）
+
+**Goal**: `runPiInlineAgentLoop` 从 `createDeepSeekWebProvider` 取 model + stream；AGENT_* 事件序列与 golden 逐字节一致。
+**S.U.P.E.R Focus**: R（替换）+ U。
+
+| # | Task | Priority | Effort | Depends On | Delivery Batch | S.U.P.E.R | Test Expectation | Acceptance Criteria |
+|:--|:-----|:---------|:-------|:-----------|:---------------|:----------|:-----------------|:--------------------|
+| B1-T5 | loop-adapter 接线：替换手工 `Model` 构造 + 直接 `createDeepSeekStreamFn` 为 provider 注册取用；`pacedStreamFn` 包装保留 | P0 | L | B1-T3 | P3-B1 | R, U | `inline-agent-event-protocol-golden.test.ts` 10/10；`stream-fn-adapter.test.ts`/`stream-fn-event-mapping.test.ts` 全绿 | golden 10/10 逐字节；行为不变；prompt:freeze 零 diff |
+| B1-T6 | 全量验证 + 体积护栏 + fixtures 检查 | P1 | M | B1-T5 | P3-B1 | R, E | `npm run compile`；`prompt:freeze`；`build:all`；`verify:manifest-policy`/`verify:extension-utf8`；`pi-bundle-budget`（三浏览器）；窄冒烟 | 全链绿；fixtures 无意外 diff（AGENT_* 载荷不变）；无新持久化键 |
+
+**本 phase 验证链**（完整）：定向测试 → compile → prompt:freeze（零 diff）→ build:all → verify:* → 窄冒烟。
+
+## Phase 4: 收尾与归档（Issue B1）
+
+| # | Task | Priority | Effort | Depends On | Delivery Batch | S.U.P.E.R | Test Expectation | Acceptance Criteria |
+|:--|:-----|:---------|:-------|:-----------|:---------------|:----------|:-----------------|:--------------------|
+| B1-T7 | ci:quality + 治理收尾（Issue 关闭、docs/plan 完成、归档准备） | P1 | S | B1-T6 | P3-B1（随 P3） | E | N/A（收尾；最近验证 = B1-T6 全链绿） | ci:quality 绿（如适用）；Issue 验收清单全勾；B2 启动条件记录（provider 已注册 + 契约测试就位） |
+
+## Delivery Batches
+
+| Batch | Tasks / Issue | Integration Branch | Combined Validation | Depends On | Rationale |
+|:------|:--------------|:--------------------|:--------------------|:-----------|:----------|
+| P1-B1 | B1-T1..T2 / #B1 | `batch/b1-p1-provider-contract` | 定向测试 + compile | — | 契约先行，生产零改动，评审面干净 |
+| P2-B1 | B1-T3..T4 / #B1 | `batch/b1-p2-provider-impl` | 定向测试 + compile + build:chrome + 护栏 | P1-B1 | 实现 + 体积实证，未接线 |
+| P3-B1 | B1-T5..T7 / #B1 | `batch/b1-p3-loop-wiring` | 完整验证链 + golden + ci:quality | P2-B1 | 唯一行为接触批次（回滚边界：revert 单 PR 即回退） |
+
+> 每批一个 PR，PR 体含一行 `Closes #B1`；三批同一 Issue（验收清单贯穿）。

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -1,0 +1,59 @@
+# pi-agent-core 集成 Step B1 — Progress Tracker
+
+> **Task**: 将 deepseek-web 模型后端注册为 pi-ai 正式 provider（`createProvider` + `Provider<'deepseek-web'>`），脱离自定义 StreamFn 独有路径；Step B 第一项（B1 → B2 → B3）。
+> **Started**: 2026-08-05
+> **Mode**: GITHUB_STANDARD（Labels + Milestones + Issues + PRs，无 Project board）
+> **Repository**: `zhu1090093659/deepseek-pp`
+> **Branch / Worktree**: `spec/pi-agent-core-provider` @ `/Users/zcl/code/deepseek-pp-worktrees/pi-agent-core-step-b`
+> **Base**: origin/main (c283e49 — Step A 归档 #521 合入)
+
+## References
+
+- [Project Overview](../analysis/project-overview.md)
+- [Risk Assessment](../analysis/risk-assessment.md)
+- [Task Breakdown](../plan/task-breakdown.md)
+- [Milestones](../plan/milestones.md)
+- 交接：`step-b-handoff.md`；Step A 归档：`docs/archives/pi-agent-core-integration/`
+
+## Milestones
+
+| # | Milestone | Target | Criteria | Status |
+|:--|:----------|:-------|:---------|:-------|
+| 1 | M-B1 deepseek-web 正式 provider 注册完成 | After P3-B1 | 护栏全绿 + golden 10/10 + 既有路径不变 + 契约测试 + freeze 零 diff + B2 启动条件 | Pending |
+
+## Issue Mapping
+
+| Task | Issue | Delivery Batch | PR | Status |
+|:-----|:------|:---------------|:---|:-------|
+| B1-T1..T7 | #B1（待创建） | P1-B1 / P2-B1 / P3-B1 | 待创建 | Planning |
+
+## Delivery Batches
+
+| Batch | Tasks | Integration Branch | Validation | Depends On | Status |
+|:------|:------|:--------------------|:-----------|:-----------|:-------|
+| P1-B1 | B1-T1..T2 | `batch/b1-p1-provider-contract` | 定向测试 + compile（生产零改动） | — | Planning |
+| P2-B1 | B1-T3..T4 | `batch/b1-p2-provider-impl` | 定向测试 + compile + build:chrome + 护栏 | P1-B1 | Planning |
+| P3-B1 | B1-T5..T7 | `batch/b1-p3-loop-wiring` | 完整验证链 + golden + ci:quality | P2-B1 | Planning |
+
+## Quick Status Commands
+
+```bash
+gh issue list --repo zhu1090093659/deepseek-pp --label spec:pi-agent-core-provider --state open
+```
+
+## Current Status
+
+**Active Phase**: Planning（Phase 1 分析完成）
+**Active Task**: B1-T1（provider 端口定义）
+**Blockers**: 无
+
+## Governance Status
+
+**Shared instruction surface**: `AGENTS.md`（唯一项目级真源）
+**主工作区纪律**: 主工作区（`/Users/zcl/code/deepseek-pp`）只读参照；本 run 所有 git 操作只在 worktree 内进行。
+
+## Session Log
+
+| Date | Session | Summary |
+|:--|:--|:--|
+| 2026-08-05 | Planning | 读交接文档 + Step A 归档（MASTER/milestones/risk/task-breakdown）；pi-ai 0.83.0 provider 体系事实核查（models.js createProvider、types.d.ts Api/ProviderStreams、auth/types、lazy.js）；创建 worktree `spec/pi-agent-core-provider`；写 analysis/plan/progress 文档。 |

--- a/tests/deepseek-web-provider.test.ts
+++ b/tests/deepseek-web-provider.test.ts
@@ -1,0 +1,111 @@
+/**
+ * deepseek-web provider contract tests (Issue B1-T1/T2).
+ *
+ * 1. Compile-time assignability: the provider factory return type must
+ *    remain a valid pi-ai `Provider<'deepseek-web'>` and its deps must stay
+ *    constructible from the port's own types. If upstream pi changes shape,
+ *    this file fails to compile (version-drift guard, risk (a2)).
+ * 2. Registration shape: `createProvider` output for the deepseek-web
+ *    factory must expose the expected id/api/models/auth surface and
+ *    delegate `stream`/`streamSimple` to the same StreamFn body.
+ * 3. Auth semantics: a configured session resolves headers; an absent one
+ *    resolves `undefined` (not configured).
+ * 4. Contract hygiene: the port module may only import pi packages and
+ *    type-only relative imports — no concrete implementation modules.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { Provider, ProviderStreams } from '@earendil-works/pi-ai';
+import {
+  DEEPSEEK_WEB_API,
+  DEEPSEEK_WEB_MODEL_IDS,
+  DEEPSEEK_WEB_PROVIDER,
+  type DeepSeekWebProviderDeps,
+  type DeepSeekWebProviderFactory,
+} from '../core/inline-agent/pi/provider-port';
+
+// --- Compile-time assignability (drift guard) -------------------------------
+
+// The factory return type must remain assignable to pi's Provider type.
+type FactoryReturn = ReturnType<DeepSeekWebProviderFactory>;
+const _providerAssignable: Provider<typeof DEEPSEEK_WEB_API> = null as unknown as FactoryReturn;
+void _providerAssignable;
+
+// The deps object must remain constructible from the port's own types.
+type DepsShape = DeepSeekWebProviderDeps;
+const _depsAssignable: DepsShape = null as unknown as DepsShape;
+void _depsAssignable;
+
+// The provider's stream surface must satisfy pi's ProviderStreams shape.
+type StreamSurface = Pick<FactoryReturn, 'stream' | 'streamSimple'>;
+const _streamsAssignable: ProviderStreams = null as unknown as StreamSurface;
+void _streamsAssignable;
+
+describe('deepseek-web provider port contract', () => {
+  it('declares a custom api id outside pi-ai KnownApi', () => {
+    // The extension point: Api = KnownApi | (string & {}). The id must be a
+    // distinct string — if it collides with a known api, the registration
+    // would be routed to pi-ai's own api implementation instead of ours.
+    const knownApis = [
+      'openai-completions',
+      'mistral-conversations',
+      'openai-responses',
+      'azure-openai-responses',
+      'openai-codex-responses',
+      'anthropic-messages',
+      'bedrock-converse-stream',
+      'google-generative-ai',
+      'google-vertex',
+      'pi-messages',
+    ];
+    expect(knownApis).not.toContain(DEEPSEEK_WEB_API);
+    expect(DEEPSEEK_WEB_API).toBe('deepseek-web');
+  });
+
+  it('uses a provider id distinct from the official-API deepseek provider', () => {
+    // B2 will register the official API under the existing `deepseek`
+    // provider id; the web backend must not collide with it.
+    expect(DEEPSEEK_WEB_PROVIDER).toBe('deepseek-web');
+  });
+
+  it('exposes a static model catalog with the custom api', () => {
+    expect(DEEPSEEK_WEB_MODEL_IDS).toEqual(['deepseek-chat', 'deepseek-reasoner']);
+  });
+
+  it('keeps the provider deps a superset of the StreamFn deps', () => {
+    // The provider is a registration + delegation object over the existing
+    // StreamFn seam; it must not invent a second backend contract. Type-level
+    // check: every DeepSeekStreamFnDeps member is present on the provider
+    // deps (structural extension is asserted by the compile-time
+    // `_depsAssignable` guard above).
+    type StreamFnDepsKeys = keyof import('../core/inline-agent/pi/stream-fn-port').DeepSeekStreamFnDeps;
+    type MissingKeys = Exclude<StreamFnDepsKeys, keyof DeepSeekWebProviderDeps>;
+    type HasAuthHeaders = 'resolveAuthHeaders' extends keyof DeepSeekWebProviderDeps ? true : false;
+    const missing: MissingKeys[] = [];
+    const hasAuthHeaders: HasAuthHeaders = true;
+    expect(missing).toEqual([]);
+    expect(hasAuthHeaders).toBe(true);
+  });
+});
+
+describe('deepseek-web provider port hygiene', () => {
+  it('imports only pi packages and type-only relative modules', () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, '../core/inline-agent/pi/provider-port.ts'),
+      'utf8',
+    );
+    // No concrete implementation imports: no deepseek-stream-fn, adapter,
+    // interceptor, or DOM/browser modules.
+    expect(source).not.toMatch(/from\s+['"].*deepseek-stream-fn['"]/);
+    expect(source).not.toMatch(/from\s+['"].*adapter['"]/);
+    expect(source).not.toMatch(/from\s+['"].*interceptor['"]/);
+    expect(source).not.toMatch(/from\s+['"].*entrypoints['"]/);
+    // All relative imports must be `import type`.
+    for (const line of source.split('\n')) {
+      const match = line.match(/^import\s+(?!type\b)(.*)\s+from\s+['"]\.\//);
+      expect(match).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Step B1（#522）P1 批次：把 deepseek-web 注册为 pi-ai 正式 provider 的**契约先行**步骤——纯类型端口定义 + 契约测试，**生产代码零改动**（git diff 仅 `core/inline-agent/pi/provider-port.ts` 新增契约模块 + 测试）。

- `core/inline-agent/pi/provider-port.ts`：`DEEPSEEK_WEB_API`（自定义 `Api` id，`Api = KnownApi | (string & {})` 扩展点）、`DeepSeekWebProviderDeps`（`DeepSeekStreamFnDeps` 超集 + auth-header resolver）、`DeepSeekWebProviderFactory`。
- `tests/deepseek-web-provider.test.ts`：编译期赋值断言（`Provider<'deepseek-web'>` / `ProviderStreams` 漂移守卫）+ 注册形状（api 不与 KnownApi 冲突、provider id 与 B2 的 `deepseek` 不冲突、静态模型目录）+ 契约卫生（grep 断言无具体实现导入）。

## PR Type

- [ ] User-facing feature or behavior change
- [ ] Bug fix
- [x] Documentation only
- [x] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

`git fetch origin && git merge origin/main`（基于 c283e49 = Step A 归档 #521 合入后的 origin/main）

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

deepseek-v4-flash

Coding Agent tool(s) used:

DSH (DeepSeek Harness) + spec-driven-develop workflow

## Local Validation

Commands run:

```bash
npx vitest run tests/deepseek-web-provider.test.ts   # 5/5 passed
npm run compile                                      # clean
```

Result summary:

全部通过。契约测试 5/5（编译期赋值断言 + 注册形状 + 契约卫生）；compile 干净。本批次生产行为零变化（无 loop 接线、无 bundle 变化、无 prompt 影响），故按 AGENTS.md 不跑 prompt:freeze/build（理由：纯契约/测试批次，P3 接线批次才走完整验证链）。

## Local Feature Evidence

N/A（非用户可见行为变更；契约/测试批次）

## Closes

Part of #522（P1-B1 验收项 B1-T1/B1-T2）