### PR TITLE
B1-P2: deepseek-web pi-ai provider 注册实现 + 体积护栏（未接线）

### DIFF
--- a/core/inline-agent/pi/deepseek-web-provider.ts
+++ b/core/inline-agent/pi/deepseek-web-provider.ts
@@ -1,0 +1,109 @@
+/**
+ * deepseek-web pi-ai provider (Issue B1-T3).
+ *
+ * Registers the DeepSeek web backend as a first-class pi-ai `Provider`
+ * through `createProvider`, using the `Api = KnownApi | (string & {})`
+ * extension point (`DEEPSEEK_WEB_API`):
+ *
+ *  - the provider is a **registration + delegation object**: it owns no page
+ *    state, no session chain, no authorization. All backend behavior is
+ *    delegated to the existing `createDeepSeekStreamFn` /
+ *    `createDeepSeekTurnSubmitter` adapters (single authority, AGENTS.md
+ *    StreamFn rule) — pi-ai's own api modules are never used, because the
+ *    DS-web wire format is not OpenAI-compatible (SSE `{p,o,v}` patches,
+ *    XML tool calls, PoW, no native function calling);
+ *  - `auth` follows pi-ai's ambient-credential semantics: `resolveAuthHeaders`
+ *    is injected by the loop adapter (it reads the page session headers via
+ *    the existing `createClientHeaders` path); an absent session resolves to
+ *    "not configured" (undefined);
+ *  - the static model catalog exposes the released DS-web model ids with the
+ *    custom api; `getModels()` is synchronous and never throws;
+ *  - `stream`/`streamSimple` both delegate to the same StreamFn body: the pi
+ *    agent loop only consumes `stream`; `streamSimple` is the interface
+ *    requirement and maps to the identical implementation.
+ *
+ * Bundle guard: this module imports only `createProvider` (models.js) plus
+ * the existing StreamFn adapter — never pi-ai's OpenAI/Anthropic/... api
+ * modules (heavy SDKs stay out of the static graph; pi-bundle-budget probe
+ * asserts it).
+ */
+import { createProvider } from '@earendil-works/pi-ai';
+import type { Model, ProviderStreams, StreamOptions } from '@earendil-works/pi-ai';
+import type { StreamFn } from '@earendil-works/pi-agent-core';
+import { createDeepSeekStreamFn, createDeepSeekTurnSubmitter } from './deepseek-stream-fn';
+import {
+  DEEPSEEK_WEB_API,
+  DEEPSEEK_WEB_MODEL_IDS,
+  DEEPSEEK_WEB_PROVIDER,
+  type DeepSeekWebProviderDeps,
+} from './provider-port';
+
+/** Static model catalog for the deepseek-web provider (B1-T3). */
+export function createDeepSeekWebModels(): Model<typeof DEEPSEEK_WEB_API>[] {
+  return DEEPSEEK_WEB_MODEL_IDS.map((id) => ({
+    id,
+    name: id === 'deepseek-chat' ? 'DeepSeek Chat (Web)' : 'DeepSeek Reasoner (Web)',
+    api: DEEPSEEK_WEB_API,
+    provider: DEEPSEEK_WEB_PROVIDER,
+    baseUrl: '',
+    reasoning: id === 'deepseek-reasoner',
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 0,
+    maxTokens: 0,
+  }));
+}
+
+/**
+ * Builds the pi-ai provider for the DeepSeek web backend. The returned
+ * `Provider<'deepseek-web'>` streams exactly like the existing custom
+ * StreamFn path (same body, same callbacks, same fail-closed semantics).
+ */
+export function createDeepSeekWebProvider(deps: DeepSeekWebProviderDeps): ReturnType<typeof createProvider<typeof DEEPSEEK_WEB_API>> {
+  const { resolveAuthHeaders, ...streamFnDeps } = deps;
+  const streamFn = createDeepSeekStreamFn(streamFnDeps);
+
+  return createProvider({
+    id: DEEPSEEK_WEB_PROVIDER,
+    name: 'DeepSeek Web',
+    auth: {
+      apiKey: {
+        name: 'DeepSeek Web session',
+        resolve: async () => {
+          const headers = await resolveAuthHeaders();
+          if (!headers) return undefined;
+          return {
+            auth: { headers },
+            source: 'DeepSeek Web session',
+          };
+        },
+      },
+    },
+    models: createDeepSeekWebModels(),
+    api: {
+      stream: toSyncStream(streamFn),
+      streamSimple: toSyncStream(streamFn),
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Adapts the pi StreamFn (whose type allows a Promise return) to pi-ai's
+ * `ProviderStreams` synchronous surface. The deepseek-web StreamFn
+ * implementation always returns its event stream synchronously — the Promise
+ * arm of the type is never taken. Fail closed: if an upstream change ever
+ * returns a Promise, this throws instead of silently misbehaving.
+ */
+function toSyncStream(streamFn: StreamFn): ProviderStreams['stream'] {
+  return (model, context, options?: StreamOptions) => {
+    const stream = streamFn(model, context, options);
+    if (stream instanceof Promise) {
+      throw new Error('deepseek-web StreamFn returned a Promise; provider stream requires a synchronous AssistantMessageEventStream');
+    }
+    return stream;
+  };
+}

--- a/scripts/pi-bundle-budget.mjs
+++ b/scripts/pi-bundle-budget.mjs
@@ -34,6 +34,14 @@
 //   - rolldown full-A3 probe (minified): 380,350 raw / 126,700 gzip (adapter
 //     + loop adapter + runAgentLoop surface; calibrated 2026-08-05 after the
 //     A3 loop swap)
+//   - rolldown provider probe (minified): 383,593 raw / 128,037 gzip
+//     (full-A3 + createDeepSeekWebProvider; the createProvider/models.js
+//     dependency surface adds only ~2.7K raw / ~1.2K gzip — no heavy SDK
+//     tree enters; calibrated 2026-08-05, B1-T4)
+//   - rolldown provider probe (minified): 383,593 raw / 128,037 gzip
+//     (full-A3 + createDeepSeekWebProvider; the createProvider/models.js
+//     dependency surface adds only ~2.7K raw / ~1.2K gzip — no heavy SDK
+//     tree enters; calibrated 2026-08-05, B1-T4)
 //   - esbuild pi-only probe (minified): 213,749 raw / 59,616 gzip (more
 //     conservative retention; kept for reference)
 //   - Budgets allow ~13-32% raw / ~14-37% gzip headroom over the measured
@@ -72,6 +80,8 @@ const PI_PROBE_RAW_MAX = 230_000;
 const PI_PROBE_GZIP_MAX = 72_000;
 const ADAPTER_PROBE_RAW_MAX = 430_000;
 const ADAPTER_PROBE_GZIP_MAX = 145_000;
+const PROVIDER_PROBE_RAW_MAX = 450_000;
+const PROVIDER_PROBE_GZIP_MAX = 152_000;
 
 const PI_CORE_DIR = resolve(rootDir, 'node_modules/@earendil-works/pi-agent-core');
 
@@ -93,10 +103,12 @@ const report = {
   redLine: { raw: RED_LINE_RAW, gzip: RED_LINE_GZIP },
   piProbeBudget: { raw: PI_PROBE_RAW_MAX, gzip: PI_PROBE_GZIP_MAX },
   adapterProbeBudget: { raw: ADAPTER_PROBE_RAW_MAX, gzip: ADAPTER_PROBE_GZIP_MAX },
+  providerProbeBudget: { raw: PROVIDER_PROBE_RAW_MAX, gzip: PROVIDER_PROBE_GZIP_MAX },
   bundles: {},
   piDistNodeGate: null,
   piProbe: null,
   adapterProbe: null,
+  providerProbe: null,
 };
 
 // ---------------------------------------------------------------------------
@@ -192,6 +204,20 @@ if (failures.length === 0) {
         "import { createDeepSeekStreamFn, createDeepSeekTurnSubmitter } from '../../core/inline-agent/pi/deepseek-stream-fn';",
         "import { runPiInlineAgentLoop } from '../../core/inline-agent/pi/loop-adapter';",
         "console.log('pi-budget-probe', typeof agentLoop, typeof setDefaultStreamFn, typeof createDeepSeekStreamFn, typeof createDeepSeekTurnSubmitter, typeof runPiInlineAgentLoop);",
+        '',
+      ].join('\n'),
+    },
+    {
+      key: 'providerProbe',
+      label: 'provider probe',
+      rawMax: PROVIDER_PROBE_RAW_MAX,
+      gzipMax: PROVIDER_PROBE_GZIP_MAX,
+      entry: [
+        "import { agentLoop, setDefaultStreamFn } from '@earendil-works/pi-agent-core';",
+        "import { createDeepSeekStreamFn, createDeepSeekTurnSubmitter } from '../../core/inline-agent/pi/deepseek-stream-fn';",
+        "import { runPiInlineAgentLoop } from '../../core/inline-agent/pi/loop-adapter';",
+        "import { createDeepSeekWebProvider, createDeepSeekWebModels } from '../../core/inline-agent/pi/deepseek-web-provider';",
+        "console.log('pi-budget-probe', typeof agentLoop, typeof setDefaultStreamFn, typeof createDeepSeekStreamFn, typeof createDeepSeekTurnSubmitter, typeof runPiInlineAgentLoop, typeof createDeepSeekWebProvider, typeof createDeepSeekWebModels);",
         '',
       ].join('\n'),
     },

--- a/tests/deepseek-web-provider.test.ts
+++ b/tests/deepseek-web-provider.test.ts
@@ -1,5 +1,5 @@
 /**
- * deepseek-web provider contract tests (Issue B1-T1/T2).
+ * deepseek-web provider contract tests (Issue B1-T1/T2/T3).
  *
  * 1. Compile-time assignability: the provider factory return type must
  *    remain a valid pi-ai `Provider<'deepseek-web'>` and its deps must stay
@@ -16,7 +16,7 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Provider, ProviderStreams } from '@earendil-works/pi-ai';
 import {
   DEEPSEEK_WEB_API,
@@ -25,6 +25,24 @@ import {
   type DeepSeekWebProviderDeps,
   type DeepSeekWebProviderFactory,
 } from '../core/inline-agent/pi/provider-port';
+
+const adapterMocks = vi.hoisted(() => ({
+  createPowHeaders: vi.fn(),
+  submitPromptStreaming: vi.fn(),
+}));
+
+vi.mock('../core/deepseek/adapter', () => ({
+  createClientHeaders: () => ({ Authorization: 'Bearer test-token' }),
+  createPowHeaders: adapterMocks.createPowHeaders,
+  submitPromptStreaming: adapterMocks.submitPromptStreaming,
+}));
+
+const { createDeepSeekWebProvider, createDeepSeekWebModels } = await import(
+  '../core/inline-agent/pi/deepseek-web-provider'
+);
+const { createDeepSeekTurnSubmitter } = await import(
+  '../core/inline-agent/pi/deepseek-stream-fn'
+);
 
 // --- Compile-time assignability (drift guard) -------------------------------
 
@@ -107,5 +125,109 @@ describe('deepseek-web provider port hygiene', () => {
       const match = line.match(/^import\s+(?!type\b)(.*)\s+from\s+['"]\.\//);
       expect(match).toBeNull();
     }
+  });
+});
+
+// --- Registration shape (real implementation, B1-T3) ------------------------
+
+function createSession() {
+  const state = { chatSessionId: 'chat-1', parentMessageId: 100 as number | null };
+  return {
+    ...state,
+    setParentMessageId(id: number | null) {
+      state.parentMessageId = id;
+    },
+  };
+}
+
+function createProviderDeps(
+  overrides: Partial<DeepSeekWebProviderDeps> = {},
+): DeepSeekWebProviderDeps {
+  return {
+    submitTurn: createDeepSeekTurnSubmitter({}),
+    session: createSession(),
+    serializePrompt: () => 'serialized',
+    mapToolCall: (call, index) => ({
+      type: 'toolCall',
+      id: `xml:${index}`,
+      name: call.invocationName,
+      arguments: call.payload,
+    }),
+    toolDescriptors: [],
+    turnDefaults: { modelType: null, refFileIds: [], thinkingEnabled: false, searchEnabled: false },
+    resolveAuthHeaders: () => ({ Authorization: 'Bearer page-token' }),
+    ...overrides,
+  };
+}
+
+describe('createDeepSeekWebProvider registration', () => {
+  beforeEach(() => {
+    adapterMocks.createPowHeaders.mockResolvedValue({ 'X-DS-PoW-Response': 'pow' });
+    adapterMocks.submitPromptStreaming.mockImplementation(async (_input, handlers) => {
+      handlers.onTextChunk('Hello from the web backend.');
+      return {
+        assistantText: 'Hello from the web backend.',
+        responseMessageId: 101,
+        requestMessageId: 100,
+        finished: true,
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers with the deepseek-web id and custom api models', () => {
+    const provider = createDeepSeekWebProvider(createProviderDeps());
+    expect(provider.id).toBe(DEEPSEEK_WEB_PROVIDER);
+    expect(provider.name).toBe('DeepSeek Web');
+    expect(provider.getModels()).toHaveLength(2);
+    for (const model of provider.getModels()) {
+      expect(model.api).toBe(DEEPSEEK_WEB_API);
+      expect(model.provider).toBe(DEEPSEEK_WEB_PROVIDER);
+    }
+    expect(provider.getModels().map((m) => m.id)).toEqual([...DEEPSEEK_WEB_MODEL_IDS]);
+  });
+
+  it('resolves auth headers from the injected resolver when configured', async () => {
+    const provider = createDeepSeekWebProvider(createProviderDeps());
+    const apiKeyAuth = provider.auth.apiKey;
+    expect(apiKeyAuth).toBeDefined();
+    const result = await apiKeyAuth!.resolve({ ctx: {} as never, credential: undefined });
+    expect(result?.auth.headers).toEqual({ Authorization: 'Bearer page-token' });
+    expect(result?.source).toBe('DeepSeek Web session');
+  });
+
+  it('resolves undefined (not configured) when the session resolver returns nothing', async () => {
+    const provider = createDeepSeekWebProvider(
+      createProviderDeps({ resolveAuthHeaders: () => undefined }),
+    );
+    const result = await provider.auth.apiKey!.resolve({ ctx: {} as never, credential: undefined });
+    expect(result).toBeUndefined();
+  });
+
+  it('delegates stream/streamSimple to the same StreamFn body', async () => {
+    const provider = createDeepSeekWebProvider(createProviderDeps());
+    const model = provider.getModels()[0];
+    const context = {
+      systemPrompt: '',
+      messages: [{ role: 'user' as const, content: 'hi', timestamp: 1 }],
+    };
+    const stream = provider.stream(model, context, {});
+    const result = await stream.result();
+    expect(result.stopReason).toBe('stop');
+    expect(result.content.some((block) => block.type === 'text')).toBe(true);
+
+    const simpleStream = provider.streamSimple(model, context, {});
+    const simpleResult = await simpleStream.result();
+    expect(simpleResult.stopReason).toBe('stop');
+  });
+
+  it('exposes a static catalog factory with the custom api', () => {
+    const models = createDeepSeekWebModels();
+    expect(models).toHaveLength(2);
+    expect(models.every((m) => m.api === DEEPSEEK_WEB_API)).toBe(true);
+    expect(models.find((m) => m.id === 'deepseek-reasoner')?.reasoning).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Step B1（#522）P2 批次：`createDeepSeekWebProvider` 实现——把 deepseek-web 注册为 pi-ai 正式 provider（`createProvider` + `Provider<'deepseek-web'>`），**未接线 loop**（生产行为零变化）。

- `core/inline-agent/pi/deepseek-web-provider.ts`：`createDeepSeekWebProvider(deps)` 复用现有 `createDeepSeekStreamFn`/`createDeepSeekTurnSubmitter`（单一权威，不复制协议逻辑）；`stream`/`streamSimple` 委托同一 StreamFn body（fail-closed 同步断言）；ambient session auth（`resolveAuthHeaders` 注入，无 token → 未配置）；静态模型目录（deepseek-chat / deepseek-reasoner，api='deepseek-web'）。
- `tests/deepseek-web-provider.test.ts`：注册形状（id/api/models）+ auth resolve 语义（有/无 token）+ stream 委托一致性，10/10 绿。
- `scripts/pi-bundle-budget.mjs`：新增 provider probe——实测 **383,593 raw / 128,037 gzip**（比 full-A3 adapter probe 仅 +2.7K raw / +1.2K gzip，`createProvider`/models.js 依赖面无重型 SDK 树进入）；无 node: 导入、无 SDK marker。

## PR Type

- [ ] User-facing feature or behavior change
- [ ] Bug fix
- [x] Documentation only
- [x] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

`git fetch origin && git rebase origin/main`（P1 #523 合入后 rebase；分支基于最新 main）

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

deepseek-v4-flash

Coding Agent tool(s) used:

DSH (DeepSeek Harness) + spec-driven-develop workflow

## Local Validation

Commands run:

```bash
npx vitest run tests/deepseek-web-provider.test.ts   # 10/10 passed
npm run compile                                      # clean
npm run build:chrome                                 # passed
node scripts/pi-bundle-budget.mjs                    # all 4 probes passed
```

Result summary:

全部通过。契约测试 10/10（含真实实现注册形状 + auth 语义 + stream 委托）；compile 干净；build:chrome 成功；护栏 4 个 probe 全绿（pi 173,663/52,534、adapter 380,917/126,859、provider 383,593/128,037，均在预算内；无 node: 导入、无 SDK marker）。本批次未接线 loop（生产行为零变化、无 prompt 影响），prompt:freeze/build:all 留给 P3 接线批次，理由记录于 #522。

## Local Feature Evidence

N/A（非用户可见行为变更；实现批次未接线）

## Closes

Part of #522（P2-B1 验收项 B1-T3/B1-T4）