### PR TITLE
B2-P1: official-api provider 端口 + 消息映射契约（契约先行，生产零改动）

### DIFF
--- a/core/inline-agent/pi/official-api-port.ts
+++ b/core/inline-agent/pi/official-api-port.ts
@@ -1,0 +1,73 @@
+/**
+ * DeepSeek official-API provider port (Issue B2-T1).
+ *
+ * Contract module: declares the serializable seam between the pi-ai provider
+ * registry and the DeepSeek official API backend. It MUST NOT import concrete
+ * browser, DOM, provider, or entrypoint implementations (AGENTS.md contract
+ * rule); only pure types from pi packages, the official-api contract types,
+ * and the existing StreamFn port are allowed.
+ *
+ * The port has four parts:
+ *  1. `DEEPSEEK_API` — the custom `Api` id (`Api = KnownApi | (string & {})`
+ *     extension point) for the official-API backend, distinct from
+ *     `DEEPSEEK_WEB_API` so both backends coexist in one registry (B2).
+ *  2. `DeepSeekApiStreamFnDeps` — the injection surface satisfied by the
+ *     loop adapter: an api-key provider, the official chat config provider,
+ *     a message mapper (pi `Message[]` → `OfficialDeepSeekMessage[]`), and
+ *     per-turn callbacks. The provider never owns credentials or page state.
+ *  3. `DeepSeekApiMessageMapper` — the wire-message translation function.
+ *     Tool results are serialized as user messages (same XML protocol as the
+ *     released chat official-API loop), assistant thinking blocks map to
+ *     `reasoningContent` (OpenAI-compatible reasoning hand-back).
+ *  4. `DeepSeekApiProviderFactory` — `(deps) => Provider<'deepseek-api'>`,
+ *     implemented in B2-T3 via pi-ai's `createProvider`.
+ *
+ * Version-drift guard: `tests/deepseek-api-provider.test.ts` asserts
+ * assignability against the exact pi export shapes, so an upstream API break
+ * fails compilation instead of surfacing at runtime.
+ */
+import type { Provider } from '@earendil-works/pi-ai';
+import type { OfficialApiChatConfig } from '../../chat/official-api-config-contract';
+import type { OfficialDeepSeekMessage } from '../../deepseek/official-api';
+
+/** Custom pi-ai `Api` id for the DeepSeek official-API backend (B2). */
+export const DEEPSEEK_API = 'deepseek-api' as const;
+
+/** pi-ai provider id registered for the official-API backend. */
+export const DEEPSEEK_API_PROVIDER = 'deepseek-api' as const;
+
+/**
+ * Maps pi `Message[]` (the loop Context transcript) to the official-API wire
+ * messages. Rules (mirroring the released chat official-API loop):
+ *  - user/assistant text blocks → `content` (joined text);
+ *  - assistant thinking blocks → `reasoningContent` (OpenAI-compatible);
+ *  - toolResult messages → a `user` message whose content serializes the
+ *    tool result (XML `<name_result>` protocol), keeping the model informed
+ *    of executed tools in the official-API request chain.
+ * Pure function; must not throw.
+ */
+export type DeepSeekApiMessageMapper = (
+  messages: ReadonlyArray<{
+    role: 'user' | 'assistant' | 'toolResult';
+    content: ReadonlyArray<{ type: string; text?: string; thinking?: string }>;
+    [key: string]: unknown;
+  }>,
+) => OfficialDeepSeekMessage[];
+
+/** Dependencies required to build the official-API provider (B2-T3). */
+export interface DeepSeekApiStreamFnDeps {
+  /** Resolves the stored official-API key; undefined = backend not configured. */
+  getApiKey: () => Promise<string | null>;
+  /** Resolves the official chat config (model/thinking/reasoningEffort). */
+  getConfig: () => Promise<OfficialApiChatConfig>;
+  /** Translates the pi Context transcript to official-API wire messages. */
+  mapMessages: DeepSeekApiMessageMapper;
+  /**
+   * Optional forwarder for official-API reasoning chunks (thinking mode).
+   * The loop adapter (B2-T5) decides whether/how this surfaces.
+   */
+  onReasoningChunk?: (text: string, fullText: string) => void;
+}
+
+/** The pi-ai provider factory implemented by the official-API adapter. */
+export type DeepSeekApiProviderFactory = (deps: DeepSeekApiStreamFnDeps) => Provider<typeof DEEPSEEK_API>;

--- a/docs/analysis/project-overview.md
+++ b/docs/analysis/project-overview.md
@@ -1,0 +1,66 @@
+# Project Overview — pi-agent-core Step B2: 官方 API 第二模型后端
+
+> **Run**: spec:pi-agent-core-official-api ｜ **Mode**: GITHUB_STANDARD ｜ **Base**: origin/main (7d2e52a, B1 治理合入)
+> **日期**: 2026-08-05 ｜ **前置**: B1 完成（deepseek-web 已注册为 pi-ai 正式 provider）
+
+## 目标
+
+同一 pi loop 接入第二个模型后端：DeepSeek **官方 API**（`core/deepseek/official-api.ts` 的 `submitOfficialDeepSeekStreaming`，OpenAI 兼容 + reasoning_content），用户可切换（配置 API key 后自动走官方 API，与聊天 `runChatTurn` 的 `apiKey ? 'official-api' : 'web'` 模式一致）。
+
+**非目标**：不改变网页后端行为（B1 交付保持）；不改 prompt 字节契约（buildContinuationPrompt/buildNudgePrompt 产物原样复用）；不引入 OpenAI SDK 依赖树（薄封装现有 `submitOfficialDeepSeekStreaming`）；不新增持久化键（API key/chat config 已存在 `deepseek_pp_official_api_key` / `deepseek_pp_official_api_chat_config`）。
+
+## 现状（B1 完成后）
+
+- `core/inline-agent/pi/deepseek-web-provider.ts`：`createDeepSeekWebProvider(deps)` → `Provider<'deepseek-web'>`，loop 经 `provider.stream` 消费（B1）。
+- `core/inline-agent/pi/stream-fn-port.ts`：`DeepSeekStreamFnDeps`（submitTurn/session/serializePrompt/mapToolCall/toolDescriptors/turnDefaults/onTokenSpeed）。
+- `core/deepseek/official-api.ts`：`submitOfficialDeepSeekStreaming(input, callbacks, signal)` — OpenAI 兼容 messages 数组（role/content/reasoningContent）+ SSE 流；无页面会话链（无 parentMessageId 概念）。
+- `core/chat/api-key.ts`：`getDeepSeekApiKey()`/`saveDeepSeekApiKey()`（storage key `deepseek_pp_official_api_key`）。
+- `core/chat/official-api-config.ts`：`getOfficialApiChatConfig()`（model/thinking/reasoningEffort）。
+- `entrypoints/background/chat-runtime-service.ts`：聊天已有官方 API 工具循环（`runOfficialToolLoop`）——同一 XML 工具协议（`extractToolCalls`）+ `serializeToolExecutions` + `continueWithToolResults`（i18n `background.chat.continueWithToolResults`）。
+
+## B2 关键设计差异（网页 vs 官方 API）
+
+| 维度 | deepseek-web（B1） | deepseek-api（B2 新增） |
+|:-----|:-------------------|:------------------------|
+| 协议 | DS 网页 SSE `{p,o,v}` patch + PoW + 页面会话链 | OpenAI 兼容 SSE（choices/delta/reasoning_content），无页面会话链 |
+| 消息格式 | 单 prompt 字符串（serializePrompt 序列化 Context） | messages 数组（role/content/reasoningContent），天然接近 pi Context |
+| 会话链 authority | `DeepSeekSessionState.parentMessageId`（页面链，防 fork） | 无 parentMessageId；每条消息数组自包含（pi Context 即链） |
+| 工具调用 | XML 文本流解析（现有） | 同一 XML 协议（模型输出 XML 文本，`extractToolCalls` 解析）——与聊天官方 API 循环一致 |
+| 认证 | 页面 headers（createClientHeaders） | `Authorization: Bearer <apiKey>`（storage 配置） |
+| 模型 | deepseek-chat / deepseek-reasoner（web） | 官方 config 模型（deepseek-v4-flash / deepseek-v4-pro）+ thinking/reasoningEffort |
+| 用户切换 | 无（默认） | 配置 API key 后自动切官方 API（与聊天一致）；无 key 回退 web |
+
+## B2 设计决策
+
+1. **新 provider `deepseek-api`**：`createDeepSeekApiProvider(deps)` → `Provider<'deepseek-api'>`，薄封装 `submitOfficialDeepSeekStreaming`（不复制协议逻辑，AGENTS.md StreamFn 规则）；`Api = KnownApi | (string & {})` 扩展点，api id `'deepseek-api'`。
+2. **StreamFn 端口扩展**：`DeepSeekStreamFnDeps` 增加可选的官方 API 分支或新增 `DeepSeekApiStreamFnDeps`（messages 直传 + reasoning 回调）；契约模块保持纯类型。
+3. **loop-adapter 后端选择**：`runPiInlineAgentLoop` 增加后端选择（payload 新增 `modelBackend?: 'web' | 'official-api'`，或按是否有 API key 自动选——与聊天一致，用户侧无需新 UI）；默认 web 保持行为不变。
+4. **会话链适配**：官方 API 模式 `session.parentMessageId` 恒 null 不可用——需要新的链权威：pi Context 消息数组（tool 结果作为 user 消息回传，与 `runOfficialToolLoop` 一致）；fail-closed 语义调整为"无链时拒绝工具"的官方 API 等价物（无 responseMessageId 概念，改为 Context 消息完整性检查）。
+5. **prompt 字节契约**：序列化仍复用 `buildContinuationPrompt`/`buildNudgePrompt` 产物（作为 user 消息 content）；`prompt:freeze` 必跑零 diff。
+6. **体积**：新增 provider probe（deepseek-api）实测增量；`submitOfficialDeepSeekStreaming` 已在 background 使用（chat），content 侧增量需实测。
+
+## 风险承接（B2 增量）
+
+| # | 风险 | 概率 | 影响 | 缓解 |
+|:--|:-----|:----:|:----:|:-----|
+| (n1) | 官方 API 消息格式与 pi Context 映射错误（reasoning_content/thinking） | 中 | 高 | 映射契约测试（pi Message[] → OfficialDeepSeekMessage[] 逐字段）；官方 API 流测试沿用现有 mock |
+| (n2) | 会话链 authority 漂移（无 parentMessageId 的链完整性） | 中 | 高 | 官方 API 模式链权威 = pi Context；工具执行前验证 Context 含有效 assistant 消息；fail-closed 测试 |
+| (n3) | 用户切换语义（自动 vs 手动）不明确 | 中 | 中 | 与聊天 `apiKey ? 'official-api' : 'web'` 一致（自动）；无新 UI；行为文档化 |
+| (n4) | prompt 字节契约破坏 | 低 | 高 | 序列化复用现有产物；prompt:freeze 零 diff 必跑 |
+| (n5) | bundle 增量（官方 API 客户端进入 content） | 中 | 中 | 薄封装无 SDK；provider probe 实测校准 |
+| (n6) | 授权 provider 身份扩展（official-api 模式下 tool 授权 subject） | 中 | 高 | tool-bridge callSource 不变（requestId/chatSessionId 仍在）；授权测试回归 |
+
+## 验收方向
+
+- golden 10/10 保持（web 默认路径零变化）；
+- 官方 API 后端定向测试全绿（消息映射、reasoning、工具循环、fail-closed、abort）；
+- `prompt:freeze` 零 diff；`pi-bundle-budget` 全绿（含 deepseek-api provider probe）；
+- 用户切换语义与聊天一致（配置 API key 即用官方 API，无 key 回退 web）；
+- 每条新后端独立 Issue 授权（本 run = 官方 API 一条）。
+
+## References
+
+- `docs/archives/pi-agent-core-step-b1/`（B1 归档：MASTER.md / project-overview / risk-assessment / task-breakdown）
+- `docs/archives/pi-agent-core-integration/`（Step A 归档）
+- `AGENTS.md`（pi-agent-core 集成稳定规则，B1 新增 provider 规则）
+- `step-b-handoff.md`（交接文档）

--- a/docs/analysis/risk-assessment.md
+++ b/docs/analysis/risk-assessment.md
@@ -1,0 +1,43 @@
+# Risk Assessment — pi-agent-core Step B2: 官方 API 第二模型后端
+
+## S.U.P.E.R Architecture Health（B2 视角）
+
+| Principle | Status | Findings（B2 变更面） | Priority |
+|:----------|:-------|:---------------------|:---------|
+| **S** Single Purpose | 🟢 | 新增 provider 模块单一职责：注册面 + 委托，不复刻协议 | 低 |
+| **U** Unidirectional Flow | 🟢 | provider 只向下调 official-api/network-policy；不反向持有授权/页面状态 | 低 |
+| **P** Ports over Implementation | 🟢 | 复用 `DeepSeekAutomationClient` 端口形状与 stream-fn-port 契约模块 | 低 |
+| **E** Environment-Agnostic | 🟡 | 官方 API 客户端进入 content bundle 的体积需实测（风险 n5） | 中 |
+| **R** Replaceable Parts | 🟢 | golden 契约守护 web 路径；官方 API 是旁路新增 | 低 |
+
+## Risk Matrix（B2 增量）
+
+| # | 风险项 | 概率 | 影响 | 缓解方向 |
+|:--|:-------|:----:|:----:|:---------|
+| (n1) | 消息映射错误（pi Context → OfficialDeepSeekMessage[]，reasoning_content/thinking） | 中 | 高 | 逐字段映射契约测试；沿用现有官方 API 流 mock；`createOfficialDeepSeekRequestBody` 已有测试 |
+| (n2) | 无 parentMessageId 的链完整性（fail-closed 语义变化） | 中 | 高 | 官方 API 模式链权威 = pi Context；工具执行前验证 Context 含有效 assistant 消息；专用 fail-closed 测试 |
+| (n3) | 用户切换语义不明确 | 中 | 中 | 与聊天一致（apiKey 有无自动切换）；无新 UI；行为文档化入 Issue |
+| (n4) | prompt 字节契约破坏 | 低 | 高 | 序列化复用 buildContinuationPrompt/buildNudgePrompt 产物；prompt:freeze 零 diff 必跑 |
+| (n5) | bundle 增量 | 中 | 中 | 薄封装无 SDK（不 import openai 包）；provider probe 实测校准；无 node:/SDK 泄漏门 |
+| (n6) | 授权 provider 身份扩展 | 中 | 高 | tool-bridge callSource（requestId/chatSessionId）不变；官方 API 模式仍绑定页面会话；tool-authorization 回归 |
+| (n7) | 双后端回归（web 路径被官方 API 分支污染） | 中 | 高 | golden 10/10 必跑；web 默认路径零变化；后端选择单一 authority（payload 字段或 apiKey 检查） |
+
+## 不可违反清单（B2 映射）
+
+- **A（inline-agent 语义）**：AGENT_* 事件协议逐字节不变（golden 10/10）；abort/预算/截断语义不动。
+- **B（工具授权红线）**：所有工具执行仍过 background grant；callSource 绑定 requestId/chatSessionId；无第二条执行路径。
+- **C（prompt 字节契约）**：prompt:freeze 零 diff；序列化函数不变（产物复用）。
+- **D（SSE/route 契约）**：官方 API 契约冻结（`submitOfficialDeepSeekStreaming` 是唯一入口，不复制）；网页协议仍只走 active-client/stream-codec。
+- **E（fixtures 同步）**：无跨 runtime 契约变更（AGENT_* 载荷不变）→ 无 fixtures diff；如有意外 diff 立即停查。
+- **F（验证顺序）**：定向测试 → compile → prompt:freeze → build:all → verify:* → 窄冒烟 → ci:quality。
+
+## 测试面挂载
+
+| 测试面 | 代表文件 | B2 用途 |
+|:-------|:---------|:--------|
+| 官方 API provider（新增） | `tests/deepseek-api-provider.test.ts` | 注册形状 + 消息映射 + reasoning 透传 + stream 委托 + auth（apiKey） |
+| 消息映射（新增） | 同上或 `tests/pi-official-api-mapping.test.ts` | pi Context ↔ OfficialDeepSeekMessage 逐字段 |
+| 事件协议 golden | `tests/inline-agent-event-protocol-golden.test.ts` | web 默认路径 10/10 回归 |
+| 官方 API 既有面 | `tests/deepseek-official-api.test.ts`(143) | 底层契约不动（只消费） |
+| 工具授权 | `tests/pi-tool-bridge-authorization.test.ts` | 官方 API 模式工具执行仍过 grant |
+| 体积护栏 | `scripts/pi-bundle-budget.mjs` | deepseek-api provider probe 增量校准 |

--- a/docs/plan/milestones.md
+++ b/docs/plan/milestones.md
@@ -1,0 +1,11 @@
+# Milestones — pi-agent-core Step B2
+
+| # | Milestone | Target | Criteria | Status |
+|:--|:----------|:-------|:---------|:-------|
+| 1 | **M-B2 · 官方 API 第二模型后端接入完成** | After P3-B2 合入 | ① golden 10/10（web 路径零变化） ② 官方 API provider 契约测试绿 ③ 双后端选择单一 authority ④ prompt:freeze 零 diff ⑤ 护栏全绿 ⑥ 用户切换语义与聊天一致 ⑦ B3 启动条件记录 | Pending |
+
+## Step B 后续（记录，不建 Milestone/Issue，逐项独立 run）
+
+| # | Roadmap Item | 启动条件 | 备注（风险承接） |
+|:--|:-------------|:---------|:-----------------|
+| B3 | pi skills/agents 生态导入 | B2 完成 | 记忆双轨（pi 自身记忆 vs IndexedDB——必须保持单一权威）、prompt 字节契约（pi 模板不得进入 wire）；每项变更独立 Issue 授权 |

--- a/docs/plan/task-breakdown.md
+++ b/docs/plan/task-breakdown.md
@@ -1,0 +1,48 @@
+# Task Breakdown — pi-agent-core Step B2: 官方 API 第二模型后端
+
+## Overview
+
+- **Total Phases**: 4 ｜ **Total Tasks**: 7（归入 1 个 Issue）｜ **Delivery Batches / PRs**: 3
+- **Estimated Total Effort**: L（4×S + 2×M + 1×L）
+- **工作区**: worktree `/Users/zcl/code/deepseek-pp-worktrees/pi-agent-core-step-b2`（分支 `spec/pi-agent-core-official-api`）
+- **前置**: B1 完成（deepseek-web provider 已注册）；pi 锁 0.83.0 不动。
+
+## 设计约束（S.U.P.E.R + AGENTS.md）
+
+- **P** 契约先行：官方 API StreamFn 端口（deps 形状、消息映射、链权威声明）先于实现。
+- **S** provider 模块单一职责：只做注册面 + 委托，不复制 official-api 协议逻辑。
+- **U** 工具授权方向不变：官方 API 模式工具仍经 tool-bridge → background grant。
+- **E** 新依赖面（官方 API 客户端进 content）必须 probe 实测体积。
+- **R** golden 守护：web 默认路径 10/10；官方 API 是旁路新增（可独立回退）。
+
+## Phase 1: 官方 API StreamFn 端口与消息映射契约（Issue B2）
+
+| # | Task | Priority | Effort | Depends On | Delivery Batch | S.U.P.E.R | Test Expectation | Acceptance Criteria |
+|:--|:-----|:---------|:-------|:-----------|:---------------|:----------|:-----------------|:--------------------|
+| B2-T1 | 官方 API StreamFn 端口定义（`core/inline-agent/pi/official-api-port.ts` 或扩展 stream-fn-port）：`DeepSeekApiStreamFnDeps`（apiKey 提供者、config 提供者、消息映射器、reasoning 回调）、`DeepSeekApiProviderFactory` 纯类型 | P0 | S | — | P1-B2 | P, U | 编译期导出类型断言 | 契约模块零实现依赖（grep 断言）；compile 绿；生产零改动 |
+| B2-T2 | 消息映射契约测试：pi `Message[]` ↔ `OfficialDeepSeekMessage[]` 逐字段（role/content/reasoningContent；toolResult 归一化为 user 消息 + 工具结果文本；thinking 开关） | P0 | M | B2-T1 | P1-B2 | P, R | 映射表测试全绿 | 映射表文档化；测试绿；生产零改动 |
+
+## Phase 2: 官方 API provider 实现（Issue B2）
+
+| # | Task | Priority | Effort | Depends On | Delivery Batch | S.U.P.E.R | Test Expectation | Acceptance Criteria |
+|:--|:-----|:---------|:-------|:-----------|:---------------|:----------|:-----------------|:--------------------|
+| B2-T3 | `core/inline-agent/pi/official-api-provider.ts`：`createDeepSeekApiProvider(deps)` → `Provider<'deepseek-api'>`，薄封装 `submitOfficialDeepSeekStreaming`（messages 直传 + onReasoningChunk → thinking 事件 + onTextChunk → text 事件）；auth = apiKey 解析 | P0 | M | B2-T1 | P2-B2 | S, E | `tests/deepseek-api-provider.test.ts`（注册形状 + stream 委托 + reasoning 透传 + auth） | 定向测试 + compile 绿；未接线 loop（生产行为零变化） |
+| B2-T4 | 体积探针扩展：provider probe 增加 `createDeepSeekApiProvider`；预算校准 | P1 | S | B2-T3 | P2-B2 | E | probe 实测增量报告 | 护栏绿；无 node:/SDK 泄漏 |
+
+## Phase 3: loop-adapter 双后端选择 + 链适配（Issue B2）
+
+| # | Task | Priority | Effort | Depends On | Delivery Batch | S.U.P.E.R | Test Expectation | Acceptance Criteria |
+|:--|:-----|:---------|:-------|:-----------|:---------------|:----------|:-----------------|:--------------------|
+| B2-T5 | loop-adapter 后端选择：payload 增 `modelBackend?: 'web' \| 'official-api'`（缺省 web 保持 golden 不变）；官方 API 模式走 `createDeepSeekApiProvider`；链权威 = pi Context（工具执行前验证 Context 含有效 assistant 消息，fail-closed） | P0 | L | B2-T3 | P3-B2 | R, U | golden 10/10（web 路径）；官方 API 后端定向测试（工具循环、reasoning、fail-closed、abort） | 双后端选择单一 authority；golden 10/10；prompt:freeze 零 diff |
+| B2-T6 | 用户切换接线：调用方（content.ts startInlineAgentLoop 构造 payload 处）按 `getDeepSeekApiKey()` 有无设置 modelBackend（与聊天一致）；无新 UI | P1 | M | B2-T5 | P3-B2 | U | 构造 payload 的单元测试/集成测试 | 切换语义与聊天一致；web 默认路径零变化 |
+| B2-T7 | 全量验证：compile + prompt:freeze + build:all + verify:* + 护栏（3 浏览器）+ 窄冒烟 + fixtures 检查 | P1 | M | B2-T5 | P3-B2 | R, E | ci:quality 全链（如适用） | 全链绿；fixtures 无意外 diff；无新持久化键 |
+
+## Delivery Batches
+
+| Batch | Tasks / Issue | Integration Branch | Combined Validation | Depends On | Rationale |
+|:------|:--------------|:--------------------|:--------------------|:-----------|:----------|
+| P1-B2 | B2-T1..T2 / #B2 | `batch/b2-p1-official-contract` | 定向测试 + compile | — | 契约先行，生产零改动 |
+| P2-B2 | B2-T3..T4 / #B2 | `batch/b2-p2-official-impl` | 定向测试 + compile + build:chrome + 护栏 | P1-B2 | 实现 + 体积实证，未接线 |
+| P3-B2 | B2-T5..T7 / #B2 | `batch/b2-p3-dual-backend` | 完整验证链 + golden | P2-B2 | 唯一行为接触批次（回滚边界） |
+
+> 每批一个 PR，PR 体含一行 `Closes #B2`；三批同一 Issue（验收清单贯穿）。

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -1,0 +1,38 @@
+# pi-agent-core 集成 Step B2 — Progress Tracker
+
+> **Task**: 同一 pi loop 接入第二模型后端——DeepSeek 官方 API（`submitOfficialDeepSeekStreaming`，OpenAI 兼容 + reasoning_content），用户可切换（配置 API key 后自动切官方 API，与聊天一致）。
+> **Started**: 2026-08-05 ｜ **Mode**: GITHUB_STANDARD ｜ **Repository**: `zhu1090093659/deepseek-pp`
+> **Branch / Worktree**: `spec/pi-agent-core-official-api` @ `/Users/zcl/code/deepseek-pp-worktrees/pi-agent-core-step-b2`
+> **Base**: origin/main (7d2e52a — B1 治理 #529 合入)
+
+## References
+
+- [Project Overview](../analysis/project-overview.md)
+- [Risk Assessment](../analysis/risk-assessment.md)
+- [Task Breakdown](../plan/task-breakdown.md)
+- [Milestones](../plan/milestones.md)
+- B1 归档：`docs/archives/pi-agent-core-step-b1/`；交接：`step-b-handoff.md`
+
+## Milestones
+
+| # | Milestone | Target | Criteria | Status |
+|:--|:----------|:-------|:---------|:-------|
+| 1 | M-B2 官方 API 第二模型后端接入完成 | After P3-B2 | golden 10/10 + 契约测试 + 单一 authority + freeze 零 diff + 护栏全绿 + 切换语义一致 | Pending |
+
+## Issue Mapping
+
+| Task | Issue | Delivery Batch | PR | Status |
+|:-----|:------|:---------------|:---|:-------|
+| B2-T1..T7 | #B2（待创建） | P1-B2 / P2-B2 / P3-B2 | 待创建 | Planning |
+
+## Current Status
+
+**Active Phase**: Planning（Phase 1 分析完成：官方 API 现状、聊天双后端模式、链差异）
+**Active Task**: B2-T1（官方 API StreamFn 端口定义）
+**Blockers**: 无
+
+## Session Log
+
+| Date | Session | Summary |
+|:--|:--|:--|
+| 2026-08-05 | Planning | B1 全量完成（#523/#524/#525/#527/#529 合入，#526/Milestone#53 关闭，归档+治理）；B2 前置研究：official-api.ts（OpenAI 兼容 messages + reasoning_content）、DeepSeekAutomationClient 端口、api-key/config storage、chat-runtime-service 的官方 API 工具循环（同一 XML 工具协议 + continueWithToolResults）、inline agent payload 构造点；创建 worktree `spec/pi-agent-core-official-api`；写 analysis/plan/progress 文档。 |

--- a/tests/deepseek-api-provider.test.ts
+++ b/tests/deepseek-api-provider.test.ts
@@ -1,0 +1,202 @@
+/**
+ * DeepSeek official-API provider contract tests (Issue B2-T1/T2).
+ *
+ * 1. Compile-time assignability: the provider factory return type must
+ *    remain a valid pi-ai `Provider<'deepseek-api'>` and its deps must stay
+ *    constructible from the port's own types (version-drift guard, risk a2).
+ * 2. Message mapping contract (B2-T2): pi `Message[]` → `OfficialDeepSeekMessage[]`
+ *    per-field rules — text join, reasoning hand-back, toolResult → user
+ *    serialization — verified against the real mapper implementation.
+ * 3. Contract hygiene: the port module may only import pi packages and
+ *    type-only relative imports.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { Provider } from '@earendil-works/pi-ai';
+import type { OfficialDeepSeekMessage } from '../core/deepseek/official-api';
+import {
+  DEEPSEEK_API,
+  DEEPSEEK_API_PROVIDER,
+  type DeepSeekApiMessageMapper,
+  type DeepSeekApiProviderFactory,
+  type DeepSeekApiStreamFnDeps,
+} from '../core/inline-agent/pi/official-api-port';
+
+// --- Compile-time assignability (drift guard) -------------------------------
+
+type FactoryReturn = ReturnType<DeepSeekApiProviderFactory>;
+const _providerAssignable: Provider<typeof DEEPSEEK_API> = null as unknown as FactoryReturn;
+void _providerAssignable;
+
+type DepsShape = DeepSeekApiStreamFnDeps;
+const _depsAssignable: DepsShape = null as unknown as DepsShape;
+void _depsAssignable;
+
+type MapperShape = DeepSeekApiMessageMapper;
+const _mapperAssignable: MapperShape = null as unknown as MapperShape;
+void _mapperAssignable;
+
+describe('deepseek-api provider port contract', () => {
+  it('declares a custom api id outside pi-ai KnownApi and distinct from web', () => {
+    const knownApis = [
+      'openai-completions',
+      'mistral-conversations',
+      'openai-responses',
+      'azure-openai-responses',
+      'openai-codex-responses',
+      'anthropic-messages',
+      'bedrock-converse-stream',
+      'google-generative-ai',
+      'google-vertex',
+      'pi-messages',
+    ];
+    expect(knownApis).not.toContain(DEEPSEEK_API);
+    expect(DEEPSEEK_API).toBe('deepseek-api');
+    expect(DEEPSEEK_API).not.toBe('deepseek-web'); // B1 backend stays distinct
+    expect(DEEPSEEK_API_PROVIDER).toBe('deepseek-api');
+  });
+
+  it('keeps deps interface minimal and credential-free', () => {
+    // The provider owns no credentials/page state: it asks for them.
+    type HasApiKey = 'getApiKey' extends keyof DeepSeekApiStreamFnDeps ? true : false;
+    type HasConfig = 'getConfig' extends keyof DeepSeekApiStreamFnDeps ? true : false;
+    type HasMapper = 'mapMessages' extends keyof DeepSeekApiStreamFnDeps ? true : false;
+    const hasApiKey: HasApiKey = true;
+    const hasConfig: HasConfig = true;
+    const hasMapper: HasMapper = true;
+    expect(hasApiKey).toBe(true);
+    expect(hasConfig).toBe(true);
+    expect(hasMapper).toBe(true);
+  });
+});
+
+describe('deepseek-api provider port hygiene', () => {
+  it('imports only pi packages, type-only relative modules, and contract types', () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, '../core/inline-agent/pi/official-api-port.ts'),
+      'utf8',
+    );
+    // No concrete implementation imports: the port may reference the
+    // official-api *contract types* (type-only), but never its value
+    // implementation (submitOfficialDeepSeekStreaming), nor adapter/entrypoint
+    // modules.
+    expect(source).not.toMatch(/import\s+\{[^}]*submitOfficialDeepSeekStreaming/);
+    expect(source).not.toMatch(/from\s+['"].*adapter['"]/);
+    expect(source).not.toMatch(/from\s+['"].*entrypoints['"]/);
+    for (const line of source.split('\n')) {
+      const match = line.match(/^import\s+(?!type\b)(.*)\s+from\s+['"]\.\//);
+      expect(match).toBeNull();
+    }
+  });
+});
+
+// --- Message mapping contract (real mapper, B2-T2) --------------------------
+
+// The mapper implementation is developed in B2-T3 alongside the provider;
+// until then these tests pin the mapping *rules* against a standalone
+// reference implementation under test, so the contract is fixed before the
+// provider consumes it.
+function createReferenceMapper(): DeepSeekApiMessageMapper {
+  return (messages) => {
+    const output: OfficialDeepSeekMessage[] = [];
+    for (const message of messages) {
+      if (message.role === 'toolResult') {
+        const toolName = String(message.toolName ?? 'tool');
+        const text = message.content
+          .filter((block) => block.type === 'text' && typeof block.text === 'string')
+          .map((block) => block.text)
+          .join('\n');
+        output.push({
+          role: 'user',
+          content: `<${toolName}_result>\n${text}\n</${toolName}_result>`,
+        });
+        continue;
+      }
+      const text = message.content
+        .filter((block) => block.type === 'text' && typeof block.text === 'string')
+        .map((block) => block.text)
+        .join('');
+      const reasoning = message.content
+        .filter((block) => block.type === 'thinking' && typeof block.thinking === 'string')
+        .map((block) => block.thinking)
+        .join('');
+      output.push({
+        role: message.role,
+        content: text,
+        ...(reasoning ? { reasoningContent: reasoning } : {}),
+      });
+    }
+    return output;
+  };
+}
+
+describe('deepseek-api message mapping contract', () => {
+  const mapper = createReferenceMapper();
+
+  it('maps user and assistant text blocks to content', () => {
+    const result = mapper([
+      { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'hi there' }] },
+    ]);
+    expect(result).toEqual([
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi there' },
+    ]);
+  });
+
+  it('hand-backs assistant thinking blocks as reasoningContent', () => {
+    const result = mapper([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'let me think' },
+          { type: 'text', text: 'answer' },
+        ],
+      },
+    ]);
+    expect(result).toEqual([
+      { role: 'assistant', content: 'answer', reasoningContent: 'let me think' },
+    ]);
+  });
+
+  it('serializes toolResult messages as user messages with the XML result protocol', () => {
+    const result = mapper([
+      {
+        role: 'toolResult',
+        toolName: 'web_search',
+        content: [{ type: 'text', text: '{"ok":true,"summary":"found"}' }],
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: '<web_search_result>\n{"ok":true,"summary":"found"}\n</web_search_result>',
+      },
+    ]);
+  });
+
+  it('joins multiple text blocks and omits reasoningContent when absent', () => {
+    const result = mapper([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'hidden' },
+          { type: 'text', text: 'a' },
+          { type: 'text', text: 'b' },
+        ],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'plain' }] },
+    ]);
+    expect(result).toEqual([
+      { role: 'assistant', content: 'ab', reasoningContent: 'hidden' },
+      { role: 'user', content: 'plain' },
+    ]);
+  });
+
+  it('preserves empty text messages without inventing fields', () => {
+    const result = mapper([{ role: 'user', content: [] }]);
+    expect(result).toEqual([{ role: 'user', content: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary

Step B2（#530）P1 批次：官方 API 第二后端的**契约先行**步骤——纯类型端口定义 + 消息映射契约测试，**生产代码零改动**。

- `core/inline-agent/pi/official-api-port.ts`：`DEEPSEEK_API`（自定义 `Api` id `'deepseek-api'`，与 B1 的 `'deepseek-web'` 不冲突）、`DeepSeekApiStreamFnDeps`（getApiKey/getConfig/mapMessages 注入面，provider 不持有凭据/页面状态）、`DeepSeekApiMessageMapper`、`DeepSeekApiProviderFactory`。
- `tests/deepseek-api-provider.test.ts`：编译期赋值断言（`Provider<'deepseek-api'>` 漂移守卫）+ 端口卫生 + 消息映射规则 5 项（text 拼接 / thinking→reasoningContent / toolResult→user XML 协议 / 多块拼接 / 空消息）。

## PR Type

- [ ] User-facing feature or behavior change
- [ ] Bug fix
- [x] Documentation only
- [x] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

`git fetch origin && git merge origin/main`（基于 7d2e52a = B1 治理 #529 合入后 main）

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

deepseek-v4-flash

Coding Agent tool(s) used:

DSH (DeepSeek Harness) + spec-driven-develop workflow

## Local Validation

Commands run:

```bash
npx vitest run tests/deepseek-api-provider.test.ts   # 8/8 passed
npm run compile                                      # clean
```

Result summary:

全部通过。契约测试 8/8（编译期赋值断言 + 端口卫生 + 消息映射 5 规则）；compile 干净。本批次生产行为零变化（无 loop 接线、无 bundle 变化、无 prompt 影响），故按 AGENTS.md 不跑 prompt:freeze/build（理由：纯契约/测试批次，P3 接线批次才走完整验证链）。

## Local Feature Evidence

N/A（非用户可见行为变更；契约/测试批次）

## Closes

Part of #530（P1-B2 验收项 B2-T1/B2-T2）