### PR TITLE
fix(export): fail visibly on empty current-session history and surface copy failures (#528)

### DIFF
--- a/core/i18n/resources/en/background.ts
+++ b/core/i18n/resources/en/background.ts
@@ -8,6 +8,7 @@ export const background = {
   export: {
     generating: 'Generating export files',
     cancelled: 'Export cancelled',
+    emptyHistory: 'No messages were returned for the current conversation. The server returned an empty history; please try again.',
   },
   sync: {
     missingWebDav: 'WebDAV is not configured',

--- a/core/i18n/resources/en/content.ts
+++ b/core/i18n/resources/en/content.ts
@@ -66,6 +66,7 @@ export const content = {
     downloadMessageMarkdownTitle: 'Download message as Markdown',
     copyMessageButton: 'Copy',
     copyMessageTitle: 'Copy full message output',
+    copyMessageFailed: 'Copy failed',
   },
   toolBlock: {
     title: 'Executed tools ({count})',

--- a/core/i18n/resources/zh-CN/background.ts
+++ b/core/i18n/resources/zh-CN/background.ts
@@ -8,6 +8,7 @@ export const background = {
   export: {
     generating: '生成导出文件',
     cancelled: '导出已取消',
+    emptyHistory: '未能读取到当前会话的消息（服务器返回了空历史），请稍后重试。',
   },
   sync: {
     missingWebDav: '未配置 WebDAV',

--- a/core/i18n/resources/zh-CN/content.ts
+++ b/core/i18n/resources/zh-CN/content.ts
@@ -66,6 +66,7 @@ export const content = {
     downloadMessageMarkdownTitle: '下载消息为 Markdown',
     copyMessageButton: '复制',
     copyMessageTitle: '复制完整对话输出',
+    copyMessageFailed: '复制失败',
   },
   toolBlock: {
     title: '已执行工具（{count}次）',

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -629,6 +629,7 @@ const runtimeCommandRegistry = createRuntimeCommandRegistry({
         missingAuthMessage: () => backgroundT('background.auth.missingDeepSeek'),
         generatingMessage: () => backgroundT('background.export.generating'),
         cancelledMessage: () => backgroundT('background.export.cancelled'),
+        emptyHistoryMessage: () => backgroundT('background.export.emptyHistory'),
       },
     }),
     ...createBackgroundRuntimeHandlers({

--- a/entrypoints/background/conversation-export-handlers.ts
+++ b/entrypoints/background/conversation-export-handlers.ts
@@ -45,6 +45,7 @@ export interface ConversationExportRuntimeHandlerDependencies {
   missingAuthMessage(): string;
   generatingMessage(): string;
   cancelledMessage(): string;
+  emptyHistoryMessage(): string;
 }
 
 export function createConversationExportRuntimeHandlers(
@@ -128,6 +129,26 @@ export function createConversationExportRuntimeHandlers(
           assertExportActive(entry);
         },
       });
+
+      // An explicit current-session export that returns zero messages means the
+      // server history was empty (or transiently unavailable) while the page is
+      // showing messages. Fail visibly instead of emitting a silent empty
+      // artifact; bulk list-based exports may legitimately contain empty
+      // sessions and are unaffected.
+      if (payload.request.sessionIds?.length && exportData.stats.messageCount === 0) {
+        const message = dependencies.emptyHistoryMessage();
+        entry.state = 'failed';
+        entry.terminalNotification = publishProgress(entry, {
+          exportId,
+          phase: 'failed',
+          status: 'failed',
+          current: 0,
+          total: 0,
+          message,
+        }, 'failed');
+        await entry.terminalNotification;
+        return { ok: false, exportId, error: message };
+      }
 
       assertExportActive(entry);
       await publishProgress(entry, {

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -575,6 +575,7 @@ function getContentUxPolishLabels() {
     messageMarkdownTitle: contentT('content.uxPolish.downloadMessageMarkdownTitle'),
     messageCopyButton: contentT('content.uxPolish.copyMessageButton'),
     messageCopyTitle: contentT('content.uxPolish.copyMessageTitle'),
+    messageCopyFailed: contentT('content.uxPolish.copyMessageFailed'),
   };
 }
 

--- a/entrypoints/content/adapters/ux-polish.ts
+++ b/entrypoints/content/adapters/ux-polish.ts
@@ -11,6 +11,7 @@ export interface ContentUxPolishLabels {
   messageMarkdownTitle: string;
   messageCopyButton: string;
   messageCopyTitle: string;
+  messageCopyFailed: string;
 }
 
 const STYLE_ID = 'dpp-content-ux-polish-css';
@@ -20,17 +21,19 @@ const MESSAGE_COPY_CLASS = 'dpp-message-copy';
 const MESSAGE_SELECTOR = '[data-message-id][data-message-role], [data-message-author-role]';
 const POLISH_MOUNT_DELAY_MS = 50;
 const CODE_BUTTON_OFFSET_PX = 6;
+const MESSAGE_COPY_STATUS_MS = 1600;
 
 export function startContentUxPolish(
   getLabels: () => ContentUxPolishLabels,
 ): ContentUxPolishController {
   injectStyles();
   const codeButtons = new Map<HTMLElement, HTMLButtonElement>();
+  const copyFeedbackTimers = new Set<ReturnType<typeof setTimeout>>();
   const syncCodeButtons = () => syncCodeButtonPositions(codeButtons);
-  const mount = () => mountPolish(document, getLabels(), codeButtons);
+  const mount = () => mountPolish(document, getLabels(), codeButtons, copyFeedbackTimers);
   const refreshLabels = () => applyPolishLabels(document, getLabels());
   mount();
-  const candidateMountScheduler = createCandidateMountScheduler(getLabels);
+  const candidateMountScheduler = createCandidateMountScheduler(getLabels, copyFeedbackTimers);
   const observer = new MutationObserver((mutations) => {
     for (const root of collectPolishCandidateRoots(mutations)) {
       candidateMountScheduler.schedule(root, codeButtons);
@@ -47,6 +50,8 @@ export function startContentUxPolish(
     stop() {
       observer.disconnect();
       candidateMountScheduler.cancel();
+      copyFeedbackTimers.forEach((timer) => clearTimeout(timer));
+      copyFeedbackTimers.clear();
       window.removeEventListener('dpp:navigation', mount);
       window.removeEventListener('scroll', syncCodeButtons, true);
       window.removeEventListener('resize', syncCodeButtons);
@@ -74,9 +79,10 @@ function mountPolish(
   root: ParentNode,
   labels: ContentUxPolishLabels,
   codeButtons: Map<HTMLElement, HTMLButtonElement>,
+  copyFeedbackTimers: Set<ReturnType<typeof setTimeout>>,
 ): void {
   collectCodeBlocks(root).forEach((pre, index) => mountCodeDownload(pre, index, labels, codeButtons));
-  collectMessageNodes(root).forEach((message) => mountMessageActions(message, labels));
+  collectMessageNodes(root).forEach((message) => mountMessageActions(message, labels, copyFeedbackTimers));
   applyPolishLabels(root, labels);
   syncCodeButtonPositions(codeButtons);
 }
@@ -118,7 +124,11 @@ function collectMessageNodes(root: ParentNode): HTMLElement[] {
     .filter((node) => node.textContent?.trim());
 }
 
-function mountMessageActions(message: HTMLElement, labels: ContentUxPolishLabels): void {
+function mountMessageActions(
+  message: HTMLElement,
+  labels: ContentUxPolishLabels,
+  copyFeedbackTimers: Set<ReturnType<typeof setTimeout>>,
+): void {
   const markdownButton = document.createElement('button');
   markdownButton.type = 'button';
   markdownButton.className = MESSAGE_BUTTON_CLASS;
@@ -147,15 +157,37 @@ function mountMessageActions(message: HTMLElement, labels: ContentUxPolishLabels
     event.stopPropagation();
     void copyTextToClipboard(getMessageText(message)).catch((error) => {
       console.warn('[DeepSeek++] copy full message output failed:', error);
+      showCopyFailure(copyButton, labels, copyFeedbackTimers);
     });
   });
   message.appendChild(copyButton);
 }
 
+function showCopyFailure(
+  button: HTMLButtonElement,
+  labels: ContentUxPolishLabels,
+  timers: Set<ReturnType<typeof setTimeout>>,
+): void {
+  button.dataset.status = 'failed';
+  button.textContent = labels.messageCopyFailed;
+  const timer = setTimeout(() => {
+    timers.delete(timer);
+    delete button.dataset.status;
+    button.textContent = labels.messageCopyButton;
+    button.title = labels.messageCopyTitle;
+  }, MESSAGE_COPY_STATUS_MS);
+  timers.add(timer);
+}
+
 async function copyTextToClipboard(text: string): Promise<void> {
   if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text);
-    return;
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // writeText rejects when clipboard permission is denied or the document
+      // is unfocused; fall through to the legacy path before giving up.
+    }
   }
   const textarea = document.createElement('textarea');
   textarea.value = text;
@@ -163,8 +195,11 @@ async function copyTextToClipboard(text: string): Promise<void> {
   textarea.style.opacity = '0';
   document.body.appendChild(textarea);
   textarea.select();
-  document.execCommand('copy');
+  const copied = document.execCommand('copy');
   textarea.remove();
+  if (!copied) {
+    throw new Error('Clipboard copy failed.');
+  }
 }
 
 function applyPolishLabels(root: ParentNode, labels: ContentUxPolishLabels): void {
@@ -177,6 +212,7 @@ function applyPolishLabels(root: ParentNode, labels: ContentUxPolishLabels): voi
     button.title = labels.messageMarkdownTitle;
   });
   root.querySelectorAll<HTMLButtonElement>(`.${MESSAGE_COPY_CLASS}`).forEach((button) => {
+    if (button.dataset.status === 'failed') return;
     button.textContent = labels.messageCopyButton;
     button.title = labels.messageCopyTitle;
   });
@@ -195,6 +231,7 @@ function normalizeRole(value: string | undefined): 'user' | 'assistant' | 'syste
 
 function createCandidateMountScheduler(
   getLabels: () => ContentUxPolishLabels,
+  copyFeedbackTimers: Set<ReturnType<typeof setTimeout>>,
 ): { schedule(root: ParentNode, codeButtons: Map<HTMLElement, HTMLButtonElement>): void; cancel(): void } {
   const pending = new Set<ParentNode>();
   let pendingCodeButtons: Map<HTMLElement, HTMLButtonElement> | null = null;
@@ -212,7 +249,7 @@ function createCandidateMountScheduler(
         pending.clear();
         const labels = getLabels();
         for (const candidate of roots) {
-          if (pendingCodeButtons) mountPolish(candidate, labels, pendingCodeButtons);
+          if (pendingCodeButtons) mountPolish(candidate, labels, pendingCodeButtons, copyFeedbackTimers);
         }
         pendingCodeButtons = null;
       }, POLISH_MOUNT_DELAY_MS);
@@ -313,7 +350,7 @@ function injectStyles(): void {
   const style = document.createElement('style');
   style.id = STYLE_ID;
   style.textContent = `
-    .${CODE_BUTTON_CLASS}, .${MESSAGE_BUTTON_CLASS} {
+    .${CODE_BUTTON_CLASS}, .${MESSAGE_BUTTON_CLASS}, .${MESSAGE_COPY_CLASS} {
       border: 1px solid rgba(0, 0, 0, 0.12);
       border-radius: 6px;
       background: rgba(255, 255, 255, 0.92);
@@ -327,10 +364,14 @@ function injectStyles(): void {
       z-index: 2147483647;
       padding: 4px 7px;
     }
-    .${MESSAGE_BUTTON_CLASS} {
+    .${MESSAGE_BUTTON_CLASS}, .${MESSAGE_COPY_CLASS} {
       float: right;
       margin: 0 0 6px 8px;
       padding: 3px 6px;
+    }
+    .${MESSAGE_COPY_CLASS}[data-status="failed"] {
+      border-color: rgba(220, 38, 38, 0.55);
+      color: #b91c1c;
     }
   `;
   document.head.appendChild(style);

--- a/scripts/sidepanel-chunk-budget.mjs
+++ b/scripts/sidepanel-chunk-budget.mjs
@@ -46,9 +46,14 @@ if (requestedBrowsers.some((browser) => !browser)) {
 // measurement: 375672 raw / 114387 gzip; CI Node-22 zlib measures 114659 gzip
 // (+272 encoder variance); the baseline below uses the CI measurement so the
 // guardrail stays green on both runtimes.
+// Refreshed for #528 (issue-528 empty-history export guard + copy failure
+// visibility): four i18n strings (background.export.emptyHistory and
+// content.uxPolish.copyMessageFailed in zh-CN/en) were added to the shared
+// resource tree that now lives in the entry chunk. Local Node-25 measurement:
+// 376072 raw (+400) / 114511 gzip (still under the CI-derived gzip baseline).
 // The initial shell is sidepanel.html's entry script plus every static modulepreload.
 const BASELINE = Object.freeze({
-  initialShell: { raw: 375_672, gzip: 114_659 },
+  initialShell: { raw: 376_072, gzip: 114_659 },
   routeChunks: {
     ChatPage: { raw: 134_938, gzip: 40_056 },
     CapabilitiesPage: { raw: 160_137, gzip: 35_259 },
@@ -86,12 +91,15 @@ const WAVE_2_CHAT_BASELINE = Object.freeze({
 // bound this encoder-only variance to a small fixed allowance.
 const GZIP_ENCODER_VARIANCE_BYTES = 256;
 
+// firstChatScreen raw cap raised 406000 -> 406328 for #528: the same four
+// i18n strings also land in the first-chat-screen module graph (+328 raw,
+// gzip 124534 stays within the 125000 cap).
 const BUDGET = Object.freeze({
   initialShell: {
     raw: BASELINE.initialShell.raw,
     gzip: BASELINE.initialShell.gzip + GZIP_ENCODER_VARIANCE_BYTES,
   },
-  firstChatScreen: { raw: 406_000, gzip: 125_000 },
+  firstChatScreen: { raw: 406_328, gzip: 125_000 },
   richRendererIncrement: { raw: 120_000, gzip: 36_000 },
   routeChunks: {
     ChatPage: { raw: 25_000, gzip: 8_000 },

--- a/tests/background-deepseek-runtime-handlers.test.ts
+++ b/tests/background-deepseek-runtime-handlers.test.ts
@@ -490,6 +490,51 @@ describe('conversation export coordinator', () => {
     await first;
   });
 
+  it('fails visibly when an explicit current-session export returns zero messages', async () => {
+    const dependencies = createExportDependencies();
+    const handlers = createConversationExportRuntimeHandlers(dependencies);
+
+    const result = await dispatch(handlers, {
+      type: 'EXPORT_DEEPSEEK_CONVERSATIONS',
+      payload: { exportId: 'empty-history', request: { sessionIds: ['session-1'] } },
+    });
+
+    expect(result).toEqual({ ok: false, exportId: 'empty-history', error: 'Empty history' });
+    expect(dependencies.buildArtifacts).not.toHaveBeenCalled();
+    expect(dependencies.emptyHistoryMessage).toHaveBeenCalledOnce();
+    expect(vi.mocked(dependencies.broadcastProgress).mock.calls
+      .some(([progress]) => progress.phase === 'failed' && progress.message === 'Empty history')).toBe(true);
+  });
+
+  it('completes explicit-session exports when messages are present', async () => {
+    const dependencies = createExportDependencies();
+    vi.mocked(dependencies.runExport).mockImplementation(async (input) => {
+      const data = exportData(input.exportId);
+      data.stats.messageCount = 4;
+      data.stats.sessionCount = 1;
+      return data;
+    });
+    const handlers = createConversationExportRuntimeHandlers(dependencies);
+
+    await expect(dispatch(handlers, {
+      type: 'EXPORT_DEEPSEEK_CONVERSATIONS',
+      payload: { exportId: 'non-empty-history', request: { sessionIds: ['session-1'] } },
+    })).resolves.toMatchObject({ ok: true, exportId: 'non-empty-history' });
+    expect(dependencies.buildArtifacts).toHaveBeenCalledOnce();
+  });
+
+  it('keeps bulk exports with zero-message results legal', async () => {
+    const dependencies = createExportDependencies();
+    const handlers = createConversationExportRuntimeHandlers(dependencies);
+
+    await expect(dispatch(handlers, {
+      type: 'EXPORT_DEEPSEEK_CONVERSATIONS',
+      payload: { exportId: 'bulk-empty', request: {} },
+    })).resolves.toMatchObject({ ok: true, exportId: 'bulk-empty' });
+    expect(dependencies.buildArtifacts).toHaveBeenCalledOnce();
+    expect(dependencies.emptyHistoryMessage).not.toHaveBeenCalled();
+  });
+
   it('binds cancellation to the sender owner and publishes cancelled exactly once', async () => {
     const dependencies = createExportDependencies();
     let runSignal: AbortSignal | undefined;
@@ -733,6 +778,7 @@ function createExportDependencies(): ConversationExportRuntimeHandlerDependencie
     missingAuthMessage: vi.fn(() => 'Missing DeepSeek auth'),
     generatingMessage: vi.fn(() => 'Generating'),
     cancelledMessage: vi.fn(() => 'Export cancelled'),
+    emptyHistoryMessage: vi.fn(() => 'Empty history'),
   };
 }
 

--- a/tests/phase5-product-surfaces.test.ts
+++ b/tests/phase5-product-surfaces.test.ts
@@ -111,6 +111,7 @@ describe('Phase 5 product surface helpers', () => {
       messageMarkdownTitle: '下载消息为 Markdown',
       messageCopyButton: '复制',
       messageCopyTitle: '复制完整对话输出',
+      messageCopyFailed: '复制失败',
     }));
 
     try {
@@ -142,6 +143,7 @@ describe('Phase 5 product surface helpers', () => {
       messageMarkdownTitle: '下载消息为 Markdown',
       messageCopyButton: '复制',
       messageCopyTitle: '复制完整对话输出',
+      messageCopyFailed: '复制失败',
     }));
 
     try {
@@ -172,6 +174,108 @@ describe('Phase 5 product surface helpers', () => {
     } finally {
       polish.stop();
     }
+  });
+
+  it('copies full message output with clipboard fallback and visible failure state', async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = `
+      <div data-message-id="message-1" data-message-role="assistant">完整回复内容</div>
+    `;
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      writable: true,
+      value: { writeText },
+    });
+    const execCommand = vi.fn(() => true);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      writable: true,
+      value: execCommand,
+    });
+
+    const polish = startContentUxPolish(() => ({
+      codeDownloadButton: '下载',
+      messageMarkdownButton: 'MD',
+      messageMarkdownTitle: '下载消息为 Markdown',
+      messageCopyButton: '复制',
+      messageCopyTitle: '复制完整对话输出',
+      messageCopyFailed: '复制失败',
+    }));
+
+    try {
+      const button = document.querySelector<HTMLButtonElement>('.dpp-message-copy')!;
+
+      button.click();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writeText).toHaveBeenCalledWith('完整回复内容');
+      expect(execCommand).not.toHaveBeenCalled();
+      expect(button.textContent).toBe('复制');
+
+      // A writeText rejection (permission denied / unfocused document) falls
+      // back to the legacy path instead of failing silently.
+      writeText.mockRejectedValueOnce(new Error('denied'));
+      button.click();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(execCommand).toHaveBeenCalledTimes(1);
+      expect(button.textContent).toBe('复制');
+
+      // When both paths fail the button shows a visible failure state that
+      // restores itself instead of leaving the failure in the console only.
+      writeText.mockRejectedValueOnce(new Error('denied'));
+      execCommand.mockReturnValueOnce(false);
+      button.click();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(button.dataset.status).toBe('failed');
+      expect(button.textContent).toBe('复制失败');
+
+      vi.advanceTimersByTime(1600);
+      expect(button.dataset.status).toBeUndefined();
+      expect(button.textContent).toBe('复制');
+    } finally {
+      polish.stop();
+      delete (navigator as { clipboard?: unknown }).clipboard;
+      delete (document as { execCommand?: unknown }).execCommand;
+    }
+  });
+
+  it('clears pending copy feedback timers on stop', async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = `
+      <div data-message-id="message-1" data-message-role="assistant">完整回复内容</div>
+    `;
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      writable: true,
+      value: { writeText: vi.fn(async () => { throw new Error('denied'); }) },
+    });
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => false),
+    });
+
+    const polish = startContentUxPolish(() => ({
+      codeDownloadButton: '下载',
+      messageMarkdownButton: 'MD',
+      messageMarkdownTitle: '下载消息为 Markdown',
+      messageCopyButton: '复制',
+      messageCopyTitle: '复制完整对话输出',
+      messageCopyFailed: '复制失败',
+    }));
+
+    const button = document.querySelector<HTMLButtonElement>('.dpp-message-copy')!;
+    button.click();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(button.dataset.status).toBe('failed');
+
+    polish.stop();
+    vi.advanceTimersByTime(1600);
+    expect(button.dataset.status).toBe('failed');
+    expect(button.textContent).toBe('复制失败');
+
+    delete (navigator as { clipboard?: unknown }).clipboard;
+    delete (document as { execCommand?: unknown }).execCommand;
   });
 
   it('filters official search results by DeepSeek++ history tags', async () => {


### PR DESCRIPTION
## Summary

#528 报告 v1.12.2 点击消息操作行按钮后「出问题」。附件证据（同一会话两次导出相隔 9 秒：4 条消息 → 0 条消息）确认扩展侧的确定性缺陷：空历史导出静默产出「成功」的 0 消息文件；复制失败仅 console.warn 静默。截图中的 `Copy-paste blocked` 字符串经全量检索确认不在本扩展代码库、也不在 DeepSeek 网页端当前全部 569 个构建 chunk 中（Chromium 源码存在对应 `CopyPasteBlockedSnackbar`），指向浏览器剪贴板权限拦截 UI。本 PR 修复扩展可确认的两个缺陷。

Refs #528（外部主诉归因浏览器剪贴板拦截，待报告者确认后再关闭 Issue）

## PR Type

- [x] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

`git checkout -b codex/handle-issue-528` from `main@43abbac`（提交前 `git fetch origin main` 复核 merge-base = origin/main = 43abbac）

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

GPT-5 (Codex)

Coding Agent tool(s) used:

Codex

## Local Validation

Commands run:

```bash
npx vitest run tests/phase5-product-surfaces.test.ts tests/background-deepseek-runtime-handlers.test.ts tests/i18n-background-slice.test.ts tests/i18n.test.ts
npx vitest run tests/conversation-export.test.ts tests/content-controller-ownership.test.ts
npm run compile
npm run prompt:freeze
npm run build:chrome && npm run verify:manifest-policy && npm run verify:extension-utf8
npm test
npm run ci:quality
```

Result summary:

- 定向测试 50+22 全绿（新增：空历史显式导出可见失败/有消息正常/批量 0 消息合法；复制成功/拒绝兜底/双失败可见态/定时器清理）
- `compile` ✔；`prompt:freeze` ✔（7 tests，prompt 字节无变化）
- `npm test`：208 文件 / **1640 tests 全绿**
- `npm run ci:quality` **全链通过**（workflows / audit:prod / prompt:freeze / compile / test / persistence-burst / i18n / automation / smoke:mcp / verify:mcp:mock / smoke:shell / smoke:pow / build:all / bundled-skills / sidepanel-chunks / utf8 / manifest-policy / zip:all / release-assets / smoke:pyodide）
- 预算重基线（沿用仓库惯例，含说明注释）：4 个新增 i18n 字符串使 sidepanel initial-shell +400 raw（376072，gzip 114511/114915 仍在 cap 内）、first-chat-screen +328 raw（406328，gzip 124534/125000 在 cap 内）

## Local Feature Evidence

Evidence:

N/A — 本 PR 为 owner 提交（`pr-contribution-rules` 对 owner 豁免截图门禁）；用户可见的两种失败状态（导出空历史错误 toast、复制失败按钮态）由上述行为测试断言覆盖。修复效果将在下一版本由 #528 报告者实测确认。
