### PR TITLE
fix: stabilize expert-mode tools and conversation downloads

### DIFF
--- a/core/export/normalize.ts
+++ b/core/export/normalize.ts
@@ -204,8 +204,25 @@ function normalizeContentPart(part: unknown): ExportedContentFragment | null {
 function normalizeContentKind(kind: string | null): ExportedContentFragment['kind'] {
   const lower = kind?.toLowerCase();
   if (lower === 'reasoning' || lower === 'thinking' || lower === 'think') return 'reasoning';
-  if (lower === 'tool' || lower === 'tool_result') return 'tool';
-  if (lower === 'text' || lower === 'markdown' || lower === 'content') return 'text';
+  if (
+    lower === 'tool' ||
+    lower === 'tool_result' ||
+    lower === 'tool_call' ||
+    lower === 'tool_calls' ||
+    lower === 'function_call' ||
+    lower === 'function_result'
+  ) return 'tool';
+  // DeepSeek's current history API names visible user/assistant fragments
+  // REQUEST and RESPONSE. Treating those as unknown made the #499
+  // input-output projection discard every visible message even though the
+  // full export still had text in `message.content` (Issue #546).
+  if (
+    lower === 'text' ||
+    lower === 'markdown' ||
+    lower === 'content' ||
+    lower === 'request' ||
+    lower === 'response'
+  ) return 'text';
   return 'unknown';
 }
 

--- a/core/export/scope.ts
+++ b/core/export/scope.ts
@@ -10,7 +10,7 @@ import type {
  *
  * `full` keeps every message and fragment (tool calls, continuations,
  * reasoning, injected context) — the troubleshooting format. `input-output`
- * keeps user inputs plus the final assistant answer, with reasoning and tool
+ * keeps the initial user input plus the final assistant answer, with reasoning and tool
  * fragments removed from the retained assistant message.
  */
 export function applyConversationExportContentScope(
@@ -24,20 +24,38 @@ export function applyConversationExportContentScope(
     return { ...session, messages };
   });
   const messageCount = sessions.reduce((total, session) => total + session.messages.length, 0);
+  const retainedMessageIds = new Set(
+    sessions.flatMap((session) => session.messages.map((message) => message.id)),
+  );
+  const retainedAttachmentIds = new Set(
+    sessions.flatMap((session) => session.messages.flatMap((message) =>
+      message.attachmentRefs.map((attachment) => attachment.id))),
+  );
+  const attachments = exportData.attachments
+    .filter((attachment) => retainedAttachmentIds.has(attachment.id))
+    .map((attachment) => ({
+      ...attachment,
+      sourceMessageIds: attachment.sourceMessageIds.filter((messageId) => retainedMessageIds.has(messageId)),
+    }));
 
   return {
     ...exportData,
     request: { ...exportData.request, contentScope: scope },
-    stats: { ...exportData.stats, messageCount },
+    stats: { ...exportData.stats, messageCount, attachmentCount: attachments.length },
     sessions,
+    attachments,
   };
 }
 
 function projectInputOutputMessages(messages: readonly ExportedMessage[]): ExportedMessage[] {
-  const userMessages = messages
+  // #499 explicitly defines this scope as the initial human input plus the
+  // final assistant output. Inline-agent continuation/tool-result prompts are
+  // persisted by DeepSeek as later `user` messages, so retaining every user
+  // role reintroduced exactly the internal context this scope must remove.
+  const initialInput = messages
     .filter((message) => message.role === 'user')
     .map((message) => projectTextFragments(message))
-    .filter((message): message is ExportedMessage => message !== null);
+    .find((message): message is ExportedMessage => message !== null);
 
   const assistantMessages = messages
     .filter((message) => message.role === 'assistant')
@@ -45,12 +63,12 @@ function projectInputOutputMessages(messages: readonly ExportedMessage[]): Expor
     .filter((message): message is ExportedMessage => message !== null);
 
   const finalOutput = assistantMessages[assistantMessages.length - 1];
-  return finalOutput ? [...userMessages, finalOutput] : userMessages;
+  return [initialInput, finalOutput].filter((message): message is ExportedMessage => message !== undefined);
 }
 
 function projectTextFragments(message: ExportedMessage): ExportedMessage | null {
   const fragments = message.contentFragments.filter((fragment) => fragment.kind === 'text');
-  const content = fragments.map((fragment) => fragment.text).join('');
+  const content = fragments.map((fragment) => fragment.text).join('\n\n').trim();
   if (!content.trim()) return null;
   return { ...message, content, contentFragments: fragments };
 }

--- a/core/export/service.ts
+++ b/core/export/service.ts
@@ -140,7 +140,14 @@ export async function runConversationExport(input: RunConversationExportInput): 
     failures,
   };
 
-  const finalExport = request.mode === 'sanitized' ? sanitizeConversationExport(exportData) : exportData;
+  const modeExport = request.mode === 'sanitized' ? sanitizeConversationExport(exportData) : exportData;
+  // Apply the requested range after sanitization and before the returned stats
+  // are validated/observed by the background coordinator. This makes
+  // projected-empty current-session exports fail visibly and keeps the response
+  // summary aligned with every generated artifact (Issue #546). Artifact
+  // builders repeat this idempotent projection defensively to preserve their
+  // existing public helper contract.
+  const finalExport = applyConversationExportContentScope(modeExport, request.contentScope);
   assertNotCancelled(input.signal);
   await report(input, 'completed', 'completed', 1, 1, '导出完成');
   assertNotCancelled(input.signal);

--- a/core/export/zip.ts
+++ b/core/export/zip.ts
@@ -1,0 +1,166 @@
+import type { ConversationExportArtifact } from './types';
+
+export interface ConversationExportArchiveArtifact {
+  filename: string;
+  mimeType: 'application/zip';
+  content: Uint8Array;
+}
+
+interface StoredZipEntry {
+  filename: string;
+  content: Uint8Array;
+}
+
+const ZIP_LOCAL_FILE_HEADER = 0x04034b50;
+const ZIP_CENTRAL_DIRECTORY_HEADER = 0x02014b50;
+const ZIP_END_OF_CENTRAL_DIRECTORY = 0x06054b50;
+const ZIP_UTF8_FLAG = 0x0800;
+const ZIP_VERSION = 20;
+const UINT16_MAX = 0xffff;
+const UINT32_MAX = 0xffffffff;
+const textEncoder = new TextEncoder();
+const crc32Table = createCrc32Table();
+
+/**
+ * Builds a single store-only ZIP so one user gesture downloads every selected
+ * export format. Browsers commonly block the second and later asynchronous
+ * `<a download>` clicks as automatic multi-downloads (Issue #546).
+ */
+export function createConversationExportArchiveArtifact(
+  artifacts: readonly ConversationExportArtifact[],
+  modifiedAt = new Date(),
+): ConversationExportArchiveArtifact {
+  if (artifacts.length === 0) {
+    throw new Error('Cannot create a conversation export archive without artifacts.');
+  }
+
+  const entries = artifacts.map((artifact) => ({
+    filename: artifact.filename,
+    content: textEncoder.encode(artifact.content),
+  }));
+  const firstStem = artifacts[0].filename.replace(/\.[^.]+$/, '') || 'deepseek-conversations-export';
+
+  return {
+    filename: `${firstStem}.zip`,
+    mimeType: 'application/zip',
+    content: createStoredZip(entries, modifiedAt),
+  };
+}
+
+function createStoredZip(entries: readonly StoredZipEntry[], modifiedAt: Date): Uint8Array {
+  if (entries.length > UINT16_MAX) throw new Error('ZIP entry count exceeds the supported limit.');
+  const dos = toDosDateTime(modifiedAt);
+  const localParts: Uint8Array[] = [];
+  const centralParts: Uint8Array[] = [];
+  let localOffset = 0;
+
+  for (const entry of entries) {
+    const filename = textEncoder.encode(entry.filename);
+    if (filename.length === 0 || filename.length > UINT16_MAX) {
+      throw new Error('ZIP entry filename is empty or too long.');
+    }
+    if (entry.content.length > UINT32_MAX || localOffset > UINT32_MAX) {
+      throw new Error('ZIP entry exceeds the supported 32-bit size limit.');
+    }
+
+    const checksum = crc32(entry.content);
+    const localHeader = new Uint8Array(30 + filename.length);
+    const localView = new DataView(localHeader.buffer);
+    localView.setUint32(0, ZIP_LOCAL_FILE_HEADER, true);
+    localView.setUint16(4, ZIP_VERSION, true);
+    localView.setUint16(6, ZIP_UTF8_FLAG, true);
+    localView.setUint16(8, 0, true);
+    localView.setUint16(10, dos.time, true);
+    localView.setUint16(12, dos.date, true);
+    localView.setUint32(14, checksum, true);
+    localView.setUint32(18, entry.content.length, true);
+    localView.setUint32(22, entry.content.length, true);
+    localView.setUint16(26, filename.length, true);
+    localView.setUint16(28, 0, true);
+    localHeader.set(filename, 30);
+    localParts.push(localHeader, entry.content);
+
+    const centralHeader = new Uint8Array(46 + filename.length);
+    const centralView = new DataView(centralHeader.buffer);
+    centralView.setUint32(0, ZIP_CENTRAL_DIRECTORY_HEADER, true);
+    centralView.setUint16(4, ZIP_VERSION, true);
+    centralView.setUint16(6, ZIP_VERSION, true);
+    centralView.setUint16(8, ZIP_UTF8_FLAG, true);
+    centralView.setUint16(10, 0, true);
+    centralView.setUint16(12, dos.time, true);
+    centralView.setUint16(14, dos.date, true);
+    centralView.setUint32(16, checksum, true);
+    centralView.setUint32(20, entry.content.length, true);
+    centralView.setUint32(24, entry.content.length, true);
+    centralView.setUint16(28, filename.length, true);
+    centralView.setUint16(30, 0, true);
+    centralView.setUint16(32, 0, true);
+    centralView.setUint16(34, 0, true);
+    centralView.setUint16(36, 0, true);
+    centralView.setUint32(38, 0, true);
+    centralView.setUint32(42, localOffset, true);
+    centralHeader.set(filename, 46);
+    centralParts.push(centralHeader);
+
+    localOffset += localHeader.length + entry.content.length;
+  }
+
+  const centralSize = centralParts.reduce((total, part) => total + part.length, 0);
+  if (centralSize > UINT32_MAX || localOffset + centralSize > UINT32_MAX) {
+    throw new Error('ZIP central directory exceeds the supported 32-bit size limit.');
+  }
+  const end = new Uint8Array(22);
+  const endView = new DataView(end.buffer);
+  endView.setUint32(0, ZIP_END_OF_CENTRAL_DIRECTORY, true);
+  endView.setUint16(4, 0, true);
+  endView.setUint16(6, 0, true);
+  endView.setUint16(8, entries.length, true);
+  endView.setUint16(10, entries.length, true);
+  endView.setUint32(12, centralSize, true);
+  endView.setUint32(16, localOffset, true);
+  endView.setUint16(20, 0, true);
+
+  return concatBytes([...localParts, ...centralParts, end]);
+}
+
+function toDosDateTime(value: Date): { date: number; time: number } {
+  const valid = Number.isNaN(value.valueOf()) ? new Date(0) : value;
+  const year = Math.max(1980, Math.min(2107, valid.getUTCFullYear()));
+  const month = valid.getUTCMonth() + 1;
+  const day = Math.max(1, valid.getUTCDate());
+  return {
+    date: ((year - 1980) << 9) | (month << 5) | day,
+    time: (valid.getUTCHours() << 11) | (valid.getUTCMinutes() << 5) | (valid.getUTCSeconds() >> 1),
+  };
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = UINT32_MAX;
+  for (const byte of bytes) {
+    crc = crc32Table[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ UINT32_MAX) >>> 0;
+}
+
+function createCrc32Table(): Uint32Array {
+  const table = new Uint32Array(256);
+  for (let index = 0; index < table.length; index += 1) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value & 1) === 1 ? (0xedb88320 ^ (value >>> 1)) : (value >>> 1);
+    }
+    table[index] = value >>> 0;
+  }
+  return table;
+}
+
+function concatBytes(parts: readonly Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const output = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.length;
+  }
+  return output;
+}

--- a/core/inline-agent/pi/loop-adapter.ts
+++ b/core/inline-agent/pi/loop-adapter.ts
@@ -178,9 +178,15 @@ export async function runPiInlineAgentLoop(deps: PiLoopAdapterDeps): Promise<voi
   // Shared per-run stream wiring: model selection + pacing wrapper. The web
   // path keeps the released semantics byte-for-byte (golden); the
   // official-api path is a peer backend over the same pi loop.
+  let requestCount = 0;
   const mapToolCall = (call: { name: string; invocationName: string; payload: Record<string, unknown> }, index: number) => ({
     type: 'toolCall' as const,
-    id: `xml:${index}`,
+    // XML indexes restart at zero for every model response. A single inline
+    // run intentionally reuses one background authorization grant, so the raw
+    // `xml:${index}` id made the first tool in turn 2 look like a replay of the
+    // first tool in turn 1. Bind the id to the model-request sequence while
+    // keeping it stable for any parsing/retry inside that same request.
+    id: `turn:${requestCount}:xml:${index}`,
     name: call.invocationName,
     arguments: call.payload,
   });
@@ -255,7 +261,6 @@ export async function runPiInlineAgentLoop(deps: PiLoopAdapterDeps): Promise<voi
 
   // One 2.5–6.5s throttle delay before every DS request except the first
   // (released request pacing).
-  let requestCount = 0;
   const pacedStreamFn: StreamFn = async (model, context, options) => {
     if (requestCount > 0) {
       await waitBetweenDeepSeekRequests(signal);

--- a/core/inline-agent/renderer.ts
+++ b/core/inline-agent/renderer.ts
@@ -1,7 +1,7 @@
 import { renderInlineMarkdown } from './markdown';
 import { injectInjectedThemeStyles } from '../ui/injected-theme';
 import { INLINE_AGENT_MAX_STEPS } from './types';
-import type { ToolExecutionRecord } from '../types';
+import type { ToolExecutionRecord, ToolResult } from '../types';
 
 const AGENT_STEP_STYLE_ID = 'dpp-inline-agent-css';
 const TOOL_SUMMARY_MAX_CHARS = 600;
@@ -757,12 +757,13 @@ export function updateStepStatus(step: HTMLElement, status: string, label?: stri
 export function addToolResultToStep(
   step: HTMLElement,
   toolName: string,
-  ok: boolean,
-  summary: string,
+  result: Pick<ToolResult, 'ok' | 'summary' | 'detail' | 'error'>,
   labels?: Partial<InlineAgentRendererLabels>,
 ): void {
   const tools = step.querySelector('.dpp-agent-step-tools');
   if (!tools) return;
+  const { ok } = result;
+  const summary = getToolRowSummary(result);
 
   // The tools section label stays hidden until the first tool row exists
   // (Issue #544).
@@ -821,6 +822,13 @@ export function addToolResultToStep(
   item.appendChild(toggle);
   item.appendChild(detail);
   tools.appendChild(item);
+}
+
+function getToolRowSummary(result: Pick<ToolResult, 'ok' | 'summary' | 'detail' | 'error'>): string {
+  if (result.ok) return result.summary;
+  const reason = result.detail?.trim() || result.error?.message.trim() || '';
+  if (!reason || reason === result.summary.trim()) return result.summary;
+  return `${result.summary}\n${reason}`;
 }
 
 export type AgentFooterVariant = 'complete' | 'error' | 'paused';

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -171,6 +171,7 @@ import type {
   ConversationExportProgress,
   ConversationExportResult,
 } from '../core/export/types';
+import { createConversationExportArchiveArtifact } from '../core/export/zip';
 import type { ToolCallPayloadChunk } from '../core/interceptor/streaming-tool-call-parser';
 import {
   replaceContentDocumentLifecycle,
@@ -192,6 +193,10 @@ import { notifyContentAuthStatusChanged } from './content/auth-status-notifier';
 import { createContentPersistenceTracker } from './content/persistence-tracking';
 import { getRestoredMessageMutationAction } from './content/restored-message-targets';
 import { bindNewChatToolCallToBrowserSession } from './content/tool-session-binding';
+import {
+  createBrowserDownloadManager,
+  type BrowserDownloadManager,
+} from './content/download-manager';
 
 const TOOL_BLOCK_ID = 'dpp-tool-block';
 const TOOL_BLOCK_STYLE_ID = 'dpp-tool-block-css';
@@ -439,10 +444,12 @@ let toolCapabilityScope: ContentResourceScope | null = null;
 let toolCapabilityEpoch = 0;
 const pendingToolPersistenceOperations = new Set<Promise<unknown>>();
 let inlineAgentCapabilityScope: ContentResourceScope | null = null;
+let inlineAgentDownloadManager: BrowserDownloadManager | null = null;
 let inlineAgentCapabilityEpoch = 0;
 const pendingInlineAgentPersistenceOperations = new Set<Promise<unknown>>();
 let multimodalCapabilityScope: ContentResourceScope | null = null;
 let exportCapabilityScope: ContentResourceScope | null = null;
+let exportDownloadManager: BrowserDownloadManager | null = null;
 let backgroundCapabilityScope: ContentResourceScope | null = null;
 let petCapabilityScope: ContentResourceScope | null = null;
 
@@ -815,6 +822,8 @@ function startInlineAgentCapability(
   mutationHub: ContentMutationHub,
 ): void {
   inlineAgentCapabilityScope = scope;
+  inlineAgentDownloadManager?.stop();
+  inlineAgentDownloadManager = createBrowserDownloadManager();
   const epoch = ++inlineAgentCapabilityEpoch;
   startInlineAgentContinuationMessageHider(scope, mutationHub);
   observeReportedPersistence(restorePersistedInlineAgentTraces(scope, epoch));
@@ -822,6 +831,8 @@ function startInlineAgentCapability(
 
 async function stopInlineAgentCapability(): Promise<void> {
   inlineAgentCapabilityScope = null;
+  inlineAgentDownloadManager?.stop();
+  inlineAgentDownloadManager = null;
   inlineAgentCapabilityEpoch += 1;
   stopInlineAgentContinuationMessageHider();
   if (activeAgentAbort || inlineAgentContainer) stopInlineAgent();
@@ -885,6 +896,8 @@ function startExportCapability(
   mutationHub: ContentMutationHub,
 ): void {
   exportCapabilityScope = scope;
+  exportDownloadManager?.stop();
+  exportDownloadManager = createBrowserDownloadManager();
   scope.addCleanup('cleanup', mutationHub.subscribe({
     matches: (mutations) => (
       exportCapabilityScope === scope
@@ -898,6 +911,8 @@ function startExportCapability(
 
 function stopExportCapability(): void {
   exportCapabilityScope = null;
+  exportDownloadManager?.stop();
+  exportDownloadManager = null;
   stopConversationExportActionInjector();
 }
 
@@ -2027,11 +2042,11 @@ async function startCurrentConversationExport(
       throw new Error(response?.error ?? contentT('content.export.failed'));
     }
 
-    for (const artifact of response.artifacts) {
-      if (formats.includes(artifact.format)) {
-        downloadConversationExportArtifact(artifact);
-      }
+    const artifacts = response.artifacts.filter((artifact) => formats.includes(artifact.format));
+    if (artifacts.length !== formats.length) {
+      throw new Error(contentT('content.export.failed'));
     }
+    downloadConversationExportArtifacts(artifacts);
 
     const warning = response.summary.failedSessionCount > 0;
     showConversationExportToast(
@@ -2989,16 +3004,19 @@ function injectMultimodalMediaStyles() {
   document.head.appendChild(style);
 }
 
-function downloadConversationExportArtifact(artifact: ConversationExportArtifact) {
-  const blob = new Blob([artifact.content], { type: artifact.mimeType });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = artifact.filename;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  URL.revokeObjectURL(url);
+function downloadConversationExportArtifacts(artifacts: readonly ConversationExportArtifact[]) {
+  const manager = exportDownloadManager;
+  if (!manager || artifacts.length === 0) throw new Error(contentT('content.export.failed'));
+  if (artifacts.length === 1) {
+    const artifact = artifacts[0];
+    manager.download(artifact.filename, new Blob([artifact.content], { type: artifact.mimeType }));
+    return;
+  }
+
+  const archive = createConversationExportArchiveArtifact(artifacts);
+  const archiveBytes = new Uint8Array(archive.content.byteLength);
+  archiveBytes.set(archive.content);
+  manager.download(archive.filename, new Blob([archiveBytes], { type: archive.mimeType }));
 }
 
 function showConversationExportToast(message: string, tone: 'info' | 'success' | 'warning' | 'error') {
@@ -3980,7 +3998,7 @@ function handleAgentStepComplete(msg: InlineAgentStepCompleteMsg): void {
   flushPendingInlineAgentStreamRender();
 
   for (const exec of msg.toolExecutions) {
-    addToolResultToStep(inlineAgentCurrentStep, exec.name, exec.result.ok, exec.result.summary, getAgentRendererLabels());
+    addToolResultToStep(inlineAgentCurrentStep, exec.name, exec.result, getAgentRendererLabels());
   }
   addToolResultDetailsToStep(inlineAgentCurrentStep, msg.toolExecutions);
   agentRunningToolCount += msg.toolExecutions.length;
@@ -4146,15 +4164,10 @@ async function downloadAgentOutputArtifact(artifactId: string): Promise<void> {
       return;
     }
     const artifact = response.artifact;
-    const blob = new Blob([artifact.content], { type: artifact.mimeType });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement('a');
-    anchor.href = url;
-    anchor.download = artifact.filename;
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    URL.revokeObjectURL(url);
+    inlineAgentDownloadManager?.download(
+      artifact.filename,
+      new Blob([artifact.content], { type: artifact.mimeType }),
+    );
   } catch (error) {
     console.warn('[DeepSeek++] agent output artifact download request failed:', error);
   }
@@ -6353,7 +6366,7 @@ function createRestoredInlineAgentContainer(trace: InlineAgentTraceRecord): HTML
     const stepText = getInlineAgentDisplayFinalText(step.text) || step.text;
     updateStepStreamText(stepEl, clampText(stepText, INLINE_AGENT_STEP_RENDER_MAX_CHARS) ?? '');
     for (const exec of step.toolExecutions) {
-      addToolResultToStep(stepEl, exec.name, exec.result.ok, exec.result.summary, getAgentRendererLabels());
+      addToolResultToStep(stepEl, exec.name, exec.result, getAgentRendererLabels());
     }
     addToolResultDetailsToStep(stepEl, step.toolExecutions);
     // A mid-flight step (streaming / executing tools) persisted by a page

--- a/entrypoints/content/adapters/ux-polish.ts
+++ b/entrypoints/content/adapters/ux-polish.ts
@@ -1,4 +1,8 @@
 import { createMessageMarkdownArtifact } from '../../../core/export/secondary-artifacts';
+import {
+  createBrowserDownloadManager,
+  type BrowserDownloadManager,
+} from '../download-manager';
 
 export interface ContentUxPolishController {
   stop(): void;
@@ -18,7 +22,15 @@ const STYLE_ID = 'dpp-content-ux-polish-css';
 const CODE_BUTTON_CLASS = 'dpp-code-download';
 const MESSAGE_BUTTON_CLASS = 'dpp-message-download';
 const MESSAGE_COPY_CLASS = 'dpp-message-copy';
-const MESSAGE_SELECTOR = '[data-message-id][data-message-role], [data-message-author-role]';
+const PRIMARY_MESSAGE_SELECTOR = [
+  '.ds-message',
+  '[data-message-id][data-message-role]',
+  '[data-message-author-role]',
+].join(', ');
+const VIRTUAL_MESSAGE_SELECTOR =
+  '.ds-virtual-list--printable .ds-virtual-list-visible-items > [data-virtual-list-item-key]';
+const MESSAGE_SELECTOR = `${PRIMARY_MESSAGE_SELECTOR}, ${VIRTUAL_MESSAGE_SELECTOR}`;
+const ASSISTANT_CONTENT_SELECTOR = '._74c0879, .ds-assistant-message-main-content';
 const POLISH_MOUNT_DELAY_MS = 50;
 const CODE_BUTTON_OFFSET_PX = 6;
 const MESSAGE_COPY_STATUS_MS = 1600;
@@ -29,11 +41,12 @@ export function startContentUxPolish(
   injectStyles();
   const codeButtons = new Map<HTMLElement, HTMLButtonElement>();
   const copyFeedbackTimers = new Set<ReturnType<typeof setTimeout>>();
+  const downloads = createBrowserDownloadManager();
   const syncCodeButtons = () => syncCodeButtonPositions(codeButtons);
-  const mount = () => mountPolish(document, getLabels(), codeButtons, copyFeedbackTimers);
+  const mount = () => mountPolish(document, getLabels(), codeButtons, copyFeedbackTimers, downloads);
   const refreshLabels = () => applyPolishLabels(document, getLabels());
   mount();
-  const candidateMountScheduler = createCandidateMountScheduler(getLabels, copyFeedbackTimers);
+  const candidateMountScheduler = createCandidateMountScheduler(getLabels, copyFeedbackTimers, downloads);
   const observer = new MutationObserver((mutations) => {
     for (const root of collectPolishCandidateRoots(mutations)) {
       candidateMountScheduler.schedule(root, codeButtons);
@@ -50,6 +63,7 @@ export function startContentUxPolish(
     stop() {
       observer.disconnect();
       candidateMountScheduler.cancel();
+      downloads.stop();
       copyFeedbackTimers.forEach((timer) => clearTimeout(timer));
       copyFeedbackTimers.clear();
       window.removeEventListener('dpp:navigation', mount);
@@ -80,9 +94,10 @@ function mountPolish(
   labels: ContentUxPolishLabels,
   codeButtons: Map<HTMLElement, HTMLButtonElement>,
   copyFeedbackTimers: Set<ReturnType<typeof setTimeout>>,
+  downloads: BrowserDownloadManager,
 ): void {
-  collectCodeBlocks(root).forEach((pre, index) => mountCodeDownload(pre, index, labels, codeButtons));
-  collectMessageNodes(root).forEach((message) => mountMessageActions(message, labels, copyFeedbackTimers));
+  collectCodeBlocks(root).forEach((pre, index) => mountCodeDownload(pre, index, labels, codeButtons, downloads));
+  collectMessageNodes(root).forEach((message) => mountMessageActions(message, labels, copyFeedbackTimers, downloads));
   applyPolishLabels(root, labels);
   syncCodeButtonPositions(codeButtons);
 }
@@ -92,6 +107,7 @@ function mountCodeDownload(
   index: number,
   labels: ContentUxPolishLabels,
   codeButtons: Map<HTMLElement, HTMLButtonElement>,
+  downloads: BrowserDownloadManager,
 ): void {
   if (codeButtons.has(pre)) return;
 
@@ -103,7 +119,10 @@ function mountCodeDownload(
   button.addEventListener('click', (event) => {
     event.preventDefault();
     event.stopPropagation();
-    downloadText(inferCodeFilename(pre, index), getCodeBlockText(pre), 'text/plain;charset=utf-8');
+    downloads.download(
+      inferCodeFilename(pre, index),
+      new Blob([getCodeBlockText(pre)], { type: 'text/plain;charset=utf-8' }),
+    );
   });
   document.body.appendChild(button);
   codeButtons.set(pre, button);
@@ -120,6 +139,7 @@ export function getCodeBlockText(pre: HTMLElement): string {
 
 function collectMessageNodes(root: ParentNode): HTMLElement[] {
   return queryIncludingRoot<HTMLElement>(root, MESSAGE_SELECTOR)
+    .filter((node) => !node.matches(VIRTUAL_MESSAGE_SELECTOR) || !node.querySelector(PRIMARY_MESSAGE_SELECTOR))
     .filter((node) => !node.querySelector(`:scope > .${MESSAGE_BUTTON_CLASS}, :scope > .${MESSAGE_COPY_CLASS}`))
     .filter((node) => node.textContent?.trim());
 }
@@ -128,6 +148,7 @@ function mountMessageActions(
   message: HTMLElement,
   labels: ContentUxPolishLabels,
   copyFeedbackTimers: Set<ReturnType<typeof setTimeout>>,
+  downloads: BrowserDownloadManager,
 ): void {
   const markdownButton = document.createElement('button');
   markdownButton.type = 'button';
@@ -138,12 +159,12 @@ function mountMessageActions(
     event.preventDefault();
     event.stopPropagation();
     const artifact = createMessageMarkdownArtifact({
-      id: message.dataset.messageId || `dom-${Date.now()}`,
-      role: normalizeRole(message.dataset.messageRole ?? message.dataset.messageAuthorRole),
+      id: message.dataset.messageId || message.dataset.virtualListItemKey || `dom-${Date.now()}`,
+      role: getMessageRole(message),
       content: getMessageText(message),
       createdAt: null,
     });
-    downloadText(artifact.filename, artifact.content, artifact.mimeType);
+    downloads.download(artifact.filename, new Blob([artifact.content], { type: artifact.mimeType }));
   });
   message.appendChild(markdownButton);
 
@@ -229,9 +250,18 @@ function normalizeRole(value: string | undefined): 'user' | 'assistant' | 'syste
   return 'unknown';
 }
 
+function getMessageRole(message: HTMLElement): 'user' | 'assistant' | 'system' | 'tool' | 'unknown' {
+  const explicit = normalizeRole(message.dataset.messageRole ?? message.dataset.messageAuthorRole);
+  if (explicit !== 'unknown') return explicit;
+  if (message.querySelector(ASSISTANT_CONTENT_SELECTOR)) return 'assistant';
+  if (message.matches('.ds-message, [data-virtual-list-item-key]')) return 'user';
+  return 'unknown';
+}
+
 function createCandidateMountScheduler(
   getLabels: () => ContentUxPolishLabels,
   copyFeedbackTimers: Set<ReturnType<typeof setTimeout>>,
+  downloads: BrowserDownloadManager,
 ): { schedule(root: ParentNode, codeButtons: Map<HTMLElement, HTMLButtonElement>): void; cancel(): void } {
   const pending = new Set<ParentNode>();
   let pendingCodeButtons: Map<HTMLElement, HTMLButtonElement> | null = null;
@@ -249,7 +279,9 @@ function createCandidateMountScheduler(
         pending.clear();
         const labels = getLabels();
         for (const candidate of roots) {
-          if (pendingCodeButtons) mountPolish(candidate, labels, pendingCodeButtons, copyFeedbackTimers);
+          if (pendingCodeButtons) {
+            mountPolish(candidate, labels, pendingCodeButtons, copyFeedbackTimers, downloads);
+          }
         }
         pendingCodeButtons = null;
       }, POLISH_MOUNT_DELAY_MS);
@@ -320,18 +352,6 @@ function positionCodeButton(pre: HTMLElement, button: HTMLButtonElement): void {
   button.style.display = hidden ? 'none' : '';
   button.style.top = `${Math.min(maxTop, Math.max(CODE_BUTTON_OFFSET_PX, rect.top + CODE_BUTTON_OFFSET_PX))}px`;
   button.style.left = `${Math.min(maxLeft, Math.max(CODE_BUTTON_OFFSET_PX, rect.right - CODE_BUTTON_OFFSET_PX))}px`;
-}
-
-function downloadText(filename: string, content: string, mimeType: string): void {
-  const blob = new Blob([content], { type: mimeType });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = filename;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  URL.revokeObjectURL(url);
 }
 
 function extensionForLanguage(language: string): string {

--- a/entrypoints/content/download-manager.ts
+++ b/entrypoints/content/download-manager.ts
@@ -1,0 +1,36 @@
+export interface BrowserDownloadManager {
+  download(filename: string, blob: Blob): void;
+  stop(): void;
+}
+
+const DEFAULT_OBJECT_URL_LIFETIME_MS = 30_000;
+
+/** Owns every object URL and timer created by a content capability. */
+export function createBrowserDownloadManager(
+  objectUrlLifetimeMs = DEFAULT_OBJECT_URL_LIFETIME_MS,
+): BrowserDownloadManager {
+  const pending = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const revoke = (url: string) => {
+    const timer = pending.get(url);
+    if (timer !== undefined) clearTimeout(timer);
+    pending.delete(url);
+    URL.revokeObjectURL(url);
+  };
+
+  return {
+    download(filename, blob) {
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      pending.set(url, setTimeout(() => revoke(url), objectUrlLifetimeMs));
+    },
+    stop() {
+      for (const url of [...pending.keys()]) revoke(url);
+    },
+  };
+}

--- a/tests/conversation-export.test.ts
+++ b/tests/conversation-export.test.ts
@@ -18,6 +18,8 @@ import {
   normalizeConversationExportRequest,
 } from '../core/export/schema';
 import { normalizeDeepSeekHistory } from '../core/export/normalize';
+import { applyConversationExportContentScope } from '../core/export/scope';
+import { createConversationExportArchiveArtifact } from '../core/export/zip';
 import type { ConversationExport } from '../core/export/types';
 
 const fixtureDir = resolve(dirname(fileURLToPath(import.meta.url)), 'fixtures/deepseek-export');
@@ -90,21 +92,17 @@ describe('DeepSeek conversation export adapter and service', () => {
               id: 1,
               message_role: 'user',
               created_at: 1760000001,
-              fragments: [
-                { type: 'text', content: '早' },
-              ],
+              fragments: [{ type: 'REQUEST', content: '早' }],
             },
             {
               id: 2,
               parent_id: 1,
               message_role: 'assistant',
               created_at: 1760000002,
-              message_content: {
-                parts: [
-                  { content_type: 'text', content: '早上好！' },
-                  { content_type: 'text', content: '新的一天开始了。' },
-                ],
-              },
+              fragments: [
+                { type: 'THINK', content: '先礼貌回应。' },
+                { type: 'RESPONSE', content: '早上好！新的一天开始了。' },
+              ],
             },
           ],
         },
@@ -112,8 +110,60 @@ describe('DeepSeek conversation export adapter and service', () => {
     }, { includeRaw: false });
 
     expect(session.messages[0].content).toBe('早');
+    expect(session.messages[0].contentFragments).toEqual([{ kind: 'text', text: '早' }]);
     expect(session.messages[1].content).toContain('早上好！');
     expect(session.messages[1].content).toContain('新的一天开始了。');
+    expect(session.messages[1].contentFragments).toEqual([
+      { kind: 'reasoning', text: '先礼貌回应。' },
+      { kind: 'text', text: '早上好！新的一天开始了。' },
+    ]);
+  });
+
+  it('applies input-output scope before returning stats and artifacts', async () => {
+    const exportData = await runConversationExport({
+      exportId: 'real-fragment-scope',
+      extensionVersion: '0.0.0-test',
+      baseUrl: 'https://chat.deepseek.com',
+      request: {
+        mode: 'sanitized',
+        contentScope: 'input-output',
+        formats: ['markdown'],
+        includeAttachmentMetadata: false,
+        includeFileBodies: false,
+        sessionIds: ['session-real'],
+      },
+      transport: {
+        listSessions: vi.fn(async () => []),
+        fetchFiles: vi.fn(async () => []),
+        fetchHistory: vi.fn(async () => ({
+          data: {
+            biz_data: {
+              chat_session: { id: 'session-real', title: 'Real fragment types' },
+              chat_messages: [
+                { message_id: 1, role: 'USER', fragments: [{ type: 'REQUEST', content: '初始输入' }] },
+                { message_id: 2, role: 'ASSISTANT', fragments: [{ type: 'THINK', content: '思考' }] },
+                {
+                  message_id: 3,
+                  role: 'USER',
+                  fragments: [{
+                    type: 'REQUEST',
+                    content: '<original_task>初始输入</original_task><tool_results>[]</tool_results>',
+                  }],
+                },
+                { message_id: 4, role: 'ASSISTANT', fragments: [{ type: 'RESPONSE', content: '最终产出' }] },
+              ],
+            },
+          },
+        })),
+      },
+    });
+
+    expect(exportData.stats.messageCount).toBe(2);
+    expect(exportData.sessions[0].messages.map((message) => message.content)).toEqual(['初始输入', '最终产出']);
+    const markdown = buildConversationExportArtifacts(exportData)[0];
+    expect(markdown.content).toContain('Messages: 2');
+    expect(markdown.content).not.toContain('<tool_results>');
+    expect(markdown.content).not.toContain('思考');
   });
 
   it('paginates sessions and exports sanitized artifacts with attachment metadata', async () => {
@@ -430,7 +480,7 @@ describe('conversation export content scope projection', () => {
       source: { provider: 'deepseek-official-web', baseUrl: 'https://chat.deepseek.com', endpointVerification: 'static-bundle-and-browser-session', fileBodies: 'unsupported-unverified' },
       generatedBy: { name: 'DeepSeek++', version: '0.0.0-test' },
       request: { mode: 'sanitized', contentScope: 'full', formats: ['markdown'], includeAttachmentMetadata: true, includeFileBodies: false, pageSize: 50, sessionIds: ['s1'] },
-      stats: { sessionCount: 1, messageCount: 5, attachmentCount: 0, failedSessionCount: 0, startedAt: '2026-08-04T00:00:00.000Z', completedAt: '2026-08-04T00:00:00.000Z' },
+      stats: { sessionCount: 1, messageCount: 6, attachmentCount: 3, failedSessionCount: 0, startedAt: '2026-08-04T00:00:00.000Z', completedAt: '2026-08-04T00:00:00.000Z' },
       sessions: [{
         id: 's1',
         title: '测试会话',
@@ -440,15 +490,20 @@ describe('conversation export content scope projection', () => {
         createdAt: null,
         updatedAt: null,
         messages: [
-          { id: 'm1', parentId: null, role: 'user', content: '输入一', contentFragments: [{ kind: 'text', text: '输入一' }], createdAt: null, updatedAt: null, modelType: null, searchEnabled: null, thinkingEnabled: null, attachmentRefs: [] },
-          { id: 'm2', parentId: 'm1', role: 'assistant', content: '思考中工具调用', contentFragments: [{ kind: 'reasoning', text: '思考' }, { kind: 'tool', text: '<shell_exec>…' }], createdAt: null, updatedAt: null, modelType: null, searchEnabled: null, thinkingEnabled: null, attachmentRefs: [] },
-          { id: 'm3', parentId: 'm2', role: 'tool', content: '工具结果', contentFragments: [{ kind: 'tool', text: '工具结果' }], createdAt: null, updatedAt: null, modelType: null, searchEnabled: null, thinkingEnabled: null, attachmentRefs: [] },
-          { id: 'm4', parentId: 'm3', role: 'assistant', content: '最终产出A（含思考）', contentFragments: [{ kind: 'reasoning', text: '不该出现' }, { kind: 'text', text: '最终产出A' }], createdAt: null, updatedAt: null, modelType: null, searchEnabled: null, thinkingEnabled: null, attachmentRefs: [] },
-          { id: 'm5', parentId: 'm4', role: 'assistant', content: '最终产出B', contentFragments: [{ kind: 'text', text: '最终产出B' }], createdAt: null, updatedAt: null, modelType: null, searchEnabled: null, thinkingEnabled: null, attachmentRefs: [] },
+          { id: 'm1', parentId: null, role: 'user', content: '输入一', contentFragments: [{ kind: 'text', text: '输入一' }], createdAt: null, updatedAt: null, modelType: null, searchEnabled: null, thinkingEnabled: null, attachmentRefs: [{ id: 'file-input', role: 'referenced' }] },
+          { id: 'm2', parentId: 'm1', role: 'assistant', content: '思考中工具调用', contentFragments: [{ kind: 'reasoning', text: '思考' }, { kind: 'tool', text: '<shell_exec>…' }], createdAt: null, updatedAt: null, modelType: null, searchEnabled: null, thinkingEnabled: null, attachmentRefs: [{ id: 'file-internal', role: 'generated' }] },
+          { id: 'm3', parentId: 'm2', role: 'user', content: '内部续跑输入', contentFragments: [{ kind: 'text', text: '内部续跑输入' }], createdAt: null, updatedAt: null, modelType: null, searchEnabled: null, thinkingEnabled: null, attachmentRefs: [] },
+          { id: 'm4', parentId: 'm3', role: 'tool', content: '工具结果', contentFragments: [{ kind: 'tool', text: '工具结果' }], createdAt: null, updatedAt: null, modelType: null, searchEnabled: null, thinkingEnabled: null, attachmentRefs: [] },
+          { id: 'm5', parentId: 'm4', role: 'assistant', content: '最终产出A（含思考）', contentFragments: [{ kind: 'reasoning', text: '不该出现' }, { kind: 'text', text: '最终产出A' }], createdAt: null, updatedAt: null, modelType: null, searchEnabled: null, thinkingEnabled: null, attachmentRefs: [] },
+          { id: 'm6', parentId: 'm5', role: 'assistant', content: '最终产出B', contentFragments: [{ kind: 'text', text: '最终产出B' }], createdAt: null, updatedAt: null, modelType: null, searchEnabled: null, thinkingEnabled: null, attachmentRefs: [{ id: 'file-output', role: 'generated' }] },
         ],
         failures: [],
       }],
-      attachments: [],
+      attachments: [
+        { id: 'file-input', fileName: 'input.txt', mimeType: 'text/plain', sizeBytes: 1, status: 'metadata_available', sourceMessageIds: ['m1'] },
+        { id: 'file-internal', fileName: 'internal.txt', mimeType: 'text/plain', sizeBytes: 2, status: 'metadata_available', sourceMessageIds: ['m2'] },
+        { id: 'file-output', fileName: 'output.txt', mimeType: 'text/plain', sizeBytes: 3, status: 'metadata_available', sourceMessageIds: ['m6', 'missing-message'] },
+      ],
       failures: [],
     };
     return base;
@@ -462,16 +517,57 @@ describe('conversation export content scope projection', () => {
     expect(markdown?.content).toContain('最终产出B');
   });
 
-  it('projects input-output scope to user inputs plus the final assistant text output', async () => {
-    const data = { ...buildExportData(), request: { ...buildExportData().request, contentScope: 'input-output' as const } };
-    const artifacts = await buildConversationExportArtifactsCancellable(data);
+  it('projects to the initial input plus final output and scopes attachments', async () => {
+    const base = buildExportData();
+    const source = {
+      ...base,
+      request: { ...base.request, contentScope: 'input-output' as const },
+    };
+    const scoped = applyConversationExportContentScope(source, 'input-output');
+    const artifacts = await buildConversationExportArtifactsCancellable(source);
     const markdown = artifacts.find((artifact) => artifact.format === 'markdown');
+
+    expect(scoped.sessions[0].messages.map((message) => message.id)).toEqual(['m1', 'm6']);
+    expect(scoped.attachments.map((attachment) => attachment.id)).toEqual(['file-input', 'file-output']);
+    expect(scoped.attachments[1].sourceMessageIds).toEqual(['m6']);
+    expect(scoped.stats).toMatchObject({ messageCount: 2, attachmentCount: 2 });
     expect(markdown?.content).toContain('输入一');
     expect(markdown?.content).toContain('最终产出B');
+    expect(markdown?.content).not.toContain('内部续跑输入');
     expect(markdown?.content).not.toContain('工具结果');
     expect(markdown?.content).not.toContain('不该出现');
     expect(markdown?.content).not.toContain('最终产出A');
     expect(markdown?.content).not.toContain('<shell_exec>');
+    expect(markdown?.content).not.toContain('internal.txt');
     expect(markdown?.content).toContain('Messages: 2');
+    expect(markdown?.content).toContain('Attachments: 2');
+  });
+});
+
+describe('conversation export multi-format archive', () => {
+  it('packs selected formats into one UTF-8 ZIP download', () => {
+    const archive = createConversationExportArchiveArtifact([
+      {
+        format: 'html',
+        filename: 'deepseek-conversations-sanitized-2026-08-06T10-00-00.html',
+        mimeType: 'text/html;charset=utf-8',
+        content: '<h1>你好</h1>',
+      },
+      {
+        format: 'markdown',
+        filename: 'deepseek-conversations-sanitized-2026-08-06T10-00-00.md',
+        mimeType: 'text/markdown;charset=utf-8',
+        content: '# 你好',
+      },
+    ], new Date('2026-08-06T10:00:00.000Z'));
+
+    expect(archive.filename).toBe('deepseek-conversations-sanitized-2026-08-06T10-00-00.zip');
+    expect(archive.mimeType).toBe('application/zip');
+    expect(Array.from(archive.content.slice(0, 4))).toEqual([0x50, 0x4b, 0x03, 0x04]);
+    const decoded = new TextDecoder().decode(archive.content);
+    expect(decoded).toContain('deepseek-conversations-sanitized-2026-08-06T10-00-00.html');
+    expect(decoded).toContain('deepseek-conversations-sanitized-2026-08-06T10-00-00.md');
+    expect(decoded).toContain('<h1>你好</h1>');
+    expect(decoded).toContain('# 你好');
   });
 });

--- a/tests/inline-agent-renderer.test.ts
+++ b/tests/inline-agent-renderer.test.ts
@@ -149,8 +149,8 @@ describe('inline agent renderer', () => {
   it('renders each tool execution as an independently collapsible row', () => {
     const step = createAgentStepElement(0, undefined, timelineLabels);
 
-    addToolResultToStep(step, 'web_search', true, 'found 5 results', timelineLabels);
-    addToolResultToStep(step, 'web_fetch', false, 'request failed: 403', timelineLabels);
+    addToolResultToStep(step, 'web_search', { ok: true, summary: 'found 5 results' }, timelineLabels);
+    addToolResultToStep(step, 'web_fetch', { ok: false, summary: 'request failed: 403' }, timelineLabels);
 
     const items = step.querySelectorAll<HTMLElement>('.dpp-agent-step-tool-item');
     expect(items).toHaveLength(2);
@@ -185,11 +185,32 @@ describe('inline agent renderer', () => {
     const step = createAgentStepElement(0, undefined, timelineLabels);
     const longSummary = 'x'.repeat(2000);
 
-    addToolResultToStep(step, 'shell_exec', true, longSummary, timelineLabels);
+    addToolResultToStep(step, 'shell_exec', { ok: true, summary: longSummary }, timelineLabels);
 
     const summary = step.querySelector<HTMLElement>('.dpp-agent-tool-summary');
     expect(summary?.textContent?.startsWith('x'.repeat(600))).toBe(true);
     expect(summary?.textContent).toContain('[truncated]');
+  });
+
+  it('shows the concrete rejection reason in the matching failed tool row', () => {
+    const step = createAgentStepElement(0, undefined, timelineLabels);
+
+    addToolResultToStep(step, 'shell_exec', {
+      ok: false,
+      summary: '工具授权被拒绝',
+      detail: 'Tool call turn:2:xml:0 has already been reserved or consumed.',
+      error: {
+        code: 'tool_call_replayed',
+        message: 'Tool call turn:2:xml:0 has already been reserved or consumed.',
+        retryable: false,
+      },
+    }, timelineLabels);
+
+    const toggle = step.querySelector<HTMLButtonElement>('.dpp-agent-tool-toggle');
+    toggle?.click();
+    expect(step.querySelector('.dpp-agent-tool-summary')?.textContent).toBe(
+      '工具授权被拒绝\nTool call turn:2:xml:0 has already been reserved or consumed.',
+    );
   });
 
   it('renders collapsible tool result details per execution', () => {
@@ -251,7 +272,7 @@ describe('inline agent renderer', () => {
     expect(processLabel?.hidden).toBe(false);
     expect(resultsLabel?.hidden).toBe(true);
 
-    addToolResultToStep(step, 'web_search', true, 'found 5 results');
+    addToolResultToStep(step, 'web_search', { ok: true, summary: 'found 5 results' });
     expect(toolsLabel?.hidden).toBe(false);
     expect(toolsLabel?.textContent).toBe('Tool calls');
   });
@@ -277,7 +298,7 @@ describe('inline agent renderer', () => {
   it('restores the same collapsed timeline structure from persisted trace data', () => {
     const step = createAgentStepElement(1, undefined, timelineLabels);
     updateStepStreamText(step, 'process text');
-    addToolResultToStep(step, 'web_search', true, 'summary', timelineLabels);
+    addToolResultToStep(step, 'web_search', { ok: true, summary: 'summary' }, timelineLabels);
     updateStepStatus(step, 'complete', 'Complete (1 tools)');
     setAgentStepCollapsed(step, true);
 
@@ -299,8 +320,8 @@ describe('inline agent renderer', () => {
 
     const step = createAgentStepElement(0, undefined, timelineLabels);
     updateStepStreamText(step, 'process text');
-    addToolResultToStep(step, 'web_search', true, 'found 5 results', timelineLabels);
-    addToolResultToStep(step, 'web_fetch', false, 'request failed: 403', timelineLabels);
+    addToolResultToStep(step, 'web_search', { ok: true, summary: 'found 5 results' }, timelineLabels);
+    addToolResultToStep(step, 'web_fetch', { ok: false, summary: 'request failed: 403' }, timelineLabels);
     updateStepStatus(step, 'complete', 'Complete (2 tools)');
 
     setAgentStepCollapsed(step, true);

--- a/tests/phase5-product-surfaces.test.ts
+++ b/tests/phase5-product-surfaces.test.ts
@@ -17,6 +17,7 @@ import {
   inferCodeFilename,
   startContentUxPolish,
 } from '../entrypoints/content/adapters/ux-polish';
+import { createBrowserDownloadManager } from '../entrypoints/content/download-manager';
 import type { SavedItem } from '../core/saved-items';
 
 let storage: Record<string, unknown>;
@@ -132,6 +133,51 @@ describe('Phase 5 product surface helpers', () => {
       history.stop();
       polish.stop();
     }
+  });
+
+  it('mounts message actions on the current printable virtual-list message shape', () => {
+    document.body.innerHTML = `
+      <div class="ds-virtual-list ds-virtual-list--printable">
+        <div class="ds-virtual-list-visible-items">
+          <div data-virtual-list-item-key="2">
+            <div class="ds-assistant-message-main-content">完整回复内容</div>
+          </div>
+        </div>
+      </div>
+    `;
+    const polish = startContentUxPolish(() => ({
+      codeDownloadButton: '下载',
+      messageMarkdownButton: 'MD',
+      messageMarkdownTitle: '下载消息为 Markdown',
+      messageCopyButton: '复制',
+      messageCopyTitle: '复制完整对话输出',
+      messageCopyFailed: '复制失败',
+    }));
+
+    try {
+      const message = document.querySelector<HTMLElement>('[data-virtual-list-item-key="2"]')!;
+      expect(message.querySelectorAll('.dpp-message-download')).toHaveLength(1);
+      expect(message.querySelectorAll('.dpp-message-copy')).toHaveLength(1);
+    } finally {
+      polish.stop();
+    }
+  });
+
+  it('keeps the object URL alive until the download lease expires', () => {
+    vi.useFakeTimers();
+    const createObjectURL = vi.fn(() => 'blob:download-1');
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL });
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+    const downloads = createBrowserDownloadManager(1_000);
+
+    downloads.download('export.md', new Blob(['hello'], { type: 'text/markdown' }));
+    expect(click).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1_000);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:download-1');
+    downloads.stop();
   });
 
   it('does not rescan processed large code block text while streaming', async () => {

--- a/tests/pi-loop-official-api.test.ts
+++ b/tests/pi-loop-official-api.test.ts
@@ -153,6 +153,41 @@ describe('runInlineAgentLoop with official-api backend', () => {
     expect(complete?.totalTools).toBe(1);
   });
 
+  it('gives the same XML tool index a distinct authorization identity in each model turn', async () => {
+    vi.useFakeTimers();
+    officialApiMocks.submitOfficialDeepSeekStreaming
+      .mockImplementationOnce(async (_input, callbacks) => {
+        callbacks.onTextChunk?.(TOOL_CALL_TEXT);
+        callbacks.onFinished?.();
+        return { assistantText: TOOL_CALL_TEXT, reasoningText: '', finished: true };
+      })
+      .mockImplementationOnce(async (_input, callbacks) => {
+        callbacks.onTextChunk?.(TOOL_CALL_TEXT);
+        callbacks.onFinished?.();
+        return { assistantText: TOOL_CALL_TEXT, reasoningText: '', finished: true };
+      })
+      .mockImplementationOnce(async (_input, callbacks) => {
+        callbacks.onTextChunk?.('Both files are ready.');
+        callbacks.onFinished?.();
+        return { assistantText: 'Both files are ready.', reasoningText: '', finished: true };
+      });
+
+    const callIds: string[] = [];
+    const loopPromise = runLoop(createPayload(), async (call) => {
+      callIds.push(call.id);
+      return {
+        name: call.name,
+        provider: { kind: 'local', id: 'artifact', displayName: 'Artifact', transport: 'in_process' },
+        result: { ok: true, summary: 'created' },
+      };
+    });
+    await vi.advanceTimersByTimeAsync(7_000);
+    await vi.advanceTimersByTimeAsync(7_000);
+    await loopPromise;
+
+    expect(callIds).toEqual(['turn:1:xml:0', 'turn:2:xml:0']);
+  });
+
   it('forwards official-API messages in OpenAI-compatible shape with tool results', async () => {
     vi.useFakeTimers();
     officialApiMocks.submitOfficialDeepSeekStreaming


### PR DESCRIPTION
## Summary

- give XML tool calls a per-model-turn identity so later expert-mode turns are not rejected as replays
- recognize DeepSeek history `REQUEST` / `RESPONSE` fragments and make “仅输入 + 最终产出” retain only the initial user input and final assistant output, including consistent attachment/stat filtering
- show the concrete tool failure detail directly in the failed tool row
- make downloads reliable by leasing object URLs, supporting the current printable virtual-list DOM, and packaging multi-format conversation exports into one UTF-8 ZIP

## PR Type

- [x] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

```bash
git fetch origin main codex/issue-546
```

Verified base `b3df0cf704dc27d582d6a144e1b19c0b8f5caa5f` and head `866696bf7df8a02a91c40c7055acc206c70c1add` immediately before merge review.

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

OpenAI Codex (current Codex desktop coding model)

Coding Agent tool(s) used:

Codex desktop, ego-browser

## Root Causes

1. XML tool indexes restart at `0` for every model response, while one inline-agent run reuses one authorization grant. Reusing `xml:0` therefore collided with the prior turn.
2. The current DeepSeek history API labels visible fragments as `REQUEST`, `THINK`, and `RESPONSE`; `REQUEST` / `RESPONSE` were normalized as unknown and disappeared from the input-output projection.
3. The timeline renderer received only a boolean and summary, so it could not render `detail` / `error.message`.
4. Multiple asynchronous download clicks and immediately revoked object URLs were unreliable, and the message selector did not cover the current printable virtual-list shape.

## Local Validation

Commands run:

```bash
npm run compile
npx vitest run tests/conversation-export.test.ts tests/background-deepseek-runtime-handlers.test.ts tests/inline-agent-event-protocol-golden.test.ts tests/pi-loop-official-api.test.ts tests/pi-tool-bridge-authorization.test.ts tests/inline-agent-renderer.test.ts tests/phase5-product-surfaces.test.ts
npm run ci:quality
git diff --check origin/main...origin/codex/issue-546
unzip -t deepseek-conversations-sanitized-2026-08-06T11-01-40.zip
```

Result summary:

- targeted Vitest: 7 files / 97 tests passed
- full Vitest in `ci:quality`: 208 files / 1667 tests passed
- prompt freeze, compile, persistence, i18n, automation, MCP, Shell, PoW, Chrome/Edge/Firefox builds, manifest, UTF-8, ZIP, release assets, and offline Pyodide checks passed
- committed source ZIP contains the two newly added source files
- remote `CI / Quality gates` passed on head `866696b`
- no unresolved review threads or comments; PR is mergeable against the unchanged latest `main`

## Local Feature Evidence

Evidence:

- ego-browser QA used a real signed-in DeepSeek page with the locally loaded branch build; the built-in browser was not used
- expert mode completed 3 steps / 3 tool calls across consecutive model turns without `tool_call_replayed`
- a deliberately failed `web_fetch` row displayed both `无效的 URL` and `无法解析 URL: file:///tmp/issue-546`
- HTML + Markdown produced one ZIP; `unzip -t` passed and the Markdown contained exactly the initial input plus final output, excluding THINK/tool context
- the page instance did not render assistant history into its virtual list, so message-action anchoring was additionally exercised on the same real DeepSeek page with a QA fixture matching the current official printable virtual-list DOM shape; the extension’s actual Markdown download path succeeded
- detailed QA and root-cause evidence is recorded in the owner comment on Issue #546: https://github.com/zhu1090093659/deepseek-pp/issues/546#issuecomment-5204006251

Addresses #546.

This PR intentionally leaves the Issue open until the fix is released and the reporter can retest the original workflow.