### PR TITLE
test(export): cover HTML input-output export stats (#543)

### DIFF
--- a/tests/conversation-export.test.ts
+++ b/tests/conversation-export.test.ts
@@ -119,7 +119,7 @@ describe('DeepSeek conversation export adapter and service', () => {
     ]);
   });
 
-  it('applies input-output scope before returning stats and artifacts', async () => {
+  it('renders the input-output projection into HTML with nonzero message stats', async () => {
     const exportData = await runConversationExport({
       exportId: 'real-fragment-scope',
       extensionVersion: '0.0.0-test',
@@ -127,7 +127,7 @@ describe('DeepSeek conversation export adapter and service', () => {
       request: {
         mode: 'sanitized',
         contentScope: 'input-output',
-        formats: ['markdown'],
+        formats: ['html', 'markdown'],
         includeAttachmentMetadata: false,
         includeFileBodies: false,
         sessionIds: ['session-real'],
@@ -160,10 +160,18 @@ describe('DeepSeek conversation export adapter and service', () => {
 
     expect(exportData.stats.messageCount).toBe(2);
     expect(exportData.sessions[0].messages.map((message) => message.content)).toEqual(['初始输入', '最终产出']);
-    const markdown = buildConversationExportArtifacts(exportData)[0];
-    expect(markdown.content).toContain('Messages: 2');
-    expect(markdown.content).not.toContain('<tool_results>');
-    expect(markdown.content).not.toContain('思考');
+    const artifacts = buildConversationExportArtifacts(exportData);
+    const html = artifacts.find((artifact) => artifact.format === 'html');
+    const markdown = artifacts.find((artifact) => artifact.format === 'markdown');
+
+    expect(html?.content).toContain('<strong>2</strong>Messages');
+    expect(html?.content).toContain('初始输入');
+    expect(html?.content).toContain('最终产出');
+    expect(html?.content).not.toContain('&lt;tool_results&gt;');
+    expect(html?.content).not.toContain('思考');
+    expect(markdown?.content).toContain('Messages: 2');
+    expect(markdown?.content).not.toContain('<tool_results>');
+    expect(markdown?.content).not.toContain('思考');
   });
 
   it('paginates sessions and exports sanitized artifacts with attachment metadata', async () => {


### PR DESCRIPTION
## Summary

- add a regression assertion for the exact `HTML + 仅输入 + 最终产出` export path reported in #543
- verify the current DeepSeek `REQUEST` / `RESPONSE` history fragments retain the initial input and final assistant output after scope projection
- assert the generated HTML reports `2 Messages` rather than `0 Messages`, and excludes reasoning/internal tool context

## Root Cause Context

The functional fix is already in `main` through PR #547: visible DeepSeek history fragments labelled `REQUEST` / `RESPONSE` had previously been normalized as `unknown`, so the input-output projection discarded every message. This PR adds an HTML artifact-level regression test so the reported rendering and statistic contract cannot silently regress.

## PR Type

- [ ] User-facing feature or behavior change
- [ ] Bug fix
- [ ] Documentation only
- [x] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Rebased onto `origin/main@ed0b9e8` before the final push; the resulting PR head was `e8e2355`.

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used: OpenAI Codex.

Coding Agent tool(s) used: Codex desktop.

## Local Validation

Commands run:

```text
npx vitest run tests/conversation-export.test.ts
npm run compile
npm test
git diff --check
```

Result summary:

- targeted export tests passed: 1 file / 19 tests;
- TypeScript compile passed;
- full unit suite passed: 208 files / 1667 tests;
- diff hygiene passed.

## Local Feature Evidence

This PR adds regression coverage only and introduces no new user-facing behavior. The underlying user-facing repair is PR #547; its owner-run DeepSeek browser QA and artifact checks are documented in that PR. This PR's direct acceptance evidence is the HTML artifact assertion for the reported `REQUEST` / `THINK` / `RESPONSE` history shape.