### PR TITLE
fix: restore tool authorization for native regenerate

### DIFF
--- a/core/deepseek/request-codec.ts
+++ b/core/deepseek/request-codec.ts
@@ -7,6 +7,18 @@ import {
 export type DeepSeekWebRouteName = keyof typeof DEEPSEEK_WEB_ROUTES;
 export type DeepSeekHttpMethod = 'GET' | 'POST';
 
+export const DEEPSEEK_AUGMENTABLE_WEB_ROUTES = [
+  'completion',
+  'editMessage',
+  'regenerate',
+] as const satisfies readonly DeepSeekWebRouteName[];
+
+export type DeepSeekAugmentableWebRoute = typeof DEEPSEEK_AUGMENTABLE_WEB_ROUTES[number];
+
+const DEEPSEEK_AUGMENTABLE_WEB_ROUTE_SET = new Set<DeepSeekWebRouteName>(
+  DEEPSEEK_AUGMENTABLE_WEB_ROUTES,
+);
+
 export interface DeepSeekRoutePolicy {
   readonly route: DeepSeekWebRouteName;
   readonly method: DeepSeekHttpMethod;
@@ -84,6 +96,12 @@ export function matchDeepSeekWebRoute(
     }
   }
   return null;
+}
+
+export function isDeepSeekAugmentableWebRoute(
+  value: unknown,
+): value is DeepSeekAugmentableWebRoute {
+  return typeof value === 'string' && DEEPSEEK_AUGMENTABLE_WEB_ROUTE_SET.has(value as DeepSeekWebRouteName);
 }
 
 export function encodeDeepSeekRouteRequest(

--- a/core/interceptor/fetch-hook.ts
+++ b/core/interceptor/fetch-hook.ts
@@ -1,7 +1,9 @@
 import { DEEPSEEK_BYPASS_HOOK_HEADER } from '../deepseek/contracts';
 import {
+  isDeepSeekAugmentableWebRoute,
   matchDeepSeekWebRoute,
   normalizeDeepSeekMessageId,
+  type DeepSeekAugmentableWebRoute,
 } from '../deepseek/request-codec';
 import type { ToolCall, ToolCallRestoreRecord, ToolCallSource, ToolDescriptor } from '../types';
 import { isInlineAgentContinuationRequest } from '../inline-agent/prompt';
@@ -50,7 +52,11 @@ const initialHookStateReady = new Promise<void>((resolve) => {
 
 interface HookState {
   toolDescriptors: ToolDescriptor[];
-  onRequestBody: (body: string, requestId: string) => Promise<RequestBodyModification | null>;
+  onRequestBody: (
+    body: string,
+    requestId: string,
+    route: DeepSeekAugmentableWebRoute,
+  ) => Promise<RequestBodyModification | null>;
   onHeadersCaptured: (headers: Record<string, string> | null) => void;
   onToolCallStarted: (call: ToolCall) => void;
   onToolCall: (call: ToolCall) => void;
@@ -147,13 +153,17 @@ interface RequestContextOverrides {
   originalPrompt?: string;
   agentTaskPrompt?: string;
   toolDescriptors?: ToolDescriptor[];
+  promptOptions?: ResponseCompletePayload['promptOptions'];
+  activeLocalSkillDir?: string;
 }
 
 export interface RequestBodyModification {
   body: string;
+  originalPrompt?: string;
   agentTaskPrompt: string;
   requestId?: string;
   toolDescriptors?: ToolDescriptor[];
+  promptOptions?: ResponseCompletePayload['promptOptions'];
   // The current request's active local skill skillDir computed at augment time;
   // travels with the request into RequestContext for cwd pinning during response-stream parsing (request-scoped isolation).
   activeLocalSkillDir?: string;
@@ -185,10 +195,7 @@ export function hookFetch(): () => void {
       return interceptHistoryResponse(originalFetch.call(this, input, init));
     }
 
-    if (
-      (route !== 'completion' && route !== 'editMessage' && route !== 'regenerate') ||
-      typeof init?.body !== 'string'
-    ) {
+    if (!isDeepSeekAugmentableWebRoute(route) || typeof init?.body !== 'string') {
       return originalFetch.call(this, input, init);
     }
 
@@ -202,7 +209,7 @@ export function hookFetch(): () => void {
     const fallbackToolDescriptors = [...hookState.toolDescriptors];
     let modified: RequestBodyModification | null;
     try {
-      modified = await hookState.onRequestBody(init.body, originalContext.requestId);
+      modified = await hookState.onRequestBody(init.body, originalContext.requestId, route);
     } catch (error) {
       hookState.onRequestTerminal({ requestId: originalContext.requestId });
       throw error;
@@ -211,9 +218,10 @@ export function hookFetch(): () => void {
     const requestContext = createRequestContext(requestBody, {
       requestId: originalContext.requestId,
       ...(modified?.requestId ? { requestId: modified.requestId } : {}),
-      originalPrompt: originalContext.originalPrompt,
+      originalPrompt: modified?.originalPrompt ?? originalContext.originalPrompt,
       agentTaskPrompt: modified?.agentTaskPrompt ?? originalContext.agentTaskPrompt,
       toolDescriptors: modified?.toolDescriptors ?? fallbackToolDescriptors,
+      ...(modified?.promptOptions ? { promptOptions: modified.promptOptions } : {}),
       ...(modified?.activeLocalSkillDir !== undefined
         ? { activeLocalSkillDir: modified.activeLocalSkillDir }
         : {}),
@@ -269,10 +277,7 @@ export function hookXHR(): () => void {
 
   XMLHttpRequest.prototype.send = function (body?: Document | XMLHttpRequestBodyInit | null) {
     const route = xhrRoutes.get(this);
-    if (
-      (route === 'completion' || route === 'editMessage' || route === 'regenerate') &&
-      typeof body === 'string'
-    ) {
+    if (isDeepSeekAugmentableWebRoute(route) && typeof body === 'string') {
       const xhr = this;
       const sendChatRequest = async () => {
         const originalContext = createRequestContext(body);
@@ -280,14 +285,18 @@ export function hookXHR(): () => void {
         try {
           hookState.onHeadersCaptured(captureDeepSeekClientHeaders(xhrHeaders.get(xhr)));
           const fallbackToolDescriptors = [...hookState.toolDescriptors];
-          const modified = await hookState.onRequestBody(body, originalContext.requestId);
+          const modified = await hookState.onRequestBody(body, originalContext.requestId, route);
           const requestBody = modified?.body ?? body;
           cancelResponseInterceptor = setupXHRResponseInterceptor(xhr, createRequestContext(requestBody, {
             requestId: originalContext.requestId,
             ...(modified?.requestId ? { requestId: modified.requestId } : {}),
-            originalPrompt: originalContext.originalPrompt,
+            originalPrompt: modified?.originalPrompt ?? originalContext.originalPrompt,
             agentTaskPrompt: modified?.agentTaskPrompt ?? originalContext.agentTaskPrompt,
             toolDescriptors: modified?.toolDescriptors ?? fallbackToolDescriptors,
+            ...(modified?.promptOptions ? { promptOptions: modified.promptOptions } : {}),
+            ...(modified?.activeLocalSkillDir !== undefined
+              ? { activeLocalSkillDir: modified.activeLocalSkillDir }
+              : {}),
           }));
           return origSend.call(xhr, requestBody);
         } catch (error) {
@@ -393,14 +402,12 @@ export function createRequestContext(bodyStr: string, overrides: RequestContextO
       agentTaskPrompt: overrides.agentTaskPrompt ?? bodyPrompt,
       chatSessionId: typeof body.chat_session_id === 'string' ? body.chat_session_id : null,
       parentMessageId: normalizeDeepSeekMessageId(body.parent_message_id),
-      promptOptions: {
-        modelType: typeof body.model_type === 'string' ? body.model_type : null,
-        searchEnabled: body.search_enabled === true,
-        thinkingEnabled: body.thinking_enabled === true,
-        refFileIds: Array.isArray(body.ref_file_ids) ? body.ref_file_ids.filter((item): item is string => typeof item === 'string') : [],
-      },
+      promptOptions: overrides.promptOptions ?? readRequestPromptOptions(body),
       suppressPageEvents: isInlineAgentContinuationRequest(originalPrompt, overrides.agentTaskPrompt ?? bodyPrompt),
       toolDescriptors: overrides.toolDescriptors ?? [...hookState.toolDescriptors],
+      ...(overrides.activeLocalSkillDir !== undefined
+        ? { activeLocalSkillDir: overrides.activeLocalSkillDir }
+        : {}),
     };
   } catch {
     return {
@@ -409,16 +416,27 @@ export function createRequestContext(bodyStr: string, overrides: RequestContextO
       agentTaskPrompt: overrides.agentTaskPrompt ?? overrides.originalPrompt ?? '',
       chatSessionId: null,
       parentMessageId: null,
-      promptOptions: {
-        modelType: null,
-        searchEnabled: false,
-        thinkingEnabled: false,
-        refFileIds: [],
-      },
+      promptOptions: overrides.promptOptions ?? readRequestPromptOptions(null),
       suppressPageEvents: isInlineAgentContinuationRequest(overrides.originalPrompt ?? '', overrides.agentTaskPrompt ?? ''),
       toolDescriptors: overrides.toolDescriptors ?? [...hookState.toolDescriptors],
+      ...(overrides.activeLocalSkillDir !== undefined
+        ? { activeLocalSkillDir: overrides.activeLocalSkillDir }
+        : {}),
     };
   }
+}
+
+function readRequestPromptOptions(
+  body: Record<string, unknown> | null,
+): ResponseCompletePayload['promptOptions'] {
+  return {
+    modelType: typeof body?.model_type === 'string' ? body.model_type : null,
+    searchEnabled: body?.search_enabled === true,
+    thinkingEnabled: body?.thinking_enabled === true,
+    refFileIds: Array.isArray(body?.ref_file_ids)
+      ? body.ref_file_ids.filter((item): item is string => typeof item === 'string')
+      : [],
+  };
 }
 
 function hasBypassHookHeader(headers: HeadersInit | undefined): boolean {

--- a/core/interceptor/regenerate-authorization-scope.ts
+++ b/core/interceptor/regenerate-authorization-scope.ts
@@ -1,0 +1,265 @@
+import { normalizeDeepSeekMessageId } from '../deepseek/request-codec';
+import type { ToolCallRestoreRecord } from '../types';
+
+const DEFAULT_MAX_REGENERATE_AUTHORIZATION_SCOPES = 64;
+const DEFAULT_MAX_REGENERATE_PROMPT_CHARS = 64_000;
+const MAX_REGENERATE_DESCRIPTOR_IDS = 512;
+export const REGENERATE_AUTHORIZATION_METADATA_KEY = 'regenerateAuthorization';
+
+export interface RegeneratePromptOptionsSnapshot {
+  modelType: string | null;
+  searchEnabled: boolean;
+  thinkingEnabled: boolean;
+  refFileIds: string[];
+}
+
+export interface RegenerateAuthorizationScopeInput {
+  chatSessionId: string | null | undefined;
+  assistantMessageId: number | string | null | undefined;
+  descriptorIds: readonly string[];
+  originalPrompt: string;
+  agentTaskPrompt: string;
+  promptOptions: RegeneratePromptOptionsSnapshot;
+  activeLocalSkillDir?: string;
+}
+
+export interface RegenerateAuthorizationScope {
+  chatSessionId: string;
+  assistantMessageId: number;
+  descriptorIds: string[];
+  originalPrompt: string;
+  agentTaskPrompt: string;
+  promptOptions: RegeneratePromptOptionsSnapshot;
+  activeLocalSkillDir?: string;
+}
+
+export interface PersistedRegenerateAuthorizationEvidence {
+  descriptorIds: string[];
+  promptOptions?: RegeneratePromptOptionsSnapshot;
+  activeLocalSkillDir?: string;
+}
+
+export interface RegenerateAuthorizationScopeStore {
+  remember(input: RegenerateAuthorizationScopeInput): boolean;
+  resolve(chatSessionId: string, childMessageId: number | string): RegenerateAuthorizationScope | null;
+  clear(): void;
+  readonly size: number;
+}
+
+export function createRegenerateAuthorizationScopeStore(options: {
+  maxEntries?: number;
+  maxPromptChars?: number;
+} = {}): RegenerateAuthorizationScopeStore {
+  const maxEntries = normalizePositiveLimit(
+    options.maxEntries,
+    DEFAULT_MAX_REGENERATE_AUTHORIZATION_SCOPES,
+  );
+  const maxPromptChars = normalizePositiveLimit(
+    options.maxPromptChars,
+    DEFAULT_MAX_REGENERATE_PROMPT_CHARS,
+  );
+  const scopes = new Map<string, RegenerateAuthorizationScope>();
+
+  return {
+    remember(input) {
+      const scope = normalizeScope(input, maxPromptChars);
+      if (!scope) return false;
+      const key = createScopeKey(scope.chatSessionId, scope.assistantMessageId);
+      scopes.delete(key);
+      scopes.set(key, scope);
+      while (scopes.size > maxEntries) {
+        const oldestKey = scopes.keys().next().value;
+        if (typeof oldestKey !== 'string') break;
+        scopes.delete(oldestKey);
+      }
+      return true;
+    },
+    resolve(chatSessionId, childMessageId) {
+      const normalizedSessionId = normalizeChatSessionId(chatSessionId);
+      const normalizedMessageId = normalizeDeepSeekMessageId(childMessageId);
+      if (!normalizedSessionId || normalizedMessageId === null) return null;
+      const key = createScopeKey(normalizedSessionId, normalizedMessageId);
+      const scope = scopes.get(key);
+      if (!scope) return null;
+      // Keep frequently regenerated branches available while the bounded store
+      // evicts unrelated older responses.
+      scopes.delete(key);
+      scopes.set(key, scope);
+      return cloneScope(scope);
+    },
+    clear() {
+      scopes.clear();
+    },
+    get size() {
+      return scopes.size;
+    },
+  };
+}
+
+export function createPersistedRegenerateAuthorizationMetadata(
+  scope: Pick<RegenerateAuthorizationScope, 'descriptorIds' | 'promptOptions' | 'activeLocalSkillDir'>,
+): Record<string, unknown> {
+  return {
+    descriptorIds: [...scope.descriptorIds],
+    promptOptions: clonePromptOptions(scope.promptOptions),
+    ...(scope.activeLocalSkillDir ? { activeLocalSkillDir: scope.activeLocalSkillDir } : {}),
+  };
+}
+
+/**
+ * Recover the narrowest extension-owned authorization evidence for an older
+ * response. New records carry the exact descriptor scope captured at response
+ * completion. Records written by older releases fall back to only the
+ * descriptors that the extension actually executed for that exact assistant
+ * message; they never expand to the current full catalog.
+ */
+export function resolvePersistedRegenerateAuthorizationEvidence(
+  records: readonly ToolCallRestoreRecord[],
+  chatSessionId: string,
+  childMessageId: number | string,
+): PersistedRegenerateAuthorizationEvidence | null {
+  const normalizedSessionId = normalizeChatSessionId(chatSessionId);
+  const normalizedMessageId = normalizeDeepSeekMessageId(childMessageId);
+  if (!normalizedSessionId || normalizedMessageId === null) return null;
+
+  const matching = records.filter((record) =>
+    readRecordChatSessionId(record) === normalizedSessionId
+    && readRecordAssistantMessageId(record) === normalizedMessageId
+  );
+  if (matching.length === 0) return null;
+
+  for (let index = matching.length - 1; index >= 0; index -= 1) {
+    const explicit = decodePersistedMetadata(matching[index].metadata?.[REGENERATE_AUTHORIZATION_METADATA_KEY]);
+    if (explicit) return explicit;
+  }
+
+  const descriptorIds = normalizeDescriptorIds(
+    matching.flatMap((record) =>
+      record.executions?.map((execution) => execution.descriptorId ?? '') ?? []
+    ),
+  );
+  return descriptorIds && descriptorIds.length > 0 ? { descriptorIds } : null;
+}
+
+function normalizeScope(
+  input: RegenerateAuthorizationScopeInput,
+  maxPromptChars: number,
+): RegenerateAuthorizationScope | null {
+  const chatSessionId = normalizeChatSessionId(input.chatSessionId);
+  const assistantMessageId = normalizeDeepSeekMessageId(input.assistantMessageId);
+  if (!chatSessionId || assistantMessageId === null) return null;
+
+  const descriptorIds = normalizeDescriptorIds(input.descriptorIds);
+  if (!descriptorIds) return null;
+  if (typeof input.originalPrompt !== 'string' || typeof input.agentTaskPrompt !== 'string') return null;
+  if (
+    input.originalPrompt.length > maxPromptChars
+    || input.agentTaskPrompt.length > maxPromptChars
+    || !isPromptOptionsSnapshot(input.promptOptions)
+  ) return null;
+
+  const activeLocalSkillDir = typeof input.activeLocalSkillDir === 'string' && input.activeLocalSkillDir.trim()
+    ? input.activeLocalSkillDir
+    : undefined;
+  return {
+    chatSessionId,
+    assistantMessageId,
+    descriptorIds,
+    originalPrompt: input.originalPrompt,
+    agentTaskPrompt: input.agentTaskPrompt,
+    promptOptions: clonePromptOptions(input.promptOptions),
+    ...(activeLocalSkillDir ? { activeLocalSkillDir } : {}),
+  };
+}
+
+function decodePersistedMetadata(value: unknown): PersistedRegenerateAuthorizationEvidence | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (!Array.isArray(record.descriptorIds)) return null;
+  const descriptorIds = normalizeDescriptorIds(record.descriptorIds);
+  if (!descriptorIds || descriptorIds.length === 0) return null;
+
+  const promptOptions = record.promptOptions === undefined
+    ? undefined
+    : isPromptOptionsSnapshot(record.promptOptions as RegeneratePromptOptionsSnapshot)
+      ? clonePromptOptions(record.promptOptions as RegeneratePromptOptionsSnapshot)
+      : null;
+  if (promptOptions === null) return null;
+
+  const activeLocalSkillDir = typeof record.activeLocalSkillDir === 'string' && record.activeLocalSkillDir.trim()
+    ? record.activeLocalSkillDir
+    : undefined;
+  return {
+    descriptorIds,
+    ...(promptOptions ? { promptOptions } : {}),
+    ...(activeLocalSkillDir ? { activeLocalSkillDir } : {}),
+  };
+}
+
+function normalizeDescriptorIds(value: readonly unknown[]): string[] | null {
+  const ids = [...new Set(value.filter((id): id is string => typeof id === 'string' && Boolean(id.trim())))];
+  return ids.length <= MAX_REGENERATE_DESCRIPTOR_IDS ? ids : null;
+}
+
+function readRecordChatSessionId(record: ToolCallRestoreRecord): string | null {
+  const metadataSessionId = normalizeChatSessionId(
+    typeof record.metadata?.chatSessionId === 'string' ? record.metadata.chatSessionId : null,
+  );
+  if (metadataSessionId) return metadataSessionId;
+  if (!record.url) return null;
+  try {
+    const parsed = new URL(record.url, 'https://chat.deepseek.com');
+    const match = parsed.pathname.match(/\/(?:a\/)?chat\/s\/([^/?#]+)/);
+    return match?.[1] ? decodeURIComponent(match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function readRecordAssistantMessageId(record: ToolCallRestoreRecord): number | null {
+  return normalizeDeepSeekMessageId(
+    record.metadata?.assistantMessageId ?? record.metadata?.messageId,
+  );
+}
+
+function isPromptOptionsSnapshot(value: RegeneratePromptOptionsSnapshot): boolean {
+  return Boolean(
+    value
+    && (value.modelType === null || typeof value.modelType === 'string')
+    && typeof value.searchEnabled === 'boolean'
+    && typeof value.thinkingEnabled === 'boolean'
+    && Array.isArray(value.refFileIds)
+    && value.refFileIds.every((id) => typeof id === 'string'),
+  );
+}
+
+function cloneScope(scope: RegenerateAuthorizationScope): RegenerateAuthorizationScope {
+  return {
+    ...scope,
+    descriptorIds: [...scope.descriptorIds],
+    promptOptions: clonePromptOptions(scope.promptOptions),
+  };
+}
+
+function clonePromptOptions(
+  promptOptions: RegeneratePromptOptionsSnapshot,
+): RegeneratePromptOptionsSnapshot {
+  return {
+    modelType: promptOptions.modelType,
+    searchEnabled: promptOptions.searchEnabled,
+    thinkingEnabled: promptOptions.thinkingEnabled,
+    refFileIds: [...promptOptions.refFileIds],
+  };
+}
+
+function normalizeChatSessionId(value: string | null | undefined): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function createScopeKey(chatSessionId: string, assistantMessageId: number): string {
+  return `${chatSessionId}\0${assistantMessageId}`;
+}
+
+function normalizePositiveLimit(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : fallback;
+}

--- a/core/interceptor/request-augmentation.ts
+++ b/core/interceptor/request-augmentation.ts
@@ -14,6 +14,10 @@ import { DEFAULT_SKILL_AUTO_ACTIVATION_SETTINGS, type SkillAutoActivationSetting
 import { projectToolDescriptorsForNativeSearch } from '../tool';
 import type { Memory, ModelType, Skill, SystemPromptPreset, ToolDescriptor } from '../types';
 import { filterMemoriesByProjectScope } from '../memory/scope';
+import {
+  normalizeDeepSeekMessageId,
+  type DeepSeekAugmentableWebRoute,
+} from '../deepseek/request-codec';
 
 export interface RequestAugmentationState {
   memories: Memory[];
@@ -53,6 +57,21 @@ export interface DeepSeekRequestBody extends Record<string, unknown> {
   prompt: string;
 }
 
+export interface DeepSeekRegenerateRequestBody extends Record<string, unknown> {
+  chat_session_id: string;
+  child_message_id: number;
+}
+
+export type DecodedDeepSeekAugmentationRequest =
+  | {
+    route: 'completion' | 'editMessage';
+    body: DeepSeekRequestBody;
+  }
+  | {
+    route: 'regenerate';
+    body: DeepSeekRegenerateRequestBody;
+  };
+
 interface ResolvedSkills {
   combinedPrompt: string;
   memoryEnabled: boolean;
@@ -79,7 +98,57 @@ export function decodeAugmentableDeepSeekRequestBody(
   }
 }
 
+export function decodeAugmentableDeepSeekRequest(
+  route: DeepSeekAugmentableWebRoute,
+  bodyStr: string,
+): DecodedDeepSeekAugmentationRequest | null {
+  try {
+    return decodeDeepSeekAugmentationRequest(route, bodyStr);
+  } catch {
+    return null;
+  }
+}
+
+export function decodeDeepSeekAugmentationRequest(
+  route: DeepSeekAugmentableWebRoute,
+  bodyStr: string,
+): DecodedDeepSeekAugmentationRequest {
+  if (route === 'regenerate') {
+    return { route, body: decodeDeepSeekRegenerateRequestBody(bodyStr) };
+  }
+  return { route, body: decodeDeepSeekRequestBody(bodyStr) };
+}
+
 export function decodeDeepSeekRequestBody(bodyStr: string): DeepSeekRequestBody {
+  const body = decodeDeepSeekRequestRecord(bodyStr);
+  if (typeof body.prompt !== 'string' || body.prompt.length === 0) {
+    throw new Error('DeepSeek request prompt must be a non-empty string.');
+  }
+  return body as DeepSeekRequestBody;
+}
+
+export function decodeDeepSeekRegenerateRequestBody(
+  bodyStr: string,
+): DeepSeekRegenerateRequestBody {
+  const body = decodeDeepSeekRequestRecord(bodyStr);
+  const chatSessionId = typeof body.chat_session_id === 'string'
+    ? body.chat_session_id.trim()
+    : '';
+  if (!chatSessionId) {
+    throw new Error('DeepSeek regenerate chat_session_id must be a non-empty string.');
+  }
+  const childMessageId = normalizeDeepSeekMessageId(body.child_message_id);
+  if (childMessageId === null) {
+    throw new Error('DeepSeek regenerate child_message_id must be a valid message id.');
+  }
+  return {
+    ...body,
+    chat_session_id: chatSessionId,
+    child_message_id: childMessageId,
+  } as DeepSeekRegenerateRequestBody;
+}
+
+function decodeDeepSeekRequestRecord(bodyStr: string): Record<string, unknown> {
   let value: unknown;
   try {
     value = JSON.parse(bodyStr);
@@ -90,11 +159,7 @@ export function decodeDeepSeekRequestBody(bodyStr: string): DeepSeekRequestBody 
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error('DeepSeek request body must be a plain object.');
   }
-  const body = value as Record<string, unknown>;
-  if (typeof body.prompt !== 'string' || body.prompt.length === 0) {
-    throw new Error('DeepSeek request prompt must be a non-empty string.');
-  }
-  return body as DeepSeekRequestBody;
+  return value as Record<string, unknown>;
 }
 
 export function augmentDecodedRequestBody(

--- a/core/messaging/schema.ts
+++ b/core/messaging/schema.ts
@@ -3,6 +3,7 @@ import {
   isToolCallRestoreRecord,
   isToolDescriptorRecord,
 } from './tool-record-codec';
+import { isDeepSeekAugmentableWebRoute } from '../deepseek/request-codec';
 
 export const BRIDGE_READY_TYPE = 'DPP_BRIDGE_READY';
 
@@ -215,6 +216,7 @@ const BRIDGE_PAYLOAD_VALIDATORS: Record<
   AUGMENT_REQUEST_BODY: (message) => (
     isNonEmptyString(message.id) &&
     typeof message.body === 'string' &&
+    isDeepSeekAugmentableWebRoute(message.route) &&
     (message.requestId === undefined || isNonEmptyString(message.requestId))
   ),
   AUGMENT_REQUEST_BODY_EXTEND_TIMEOUT: (message) => (
@@ -256,6 +258,12 @@ function isAugmentResult(message: Record<string, unknown>): boolean {
       isPlainRecord(message.result) &&
       typeof message.result.body === 'string' &&
       typeof message.result.agentTaskPrompt === 'string' &&
+      optionalString(message.result.originalPrompt) &&
+      optionalString(message.result.activeLocalSkillDir) &&
+      (
+        message.result.promptOptions === undefined ||
+        isPromptOptionsPayload(message.result.promptOptions)
+      ) &&
       (message.result.requestId === undefined || isNonEmptyString(message.result.requestId)) &&
       (
         message.result.toolDescriptors === undefined ||
@@ -287,12 +295,17 @@ function isResponseCompletePayload(value: unknown): boolean {
     isNullableString(value.chatSessionId) &&
     isNullableNumber(value.parentMessageId) &&
     isNullableNumber(value.assistantMessageId) &&
-    isNullableString(value.promptOptions.modelType) &&
-    typeof value.promptOptions.searchEnabled === 'boolean' &&
-    typeof value.promptOptions.thinkingEnabled === 'boolean' &&
-    Array.isArray(value.promptOptions.refFileIds) &&
-    value.promptOptions.refFileIds.every((id) => typeof id === 'string')
+    isPromptOptionsPayload(value.promptOptions)
   );
+}
+
+function isPromptOptionsPayload(value: unknown): boolean {
+  return isPlainRecord(value) &&
+    isNullableString(value.modelType) &&
+    typeof value.searchEnabled === 'boolean' &&
+    typeof value.thinkingEnabled === 'boolean' &&
+    Array.isArray(value.refFileIds) &&
+    value.refFileIds.every((id) => typeof id === 'string');
 }
 
 function isResponseTokenSpeedPayload(value: unknown): boolean {

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -34,9 +34,19 @@ import {
 } from '../core/interceptor/tool-parser';
 import {
   augmentDecodedRequestBody,
-  decodeAugmentableDeepSeekRequestBody,
+  decodeAugmentableDeepSeekRequest,
   type DeepSeekRequestBody,
+  type DeepSeekRegenerateRequestBody,
 } from '../core/interceptor/request-augmentation';
+import { isDeepSeekAugmentableWebRoute } from '../core/deepseek/request-codec';
+import {
+  REGENERATE_AUTHORIZATION_METADATA_KEY,
+  createPersistedRegenerateAuthorizationMetadata,
+  createRegenerateAuthorizationScopeStore,
+  resolvePersistedRegenerateAuthorizationEvidence,
+  type RegenerateAuthorizationScope,
+  type RegeneratePromptOptionsSnapshot,
+} from '../core/interceptor/regenerate-authorization-scope';
 import { DEFAULT_SKILL_AUTO_ACTIVATION_SETTINGS, normalizeSkillAutoActivationSettings, type SkillAutoActivationSettings } from '../core/skill/auto-activation-settings';
 import { containsInternalPromptMarker, sanitizeInternalPromptText } from '../core/prompt';
 import { createRestoredArtifactToolResult } from '../core/artifact';
@@ -349,6 +359,10 @@ const pendingExternalToolPayloadWrites = new Map<string, Promise<void>>();
 const activeToolAuthorizations = new Map<string, ToolAuthorizationGrantSummary>();
 const toolAuthorizationRequestAliases = new Map<string, string>();
 const inlineAgentAuthorizationRequestKeys = new Map<string, string>();
+const activeToolAuthorizationRequestMetadata = new Map<string, {
+  activeLocalSkillDir?: string;
+}>();
+const regenerateAuthorizationScopes = createRegenerateAuthorizationScopeStore();
 const pendingToolAuthorizationCorrelations = new PendingAuthorizationCorrelations();
 const pendingToolExecutionTasksByRequest = new Map<string, Set<Promise<ToolCardResult>>>();
 const pendingStartedToolCallsByRequest = new PendingRequestRegistry<PendingStartedToolCall>();
@@ -806,6 +820,8 @@ async function stopToolCapability(): Promise<void> {
   activeToolAuthorizations.clear();
   toolAuthorizationRequestAliases.clear();
   inlineAgentAuthorizationRequestKeys.clear();
+  activeToolAuthorizationRequestMetadata.clear();
+  regenerateAuthorizationScopes.clear();
   pendingExternalToolPayloadWrites.clear();
   pendingToolExecutionTasksByRequest.clear();
   restoredRenderAttempts = 0;
@@ -1016,6 +1032,7 @@ async function dispatchMainWorldMessage(data: Record<string, unknown>): Promise<
       }
       case 'RESPONSE_COMPLETE': {
         const complete = normalizeResponseCompletePayload(data.payload, data.text);
+        rememberRegenerateAuthorizationScope(complete);
         const generation = ++responseGeneration;
         activeStreamingToolCount = 0;
         await waitForPendingToolExecutions(complete.requestId);
@@ -1175,12 +1192,18 @@ function handleContentRuntimeMessage(
 
 async function disconnectMainWorldRuntimeState(): Promise<void> {
   pendingToolAuthorizationCorrelations.terminateAll();
-  await closeAllContentToolAuthorizations();
+  try {
+    await closeAllContentToolAuthorizations();
+  } finally {
+    activeToolAuthorizationRequestMetadata.clear();
+    regenerateAuthorizationScopes.clear();
+  }
 }
 
 async function handleAugmentRequestBody(data: {
   id?: unknown;
   requestId?: unknown;
+  route?: unknown;
   body?: unknown;
 }): Promise<void> {
   const id = typeof data.id === 'string' ? data.id : '';
@@ -1194,14 +1217,24 @@ async function handleAugmentRequestBody(data: {
     if (typeof data.body !== 'string') {
       throw new Error('Request body must be a string.');
     }
-    const decodedBody = decodeAugmentableDeepSeekRequestBody(data.body);
-    if (!decodedBody) {
-      postToMainWorld({
-        type: 'AUGMENT_REQUEST_BODY_RESULT',
-        id,
-        ok: true,
-        result: null,
-      });
+    if (!isDeepSeekAugmentableWebRoute(data.route)) {
+      throw new Error('Request augmentation route is invalid.');
+    }
+    const decodedRequest = decodeAugmentableDeepSeekRequest(data.route, data.body);
+    if (!decodedRequest) {
+      postAugmentRequestPassthrough(id);
+      return;
+    }
+
+    const regenerateScope = decodedRequest.route === 'regenerate'
+      ? await resolveRegenerateAuthorizationScopeForRequest(decodedRequest.body)
+      : null;
+    if (decodedRequest.route === 'regenerate' && !regenerateScope) {
+      // A regenerate request carries no prompt or trusted descriptor scope. If
+      // the exact receiver-owned response scope is unavailable (for example
+      // after a full page reload), preserve the native request but do not grant
+      // the page/model a broader tool catalog.
+      postAugmentRequestPassthrough(id);
       return;
     }
     if (!mainRequestId) {
@@ -1216,6 +1249,49 @@ async function handleAugmentRequestBody(data: {
     tracksPendingAlias = true;
     requestId = crypto.randomUUID();
 
+    if (decodedRequest.route === 'regenerate') {
+      const scope = regenerateScope!;
+      authorization = await createContentToolAuthorization({
+        requestId,
+        trigger: 'manual_chat',
+        chatSessionId: decodedRequest.body.chat_session_id,
+        descriptorIds: scope.descriptorIds,
+        localSkillDir: scope.activeLocalSkillDir,
+      });
+      activateContentToolAuthorization({
+        mainRequestId,
+        requestId,
+        authorization,
+        activeLocalSkillDir: scope.activeLocalSkillDir,
+      });
+
+      const requestAlreadyEnded = pendingToolAuthorizationCorrelations.activate(mainRequestId);
+      tracksPendingAlias = false;
+      if (requestAlreadyEnded) {
+        throw new Error('Request ended before its tool authorization became active.');
+      }
+
+      postToMainWorld({
+        type: 'AUGMENT_REQUEST_BODY_RESULT',
+        id,
+        ok: true,
+        result: {
+          // Regenerate has no prompt to augment. Preserve the captured request
+          // bytes exactly and attach only extension-owned parser/authorization
+          // context outside the DeepSeek wire body.
+          body: data.body,
+          originalPrompt: scope.originalPrompt,
+          agentTaskPrompt: scope.agentTaskPrompt,
+          requestId,
+          toolDescriptors: authorization.descriptors,
+          promptOptions: scope.promptOptions,
+          activeLocalSkillDir: scope.activeLocalSkillDir,
+        },
+      });
+      return;
+    }
+
+    const decodedBody = decodedRequest.body;
     const bodyWithMultimodalMedia = await consumePendingMultimodalMediaForRequest(decodedBody, {
       onLongRunning(timeoutMs) {
         postToMainWorld({
@@ -1268,8 +1344,12 @@ async function handleAugmentRequestBody(data: {
       toolIntent: bodyWithMultimodalMedia.prompt.slice(0, 16_000),
       localSkillDir: result.activeLocalSkillDir,
     });
-    activeToolAuthorizations.set(requestId, authorization);
-    toolAuthorizationRequestAliases.set(mainRequestId, requestId);
+    activateContentToolAuthorization({
+      mainRequestId,
+      requestId,
+      authorization,
+      activeLocalSkillDir: result.activeLocalSkillDir,
+    });
 
     const requestAlreadyEnded = pendingToolAuthorizationCorrelations.activate(mainRequestId);
     tracksPendingAlias = false;
@@ -1293,12 +1373,7 @@ async function handleAugmentRequestBody(data: {
     if (authorization) await closeContentToolAuthorization(requestId);
     if (isExtensionInvalidatedError(error)) {
       invalidateExtensionContext();
-      postToMainWorld({
-        type: 'AUGMENT_REQUEST_BODY_RESULT',
-        id,
-        ok: true,
-        result: null,
-      });
+      postAugmentRequestPassthrough(id);
       return;
     }
 
@@ -1313,6 +1388,159 @@ async function handleAugmentRequestBody(data: {
       pendingToolAuthorizationCorrelations.finish(mainRequestId);
     }
   }
+}
+
+function postAugmentRequestPassthrough(id: string): void {
+  postToMainWorld({
+    type: 'AUGMENT_REQUEST_BODY_RESULT',
+    id,
+    ok: true,
+    result: null,
+  });
+}
+
+function activateContentToolAuthorization(input: {
+  mainRequestId: string;
+  requestId: string;
+  authorization: ToolAuthorizationGrantSummary;
+  activeLocalSkillDir?: string;
+}): void {
+  activeToolAuthorizations.set(input.requestId, input.authorization);
+  toolAuthorizationRequestAliases.set(input.mainRequestId, input.requestId);
+  activeToolAuthorizationRequestMetadata.set(input.requestId, {
+    ...(input.activeLocalSkillDir
+      ? { activeLocalSkillDir: input.activeLocalSkillDir }
+      : {}),
+  });
+}
+
+function rememberRegenerateAuthorizationScope(complete: ResponseCompletePayload): void {
+  if (!complete.requestId || complete.assistantMessageId == null) return;
+  const authoritativeRequestId = activeToolAuthorizations.has(complete.requestId)
+    ? complete.requestId
+    : toolAuthorizationRequestAliases.get(complete.requestId);
+  if (!authoritativeRequestId) return;
+  const authorization = activeToolAuthorizations.get(authoritativeRequestId);
+  const metadata = activeToolAuthorizationRequestMetadata.get(authoritativeRequestId);
+  if (!authorization) return;
+  // A grant created on /a/chat is intentionally unbound until the first tool
+  // execution observes the browser-owned /a/chat/s/:id route. The summary in
+  // this content realm remains null after background performs that binding,
+  // so recover the same browser-owned route here instead of dropping replay
+  // evidence for every newly created conversation.
+  const chatSessionId = authorization.chatSessionId ?? getCurrentChatSessionId();
+  if (!chatSessionId) return;
+
+  regenerateAuthorizationScopes.remember({
+    chatSessionId,
+    assistantMessageId: complete.assistantMessageId,
+    descriptorIds: authorization.descriptors.map((descriptor) => descriptor.id),
+    originalPrompt: complete.originalPrompt,
+    agentTaskPrompt: complete.agentTaskPrompt,
+    promptOptions: cloneRegeneratePromptOptions(complete.promptOptions),
+    activeLocalSkillDir: metadata?.activeLocalSkillDir,
+  });
+}
+
+async function resolveRegenerateAuthorizationScopeForRequest(
+  body: DeepSeekRegenerateRequestBody,
+): Promise<RegenerateAuthorizationScope | null> {
+  const liveScope = regenerateAuthorizationScopes.resolve(
+    body.chat_session_id,
+    body.child_message_id,
+  );
+  if (liveScope) return liveScope;
+
+  let persistedBlocks: PersistedToolBlock[];
+  try {
+    persistedBlocks = await readPersistedToolExecutionBlocks();
+  } catch (error) {
+    console.error('[DeepSeek++] persisted regenerate authorization evidence read failed', error);
+    return null;
+  }
+
+  const evidence = resolvePersistedRegenerateAuthorizationEvidence(
+    persistedBlocks,
+    body.chat_session_id,
+    body.child_message_id,
+  );
+  if (!evidence) return null;
+
+  const visiblePrompt = readVisibleRegeneratePrompt(
+    persistedBlocks,
+    body.chat_session_id,
+    body.child_message_id,
+  );
+  return {
+    chatSessionId: body.chat_session_id,
+    assistantMessageId: body.child_message_id,
+    descriptorIds: evidence.descriptorIds,
+    originalPrompt: visiblePrompt,
+    agentTaskPrompt: visiblePrompt,
+    promptOptions: evidence.promptOptions ?? createRegeneratePromptOptionsFromRequest(body),
+    activeLocalSkillDir: evidence.activeLocalSkillDir,
+  };
+}
+
+function createRegeneratePromptOptionsFromRequest(
+  body: DeepSeekRegenerateRequestBody,
+): RegeneratePromptOptionsSnapshot {
+  return {
+    modelType: currentModelType,
+    searchEnabled: body.search_enabled === true,
+    thinkingEnabled: body.thinking_enabled === true,
+    refFileIds: [],
+  };
+}
+
+function readVisibleRegeneratePrompt(
+  blocks: readonly PersistedToolBlock[],
+  chatSessionId: string,
+  assistantMessageId: number,
+): string {
+  const matchingBlock = [...blocks].reverse().find((block) =>
+    getToolRecordChatSessionId(block) === chatSessionId
+    && getToolRecordAssistantMessageId(block) === String(assistantMessageId)
+  );
+  const allMessages = Array.from(document.querySelectorAll<HTMLElement>('.ds-message'));
+  if (allMessages.length === 0) return '';
+
+  const assistantMessages = getAssistantMessages();
+  const target = matchingBlock
+    ? findRestoredToolTarget(matchingBlock, assistantMessages, new Set())
+    : assistantMessages.find((message) => elementHasMessageId(message, String(assistantMessageId))) ?? null;
+  const targetIndex = target ? allMessages.indexOf(target as HTMLElement) : allMessages.length;
+  for (let index = targetIndex - 1; index >= 0; index -= 1) {
+    const candidate = allMessages[index];
+    if (getAssistantContentHosts(candidate).length > 0) continue;
+    const prompt = extractVisibleUserMessageText(candidate);
+    if (prompt) return prompt;
+  }
+  return '';
+}
+
+function extractVisibleUserMessageText(message: HTMLElement): string {
+  const clone = message.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll([
+    '[class*="dpp-"]',
+    '[data-dpp-agent]',
+    '[data-dpp-body-text]',
+    '[data-dpp-tool-key]',
+    'button',
+    '[role="button"]',
+  ].join(',')).forEach((node) => node.remove());
+  return sanitizeInternalPromptText(clone.textContent?.trim() ?? '').slice(0, 64_000);
+}
+
+function cloneRegeneratePromptOptions(
+  promptOptions: ResponseCompletePayload['promptOptions'],
+): RegeneratePromptOptionsSnapshot {
+  return {
+    modelType: promptOptions.modelType,
+    searchEnabled: promptOptions.searchEnabled,
+    thinkingEnabled: promptOptions.thinkingEnabled,
+    refFileIds: [...promptOptions.refFileIds],
+  };
 }
 
 async function resolveProjectContextForRequestBody(
@@ -1386,6 +1614,7 @@ async function closeContentToolAuthorization(requestId: string): Promise<void> {
 
 function removeLocalToolAuthorization(requestId: string, authorizationId: string): void {
   activeToolAuthorizations.delete(requestId);
+  activeToolAuthorizationRequestMetadata.delete(requestId);
   for (const key of pendingExternalToolPayloadWrites.keys()) {
     if (key.startsWith(`${authorizationId}:`)) pendingExternalToolPayloadWrites.delete(key);
   }
@@ -5156,6 +5385,10 @@ async function persistToolBlockSession(session: ActiveToolBlockSession, fullText
   const content = fullText ? stripToolCalls(fullText, { descriptors: currentToolDescriptors }) : '';
   session.content = content || session.content;
   session.updatedAt = Date.now();
+  const replayChatSessionId = session.chatSessionId ?? getCurrentChatSessionId();
+  const regenerateScope = replayChatSessionId && complete?.assistantMessageId != null
+    ? regenerateAuthorizationScopes.resolve(replayChatSessionId, complete.assistantMessageId)
+    : null;
 
   const block: PersistedToolBlock = {
     id: session.id,
@@ -5172,6 +5405,12 @@ async function persistToolBlockSession(session: ActiveToolBlockSession, fullText
       toolCount: session.executions.length,
       mcpToolCount: session.executions.filter((execution) => execution.provider?.kind === 'mcp').length,
       updatedAt: session.updatedAt,
+      ...(regenerateScope
+        ? {
+            [REGENERATE_AUTHORIZATION_METADATA_KEY]:
+              createPersistedRegenerateAuthorizationMetadata(regenerateScope),
+          }
+        : {}),
     },
   };
 

--- a/entrypoints/content/controllers/main-world-bridge-controller.ts
+++ b/entrypoints/content/controllers/main-world-bridge-controller.ts
@@ -1,4 +1,5 @@
 import type { RequestBodyModification } from '../../../core/interceptor/fetch-hook';
+import type { DeepSeekAugmentableWebRoute } from '../../../core/deepseek/request-codec';
 import {
   BRIDGE_HANDSHAKE_TYPES,
   BRIDGE_READY_TYPE,
@@ -23,7 +24,11 @@ import type {
 
 export interface MainWorldBridgeController extends ContentCapabilityController {
   post(message: Record<string, unknown>): void;
-  requestAugmentedBody(body: string, requestId: string): Promise<RequestBodyModification | null>;
+  requestAugmentedBody(
+    body: string,
+    requestId: string,
+    route: DeepSeekAugmentableWebRoute,
+  ): Promise<RequestBodyModification | null>;
 }
 
 export interface MainWorldBridgeState {
@@ -262,6 +267,7 @@ export function createMainWorldBridgeController(
   const requestAugmentedBody = (
     body: string,
     requestId: string,
+    route: DeepSeekAugmentableWebRoute,
   ): Promise<RequestBodyModification | null> => {
     if (!scope?.active || !port) return Promise.resolve(null);
     const id = createSessionId();
@@ -271,7 +277,7 @@ export function createMainWorldBridgeController(
         reject(new Error('DeepSeek++ request augmentation timed out.'));
       }, REQUEST_TIMEOUT_MS);
       pendingRequests.set(id, { resolve, reject, timeout });
-      post({ type: 'AUGMENT_REQUEST_BODY', id, requestId, body });
+      post({ type: 'AUGMENT_REQUEST_BODY', id, requestId, route, body });
     });
   };
 

--- a/entrypoints/main-world.content.ts
+++ b/entrypoints/main-world.content.ts
@@ -48,8 +48,8 @@ export default defineContentScript({
       },
     });
     updateHookState({
-      onRequestBody(body: string, requestId: string) {
-        return bridge.requestAugmentedBody(body, requestId);
+      onRequestBody(body, requestId, route) {
+        return bridge.requestAugmentedBody(body, requestId, route);
       },
       onHeadersCaptured(headers: Record<string, string> | null) {
         bridge.post({ type: 'HEADERS_CAPTURED', headers });

--- a/tests/content-bridge-controllers.test.ts
+++ b/tests/content-bridge-controllers.test.ts
@@ -85,7 +85,15 @@ describe('content bridge controllers', () => {
       type: BRIDGE_READY_TYPE,
     });
 
-    const pending = controller.requestAugmentedBody('{}', 'request-1');
+    const pending = controller.requestAugmentedBody('{}', 'request-1', 'completion');
+    expect(port.postMessage).toHaveBeenLastCalledWith({
+      source: BRIDGE_SOURCES.mainWorld,
+      type: 'AUGMENT_REQUEST_BODY',
+      id: 'id-2',
+      requestId: 'request-1',
+      route: 'completion',
+      body: '{}',
+    });
     const staleHandler = port.onmessage;
     await kernel.stop('pagehide');
     await expect(pending).rejects.toThrow('main/content bridge disconnected');
@@ -139,6 +147,7 @@ describe('content bridge controllers', () => {
       type: 'AUGMENT_REQUEST_BODY',
       id: 'augment-1',
       requestId: 'request-1',
+      route: 'regenerate',
       body: '{}',
     });
     await Promise.resolve();

--- a/tests/fetch-hook-request-lifecycle.test.ts
+++ b/tests/fetch-hook-request-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   updateHookState,
 } from '../core/interceptor/fetch-hook';
 import type { ToolDescriptor } from '../core/types';
+import type { DeepSeekAugmentableWebRoute } from '../core/deepseek/request-codec';
 
 describe('fetch hook request lifecycle', () => {
   const onRequestTerminal = vi.fn();
@@ -20,6 +21,7 @@ describe('fetch hook request lifecycle', () => {
   const onRequestBody = vi.fn<(
     body: string,
     requestId: string,
+    route: DeepSeekAugmentableWebRoute,
   ) => Promise<RequestBodyModification | null>>(async () => null);
 
   beforeEach(() => {
@@ -289,7 +291,7 @@ describe('fetch hook request lifecycle', () => {
       xhr.open('POST', 'https://chat.deepseek.com/api/v0/chat/completion');
 
       await vi.waitFor(() => expect(pageLoadResponse).toHaveBeenCalledOnce());
-      expect(onRequestBody).toHaveBeenCalledWith('{"prompt":"hello"}', expect.any(String));
+      expect(onRequestBody).toHaveBeenCalledWith('{"prompt":"hello"}', expect.any(String), 'completion');
       expect(onHeadersCaptured).toHaveBeenCalledWith(expect.objectContaining({
         Authorization: 'Bearer test',
       }));
@@ -392,13 +394,108 @@ describe('fetch hook request lifecycle', () => {
         body: '{"prompt":"edited prompt"}',
       });
 
-      expect(onRequestBody).toHaveBeenCalledWith('{"prompt":"edited prompt"}', expect.any(String));
+      expect(onRequestBody).toHaveBeenCalledWith(
+        '{"prompt":"edited prompt"}',
+        expect.any(String),
+        'editMessage',
+      );
       expect(fetchImpl).toHaveBeenCalledWith(
         'https://chat.deepseek.com/api/v0/chat/edit_message',
         expect.objectContaining({ body: '{"prompt":"augmented edit"}' }),
       );
     } finally {
       window.fetch = nativeFetch;
+    }
+  });
+
+  it('preserves a promptless regenerate fetch body while attaching replay context', async () => {
+    const nativeFetch = window.fetch;
+    const rawBody = '{\n  "chat_session_id": "session-1",\n  "child_message_id": 18,\n  "thinking_enabled": true\n}';
+    const fetchImpl = vi.fn(async () => new Response(
+      'data: {"p":"response/content","o":"APPEND","v":"done"}\n\n',
+    ));
+    window.fetch = fetchImpl;
+    onRequestBody.mockResolvedValueOnce({
+      body: rawBody,
+      originalPrompt: 'review the implementation',
+      agentTaskPrompt: 'review the implementation',
+      requestId: 'authorized-regenerate-fetch',
+      toolDescriptors: [makeDescriptor('request-regenerate')],
+      promptOptions: {
+        modelType: 'expert',
+        searchEnabled: false,
+        thinkingEnabled: true,
+        refFileIds: ['file-1'],
+      },
+      activeLocalSkillDir: '/trusted/skill',
+    });
+
+    try {
+      hookFetch();
+      const response = await window.fetch('https://chat.deepseek.com/api/v0/chat/regenerate', {
+        method: 'POST',
+        body: rawBody,
+      });
+      await response.text();
+
+      expect(onRequestBody).toHaveBeenCalledWith(rawBody, expect.any(String), 'regenerate');
+      expect(fetchImpl).toHaveBeenCalledWith(
+        'https://chat.deepseek.com/api/v0/chat/regenerate',
+        expect.objectContaining({ body: rawBody }),
+      );
+      expect(onResponseComplete).toHaveBeenCalledWith(expect.objectContaining({
+        requestId: 'authorized-regenerate-fetch',
+        originalPrompt: 'review the implementation',
+        agentTaskPrompt: 'review the implementation',
+        promptOptions: {
+          modelType: 'expert',
+          searchEnabled: false,
+          thinkingEnabled: true,
+          refFileIds: ['file-1'],
+        },
+      }));
+    } finally {
+      window.fetch = nativeFetch;
+    }
+  });
+
+  it('preserves a promptless regenerate XHR body and route identity', async () => {
+    const nativeXMLHttpRequest = globalThis.XMLHttpRequest;
+    const rawBody = '{"chat_session_id":"session-1","child_message_id":18,"search_enabled":false}';
+    const rawWire = 'data: {"p":"response/content","o":"APPEND","v":"done"}';
+    const FakeXMLHttpRequest = createFakeXMLHttpRequest(rawWire, 200);
+    vi.stubGlobal('XMLHttpRequest', FakeXMLHttpRequest);
+    onRequestBody.mockResolvedValueOnce({
+      body: rawBody,
+      originalPrompt: 'review the implementation',
+      agentTaskPrompt: 'review the implementation',
+      requestId: 'authorized-regenerate-xhr',
+      toolDescriptors: [makeDescriptor('request-regenerate')],
+      promptOptions: {
+        modelType: 'expert',
+        searchEnabled: false,
+        thinkingEnabled: true,
+        refFileIds: [],
+      },
+      activeLocalSkillDir: '/trusted/skill',
+    });
+
+    try {
+      hookXHR();
+      const xhr = new XMLHttpRequest();
+      xhr.open('POST', 'https://chat.deepseek.com/api/v0/chat/regenerate');
+      xhr.send(rawBody);
+
+      await vi.waitFor(() => expect(onResponseComplete).toHaveBeenCalledOnce());
+      expect(onRequestBody).toHaveBeenCalledWith(rawBody, expect.any(String), 'regenerate');
+      expect((xhr as unknown as FakeXMLHttpRequestInstance).sentBody).toBe(rawBody);
+      expect(onResponseComplete).toHaveBeenCalledWith(expect.objectContaining({
+        requestId: 'authorized-regenerate-xhr',
+        originalPrompt: 'review the implementation',
+        promptOptions: expect.objectContaining({ modelType: 'expert' }),
+      }));
+    } finally {
+      vi.stubGlobal('XMLHttpRequest', nativeXMLHttpRequest);
     }
   });
 

--- a/tests/fixtures/runtime-contract/bridge.ts
+++ b/tests/fixtures/runtime-contract/bridge.ts
@@ -80,6 +80,7 @@ export const LEGAL_BRIDGE_CASES = {
       type: 'AUGMENT_REQUEST_BODY',
       id: 'augment-1',
       requestId: 'request-contract-1',
+      route: 'completion',
       body: '{"prompt":"hello"}',
     },
   }],
@@ -98,8 +99,16 @@ export const LEGAL_BRIDGE_CASES = {
       ok: true,
       result: {
         body: '{"prompt":"augmented"}',
+        originalPrompt: 'hello',
         agentTaskPrompt: 'hello',
         requestId: 'request-authorized-1',
+        promptOptions: {
+          modelType: 'expert',
+          searchEnabled: false,
+          thinkingEnabled: true,
+          refFileIds: [],
+        },
+        activeLocalSkillDir: '/trusted/skill',
         toolDescriptors: [{
           id: 'mcp:browser-tools:capture_page',
           provider: TOOL_PROVIDER,
@@ -254,6 +263,7 @@ export const REJECTED_BRIDGE_CASES: ReadonlyArray<{
   { name: 'non-string id', message: { source: MAIN, type: 'AUGMENT_REQUEST_BODY', id: 7, body: '{}' } },
   { name: 'non-string body', message: { source: MAIN, type: 'AUGMENT_REQUEST_BODY', id: 'augment-1', body: {} } },
   { name: 'non-string request id', message: { source: MAIN, type: 'AUGMENT_REQUEST_BODY', id: 'augment-1', requestId: 7, body: '{}' } },
+  { name: 'invalid request route', message: { source: MAIN, type: 'AUGMENT_REQUEST_BODY', id: 'augment-1', requestId: 'request-1', route: 'history', body: '{}' } },
   { name: 'non-boolean ok', message: { source: CONTENT, type: 'AUGMENT_REQUEST_BODY_RESULT', id: 'augment-1', ok: 'yes' } },
   { name: 'non-string error', message: { source: CONTENT, type: 'AUGMENT_REQUEST_BODY_RESULT', id: 'augment-1', ok: false, error: {} } },
   { name: 'non-positive timeout', message: { source: CONTENT, type: 'AUGMENT_REQUEST_BODY_EXTEND_TIMEOUT', id: 'augment-1', timeoutMs: 0 } },

--- a/tests/regenerate-authorization-scope.test.ts
+++ b/tests/regenerate-authorization-scope.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import type { ToolCallRestoreRecord } from '../core/types';
+import {
+  REGENERATE_AUTHORIZATION_METADATA_KEY,
+  createPersistedRegenerateAuthorizationMetadata,
+  createRegenerateAuthorizationScopeStore,
+  resolvePersistedRegenerateAuthorizationEvidence,
+} from '../core/interceptor/regenerate-authorization-scope';
+
+const PROMPT_OPTIONS = {
+  modelType: 'expert',
+  searchEnabled: false,
+  thinkingEnabled: true,
+  refFileIds: ['file-1'],
+};
+
+describe('regenerate authorization scope', () => {
+  it('resolves only the exact receiver-owned session and assistant message pair', () => {
+    const store = createRegenerateAuthorizationScopeStore();
+    expect(store.remember({
+      chatSessionId: ' session-1 ',
+      assistantMessageId: 18,
+      descriptorIds: ['mcp:one', 'mcp:one', 'local:two'],
+      originalPrompt: 'visible prompt',
+      agentTaskPrompt: 'agent task',
+      promptOptions: PROMPT_OPTIONS,
+      activeLocalSkillDir: '/trusted/skill',
+    })).toBe(true);
+
+    expect(store.resolve('session-1', 18)).toEqual({
+      chatSessionId: 'session-1',
+      assistantMessageId: 18,
+      descriptorIds: ['mcp:one', 'local:two'],
+      originalPrompt: 'visible prompt',
+      agentTaskPrompt: 'agent task',
+      promptOptions: PROMPT_OPTIONS,
+      activeLocalSkillDir: '/trusted/skill',
+    });
+    expect(store.resolve('session-2', 18)).toBeNull();
+    expect(store.resolve('session-1', 19)).toBeNull();
+  });
+
+  it('returns isolated snapshots instead of mutable authority references', () => {
+    const store = createRegenerateAuthorizationScopeStore();
+    store.remember({
+      chatSessionId: 'session-1',
+      assistantMessageId: 18,
+      descriptorIds: ['mcp:one'],
+      originalPrompt: 'visible prompt',
+      agentTaskPrompt: 'agent task',
+      promptOptions: PROMPT_OPTIONS,
+    });
+
+    const first = store.resolve('session-1', 18)!;
+    first.descriptorIds.push('mcp:injected');
+    first.promptOptions.refFileIds.push('file-injected');
+
+    expect(store.resolve('session-1', 18)).toEqual(expect.objectContaining({
+      descriptorIds: ['mcp:one'],
+      promptOptions: expect.objectContaining({ refFileIds: ['file-1'] }),
+    }));
+  });
+
+  it('evicts older responses at the configured bound and rejects malformed scopes', () => {
+    const store = createRegenerateAuthorizationScopeStore({ maxEntries: 2, maxPromptChars: 16 });
+    const remember = (assistantMessageId: number, prompt = 'prompt') => store.remember({
+      chatSessionId: 'session-1',
+      assistantMessageId,
+      descriptorIds: ['mcp:one'],
+      originalPrompt: prompt,
+      agentTaskPrompt: prompt,
+      promptOptions: PROMPT_OPTIONS,
+    });
+
+    expect(remember(1)).toBe(true);
+    expect(remember(2)).toBe(true);
+    expect(remember(3)).toBe(true);
+    expect(store.size).toBe(2);
+    expect(store.resolve('session-1', 1)).toBeNull();
+    expect(store.resolve('session-1', 2)).not.toBeNull();
+    expect(store.resolve('session-1', 3)).not.toBeNull();
+
+    expect(store.remember({
+      chatSessionId: '',
+      assistantMessageId: 4,
+      descriptorIds: [],
+      originalPrompt: '',
+      agentTaskPrompt: '',
+      promptOptions: PROMPT_OPTIONS,
+    })).toBe(false);
+    expect(remember(4, 'prompt that is too long')).toBe(false);
+  });
+
+  it('prefers an exact persisted descriptor scope over legacy execution evidence', () => {
+    const metadata = createPersistedRegenerateAuthorizationMetadata({
+      descriptorIds: ['mcp:one', 'local:two'],
+      promptOptions: PROMPT_OPTIONS,
+      activeLocalSkillDir: '/trusted/skill',
+    });
+    const records = [
+      createPersistedBlock({
+        id: 'legacy',
+        descriptorIds: ['mcp:legacy'],
+      }),
+      createPersistedBlock({
+        id: 'exact',
+        descriptorIds: ['mcp:executed-only'],
+        metadata: { [REGENERATE_AUTHORIZATION_METADATA_KEY]: metadata },
+      }),
+    ];
+
+    const evidence = resolvePersistedRegenerateAuthorizationEvidence(records, 'session-1', 18);
+
+    expect(evidence).toEqual({
+      descriptorIds: ['mcp:one', 'local:two'],
+      promptOptions: PROMPT_OPTIONS,
+      activeLocalSkillDir: '/trusted/skill',
+    });
+    evidence!.descriptorIds.push('mcp:mutated');
+    evidence!.promptOptions!.refFileIds.push('file-mutated');
+    expect(metadata).toEqual(expect.objectContaining({
+      descriptorIds: ['mcp:one', 'local:two'],
+      promptOptions: expect.objectContaining({ refFileIds: ['file-1'] }),
+    }));
+  });
+
+  it('recovers only previously executed descriptors for an exact legacy response', () => {
+    const records = [
+      createPersistedBlock({ id: 'first', descriptorIds: ['mcp:one', 'mcp:one'] }),
+      createPersistedBlock({ id: 'second', descriptorIds: ['local:two'] }),
+      createPersistedBlock({
+        id: 'other-message',
+        assistantMessageId: 19,
+        descriptorIds: ['mcp:not-authorized'],
+      }),
+      createPersistedBlock({
+        id: 'other-session',
+        chatSessionId: 'session-2',
+        descriptorIds: ['mcp:not-authorized'],
+      }),
+    ];
+
+    expect(resolvePersistedRegenerateAuthorizationEvidence(records, 'session-1', 18)).toEqual({
+      descriptorIds: ['mcp:one', 'local:two'],
+    });
+    expect(resolvePersistedRegenerateAuthorizationEvidence(records, 'session-1', 20)).toBeNull();
+  });
+});
+
+function createPersistedBlock(options: {
+  id: string;
+  chatSessionId?: string;
+  assistantMessageId?: number;
+  descriptorIds: string[];
+  metadata?: Record<string, unknown>;
+}): ToolCallRestoreRecord {
+  const chatSessionId = options.chatSessionId ?? 'session-1';
+  const assistantMessageId = options.assistantMessageId ?? 18;
+  return {
+    id: options.id,
+    source: 'storage',
+    url: `https://chat.deepseek.com/a/chat/s/${chatSessionId}`,
+    createdAt: 1,
+    executions: options.descriptorIds.map((descriptorId) => ({
+      name: descriptorId,
+      descriptorId,
+      result: { ok: true, summary: 'done' },
+    })),
+    metadata: {
+      chatSessionId,
+      assistantMessageId,
+      ...options.metadata,
+    },
+  };
+}

--- a/tests/regenerate-request-authorization-boundary.test.ts
+++ b/tests/regenerate-request-authorization-boundary.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('regenerate request authorization boundary', () => {
+  const source = readFileSync('entrypoints/content.ts', 'utf8');
+
+  it('replays only an exact receiver-owned descriptor scope without changing the wire body', () => {
+    const handlerStart = source.indexOf('async function handleAugmentRequestBody');
+    const handlerEnd = source.indexOf('\nasync function resolveProjectContextForRequestBody', handlerStart);
+    const handler = source.slice(handlerStart, handlerEnd);
+    const regenerateStart = handler.indexOf("if (decodedRequest.route === 'regenerate')");
+    const promptStart = handler.indexOf('const decodedBody = decodedRequest.body', regenerateStart);
+    const regenerateBranch = handler.slice(regenerateStart, promptStart);
+
+    expect(regenerateStart).toBeGreaterThanOrEqual(0);
+    expect(promptStart).toBeGreaterThan(regenerateStart);
+    expect(regenerateBranch).toContain('descriptorIds: scope.descriptorIds');
+    expect(regenerateBranch).toContain('localSkillDir: scope.activeLocalSkillDir');
+    expect(regenerateBranch).toContain('body: data.body');
+    expect(regenerateBranch).toContain('toolDescriptors: authorization.descriptors');
+    expect(regenerateBranch).not.toContain('toolIntent:');
+  });
+
+  it('recovers new-chat and pre-upgrade response evidence without expanding to the current catalog', () => {
+    const rememberStart = source.indexOf('function rememberRegenerateAuthorizationScope');
+    const rememberEnd = source.indexOf('\nasync function resolveRegenerateAuthorizationScopeForRequest', rememberStart);
+    const remember = source.slice(rememberStart, rememberEnd);
+    const recoveryStart = rememberEnd;
+    const recoveryEnd = source.indexOf('\nfunction createRegeneratePromptOptionsFromRequest', recoveryStart);
+    const recovery = source.slice(recoveryStart, recoveryEnd);
+
+    expect(remember).toContain('authorization.chatSessionId ?? getCurrentChatSessionId()');
+    expect(recovery).toContain('readPersistedToolExecutionBlocks()');
+    expect(recovery).toContain('resolvePersistedRegenerateAuthorizationEvidence(');
+    expect(recovery).not.toContain('currentToolDescriptors');
+    expect(recovery).not.toContain('toolIntent:');
+  });
+
+  it('persists the exact live descriptor scope for later page reloads', () => {
+    const persistStart = source.indexOf('async function persistToolBlockSession');
+    const persistEnd = source.indexOf('\nasync function restorePersistedToolBlocks', persistStart);
+    const persist = source.slice(persistStart, persistEnd);
+
+    expect(persist).toContain('REGENERATE_AUTHORIZATION_METADATA_KEY');
+    expect(persist).toContain('createPersistedRegenerateAuthorizationMetadata(regenerateScope)');
+  });
+
+  it('captures the response scope before terminal cleanup can close its grant', () => {
+    const responseCase = source.indexOf("case 'RESPONSE_COMPLETE'");
+    const terminalCase = source.indexOf("case 'REQUEST_TERMINAL'", responseCase);
+    const responseHandler = source.slice(responseCase, terminalCase);
+    const rememberIndex = responseHandler.indexOf('rememberRegenerateAuthorizationScope(complete)');
+    const pendingExecutionsIndex = responseHandler.indexOf('await waitForPendingToolExecutions');
+    const continuationIndex = responseHandler.indexOf('startInlineAgentIfNeeded(complete');
+
+    expect(responseCase).toBeGreaterThanOrEqual(0);
+    expect(terminalCase).toBeGreaterThan(responseCase);
+    expect(rememberIndex).toBeGreaterThanOrEqual(0);
+    expect(pendingExecutionsIndex).toBeGreaterThan(rememberIndex);
+    expect(continuationIndex).toBeGreaterThan(rememberIndex);
+    expect(source.slice(terminalCase, source.indexOf("case 'RESPONSE_TOKEN_SPEED'", terminalCase)))
+      .toContain('closeContentToolAuthorization(requestId)');
+  });
+});

--- a/tests/request-augmentation-boundary.test.ts
+++ b/tests/request-augmentation-boundary.test.ts
@@ -7,16 +7,21 @@ describe('Content request augmentation boundary', () => {
     const start = source.indexOf('async function handleAugmentRequestBody');
     const end = source.indexOf('\nasync function resolveProjectContextForRequestBody', start);
     const handler = source.slice(start, end);
-    const decodeIndex = handler.indexOf('decodeAugmentableDeepSeekRequestBody(data.body)');
-    const passthroughIndex = handler.indexOf('if (!decodedBody)');
+    const routeIndex = handler.indexOf('isDeepSeekAugmentableWebRoute(data.route)');
+    const decodeIndex = handler.indexOf('decodeAugmentableDeepSeekRequest(data.route, data.body)');
+    const passthroughIndex = handler.indexOf('if (!decodedRequest)');
+    const replayScopeIndex = handler.indexOf('resolveRegenerateAuthorizationScopeForRequest(decodedRequest.body)');
     const correlationIndex = handler.indexOf('pendingToolAuthorizationCorrelations.begin');
 
     expect(start).toBeGreaterThanOrEqual(0);
     expect(end).toBeGreaterThan(start);
+    expect(routeIndex).toBeGreaterThanOrEqual(0);
     expect(decodeIndex).toBeGreaterThanOrEqual(0);
+    expect(decodeIndex).toBeGreaterThan(routeIndex);
     expect(passthroughIndex).toBeGreaterThan(decodeIndex);
-    expect(handler.slice(passthroughIndex, correlationIndex)).toContain("type: 'AUGMENT_REQUEST_BODY_RESULT'");
-    expect(handler.slice(passthroughIndex, correlationIndex)).toContain('result: null');
+    expect(replayScopeIndex).toBeGreaterThan(passthroughIndex);
+    expect(replayScopeIndex).toBeLessThan(correlationIndex);
+    expect(handler.slice(passthroughIndex, correlationIndex)).toContain('postAugmentRequestPassthrough(id)');
     for (const privilegedOperation of [
       'pendingToolAuthorizationCorrelations.begin',
       'consumePendingMultimodalMediaForRequest',

--- a/tests/request-augmentation.test.ts
+++ b/tests/request-augmentation.test.ts
@@ -3,7 +3,9 @@ import { DEFAULT_TOOL_DESCRIPTORS } from '../core/tool';
 import { createBrowserControlToolDescriptors } from '../core/browser-control/tool';
 import {
   augmentRequestBody,
+  decodeAugmentableDeepSeekRequest,
   decodeAugmentableDeepSeekRequestBody,
+  decodeDeepSeekRegenerateRequestBody,
   decodeDeepSeekRequestBody,
 } from '../core/interceptor/request-augmentation';
 import { buildPromptAugmentation, extractVisibleUserPrompt } from '../core/prompt';
@@ -34,6 +36,40 @@ describe('augmentRequestBody', () => {
     expect(decodeAugmentableDeepSeekRequestBody('{bad json}')).toBeNull();
     expect(decodeAugmentableDeepSeekRequestBody(JSON.stringify({ prompt: '' }))).toBeNull();
     expect(decodeAugmentableDeepSeekRequestBody(JSON.stringify({ prompt: 1 }))).toBeNull();
+  });
+
+  it('decodes the native promptless regenerate route without inventing a prompt', () => {
+    const rawBody = JSON.stringify({
+      chat_session_id: ' session-1 ',
+      child_message_id: 18,
+      search_enabled: false,
+      thinking_enabled: true,
+      user_options: null,
+      future_sibling: { keep: true },
+    });
+
+    expect(decodeDeepSeekRegenerateRequestBody(rawBody)).toEqual({
+      chat_session_id: 'session-1',
+      child_message_id: 18,
+      search_enabled: false,
+      thinking_enabled: true,
+      user_options: null,
+      future_sibling: { keep: true },
+    });
+    expect(decodeAugmentableDeepSeekRequest('regenerate', rawBody)).toEqual({
+      route: 'regenerate',
+      body: expect.objectContaining({
+        chat_session_id: 'session-1',
+        child_message_id: 18,
+      }),
+    });
+    expect(decodeAugmentableDeepSeekRequest('completion', rawBody)).toBeNull();
+    expect(decodeAugmentableDeepSeekRequest('regenerate', JSON.stringify({
+      chat_session_id: 'session-1',
+    }))).toBeNull();
+    expect(decodeAugmentableDeepSeekRequest('regenerate', JSON.stringify({
+      child_message_id: 18,
+    }))).toBeNull();
   });
 
   it('does not hide augmentation failures after the request body has decoded', () => {


### PR DESCRIPTION
## Summary

Fix DeepSeek native “regenerate/retry” requests so every regenerated response receives a fresh, narrowly scoped tool-authorization grant. The fix also restores exact extension-owned authorization evidence after page/extension reloads and supports pre-1.13.1 tool-execution records without expanding to the current full tool catalog.

## PR Type

- [x] User-facing feature or behavior change
- [x] Bug fix
- [ ] Documentation only
- [ ] Maintenance / refactor

## Latest Codebase Confirmation

- [x] I developed this PR from the latest `main` branch or rebased/merged latest `main` before submitting.

Base sync command or commit:

```bash
git fetch origin --prune
git rev-parse origin/main
# 4b476c4d88871736977d9305c970f19640dd24bd
```

## AI Coding Disclosure

- [x] Fully AI-coded: all programming changes were produced by AI and accepted/reviewed by the contributor.
- [ ] Partially AI-assisted: AI helped write or modify some programming changes.
- [ ] No AI coding assistance was used.

AI model(s) used:

OpenAI Codex

Coding Agent tool(s) used:

Codex Desktop

## Local Validation

Commands run:

```bash
npm exec vitest -- run tests/regenerate-authorization-scope.test.ts tests/regenerate-request-authorization-boundary.test.ts tests/request-augmentation-boundary.test.ts tests/request-augmentation.test.ts tests/fetch-hook-request-lifecycle.test.ts tests/content-bridge-controllers.test.ts --testTimeout=60000
npm run compile
npm run prompt:freeze
npm test -- --testTimeout=60000
npm run build:all
npm run verify:manifest-policy
npm run verify:extension-utf8
npm run ci:quality
```

Result summary:

- Targeted tests: 6 files / 53 tests passed.
- Full tests: 210 files / 1680 tests passed.
- TypeScript compile and prompt freeze passed.
- Chrome, Edge, and Firefox builds passed.
- Manifest and UTF-8 checks passed.
- Post-commit `npm run ci:quality` passed, including workflow/audit checks, full tests, MCP/Shell/PoW/Pyodide smoke tests, three-browser builds, ZIP generation, and release-asset verification.

## Local Feature Evidence

Evidence:

Owner-authored PR. Real DeepSeek browser QA was completed from the locally loaded PR build:

1. A new expert-mode conversation successfully executed `web_fetch https://example.com`.
2. Native regenerate succeeded on the same page and advanced the branch from 1/1 to 2/2.
3. After reloading the extension and page, native regenerate succeeded again and advanced from 2/2 to 3/3.
4. The captured `POST /api/v0/chat/regenerate` body remained unchanged.
5. A pre-upgrade execution-only record was matched by exact session/message evidence and completed `web_fetch` without `tool_authorization_missing`.

## Root Cause and Security Boundary

DeepSeek native regenerate uses a promptless `POST /api/v0/chat/regenerate` request. The previous prompt decoder treated it as non-augmentable and passed it through without creating a new tool grant.

The repair adds route-aware request decoding and creates a new grant through the standard authorization path. Same-page responses retain an exact `chatSessionId + assistantMessageId` scope; refreshed pages recover extension-owned evidence from the existing tool-execution block store. New records use the original exact descriptor scope, while legacy records permit only descriptors actually executed by that assistant response.

The fix does not mutate the regenerate wire body, does not trust MAIN-world descriptor claims, does not fall back to the current full tool catalog, does not add a missing-grant bypass, and does not add a new persistence key.

Related to #546. Keep the Issue open until the merged fix is released and the reporter retests the original upgraded-conversation scenario.